### PR TITLE
feat: allow count-only tier3 recruitment records

### DIFF
--- a/app/components/features/forms/StudentSelectForm.tsx
+++ b/app/components/features/forms/StudentSelectForm.tsx
@@ -1,6 +1,6 @@
 import { ChevronDownIcon, XMarkIcon } from "@heroicons/react/20/solid";
 import hangul from "hangul-js";
-import { useEffect, useId, useRef, useState } from "react";
+import { type ReactNode, useEffect, useId, useRef, useState } from "react";
 import { Field } from "~/components/primitives";
 import { cn } from "~/lib/utils";
 import { studentImageUrl } from "~/models/assets";
@@ -51,6 +51,7 @@ function SearchInput({ searchQuery, setSearchQuery, searchPlaceholder, inputRef 
 export type StudentSelectFormProps = {
   label?: string;
   description?: string;
+  descriptionAction?: ReactNode;
   name?: string;
   students: Student[];
   initialStudentUids?: string[];
@@ -59,6 +60,7 @@ export type StudentSelectFormProps = {
   multiple?: boolean;
   allowDuplicateSelection?: boolean;
   maxSelectedCount?: number;
+  hideInput?: boolean;
   onSelect?: (value: string | string[]) => void;
   className?: string;
   containerClassName?: string;
@@ -67,6 +69,7 @@ export type StudentSelectFormProps = {
 export default function StudentSelectForm({
   label,
   description,
+  descriptionAction,
   name,
   students,
   initialStudentUids,
@@ -75,6 +78,7 @@ export default function StudentSelectForm({
   multiple = false,
   allowDuplicateSelection = false,
   maxSelectedCount,
+  hideInput = false,
   onSelect,
   className,
   containerClassName,
@@ -117,6 +121,12 @@ export default function StudentSelectForm({
   }, [searchQuery]);
 
   useEffect(() => {
+    if (hideInput) {
+      setIsOpen(false);
+      setSearchQuery("");
+      return;
+    }
+
     if (!isOpen) {
       return;
     }
@@ -144,7 +154,7 @@ export default function StudentSelectForm({
       window.removeEventListener("mousedown", handlePointerDown);
       window.removeEventListener("keydown", handleKeyDown);
     };
-  }, [isOpen]);
+  }, [hideInput, isOpen]);
 
   const updateSelection = (newSelectedValues: string[]) => {
     setSelectedUids(newSelectedValues);
@@ -236,65 +246,68 @@ export default function StudentSelectForm({
 
   return (
     <>
-      <Field
-        label={label}
-        description={description}
-        containerClassName={containerClassName ?? "mt-2 mb-8 last:mb-2"}
-      >
-        <div className="relative" ref={rootRef}>
-          <button
-            id={buttonId}
-            type="button"
-            className={cn(
-              "flex min-h-10 w-full items-center justify-between gap-3 rounded-md border border-input bg-background px-3 py-2 text-left text-foreground transition-colors hover:bg-muted/40 focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/20 focus-visible:outline-none",
-              className,
-            )}
-            onClick={() => setIsOpen((prev) => !prev)}
-            aria-controls={listboxId}
-            aria-expanded={isOpen}
-            aria-haspopup="dialog"
-          >
-            <div className="min-w-0 flex-1">{renderSelectedDisplay()}</div>
-            <ChevronDownIcon className={cn("size-5 shrink-0 text-muted-foreground transition-transform", isOpen && "rotate-180")} />
-          </button>
-          {isOpen && (
-            <div
-              id={listboxId}
-              aria-labelledby={buttonId}
-              className="no-scrollbar absolute top-full left-0 z-20 mt-2 max-h-72 w-full overflow-y-auto rounded-xl border border-border bg-popover text-popover-foreground shadow-lg shadow-foreground/10"
-            >
-              <SearchInput
-                searchQuery={searchQuery}
-                setSearchQuery={setSearchQuery}
-                searchPlaceholder={searchPlaceholder}
-                inputRef={searchInputRef}
-              />
-              {filteredStudents.length > 0 ? (
-                <ul className="py-0.5">
-                  {filteredStudents.slice(0, 10).map((student) => (
-                    <li key={student.uid}>
-                      <button
-                        type="button"
-                        className="flex w-full cursor-pointer items-center gap-x-2 text-left transition-colors duration-100 hover:bg-muted/60"
-                        onClick={() => handleSelect(student.uid)}
-                      >
-                        <div className="flex w-full items-center gap-x-3 px-3 py-2">
-                          <StudentImage student={student} size="size-8" />
-                          <p className="grow text-sm text-foreground">{student.name}</p>
-                          {selectedUids.includes(student.uid) && (
-                            <span className="text-xs font-medium text-primary">선택됨</span>
-                          )}
-                        </div>
-                      </button>
-                    </li>
-                  ))}
-                </ul>
-              ) : (
-                <div className="p-4 text-center text-sm text-muted-foreground">검색 결과가 없어요</div>
+      <Field label={label} description={description} containerClassName={containerClassName ?? "mt-2 mb-8 last:mb-2"}>
+        <>
+          {descriptionAction}
+          {!hideInput && (
+            <div className="relative" ref={rootRef}>
+              <button
+                id={buttonId}
+                type="button"
+                className={cn(
+                  "flex min-h-10 w-full items-center justify-between gap-3 rounded-md border border-input bg-background px-3 py-2 text-left text-foreground transition-colors hover:bg-muted/40 focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/20 focus-visible:outline-none",
+                  className,
+                )}
+                onClick={() => setIsOpen((prev) => !prev)}
+                aria-controls={listboxId}
+                aria-expanded={isOpen}
+                aria-haspopup="dialog"
+              >
+                <div className="min-w-0 flex-1">{renderSelectedDisplay()}</div>
+                <ChevronDownIcon
+                  className={cn("size-5 shrink-0 text-muted-foreground transition-transform", isOpen && "rotate-180")}
+                />
+              </button>
+              {isOpen && (
+                <div
+                  id={listboxId}
+                  aria-labelledby={buttonId}
+                  className="no-scrollbar absolute top-full left-0 z-20 mt-2 max-h-72 w-full overflow-y-auto rounded-xl border border-border bg-popover text-popover-foreground shadow-lg shadow-foreground/10"
+                >
+                  <SearchInput
+                    searchQuery={searchQuery}
+                    setSearchQuery={setSearchQuery}
+                    searchPlaceholder={searchPlaceholder}
+                    inputRef={searchInputRef}
+                  />
+                  {filteredStudents.length > 0 ? (
+                    <ul className="py-0.5">
+                      {filteredStudents.slice(0, 10).map((student) => (
+                        <li key={student.uid}>
+                          <button
+                            type="button"
+                            className="flex w-full cursor-pointer items-center gap-x-2 text-left transition-colors duration-100 hover:bg-muted/60"
+                            onClick={() => handleSelect(student.uid)}
+                          >
+                            <div className="flex w-full items-center gap-x-3 px-3 py-2">
+                              <StudentImage student={student} size="size-8" />
+                              <p className="grow text-sm text-foreground">{student.name}</p>
+                              {selectedUids.includes(student.uid) && (
+                                <span className="text-xs font-medium text-primary">선택됨</span>
+                              )}
+                            </div>
+                          </button>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <div className="p-4 text-center text-sm text-muted-foreground">검색 결과가 없어요</div>
+                  )}
+                </div>
               )}
             </div>
           )}
-        </div>
+        </>
       </Field>
       <input type="hidden" name={name} value={selectedUids.join(",")} />
     </>

--- a/app/models/community-feed.ts
+++ b/app/models/community-feed.ts
@@ -68,6 +68,7 @@ async function getRecruitmentFeedStatsByPostUid(
     .select({
       userId: recruitmentResultsTable.userId,
       recruitedStudents: recruitmentResultsTable.recruitedStudents,
+      tier3Count: recruitmentResultsTable.tier3Count,
       trial: recruitmentResultsTable.trial,
       commentPostUid: recruitmentResultsTable.commentPostUid,
     })
@@ -91,6 +92,7 @@ async function getRecruitmentFeedStatsByPostUid(
       const stats = getRecruitmentResultCountStats(
         {
           recruitedStudents,
+          tier3Count: row.tier3Count ?? null,
           trial: row.trial ?? null,
         },
         {

--- a/app/models/recruitment-result-stats.ts
+++ b/app/models/recruitment-result-stats.ts
@@ -103,20 +103,21 @@ export function resolveRecruitmentResultStudents(
 }
 
 export function getRecruitmentResultCountStats(
-  result: Pick<RecruitmentResult, "recruitedStudents" | "trial">,
+  result: Pick<RecruitmentResult, "recruitedStudents" | "tier3Count" | "trial">,
   lookup: StudentLookup,
 ): RecruitmentResultCountStats {
   const recruitedStudents = resolveRecruitmentResultStudents(result.recruitedStudents, lookup);
   const tier3Students = recruitedStudents.filter(({ tier }) => tier === 3);
   const pickupStudents = tier3Students.filter(({ pickup }) => pickup);
+  const tier3Count = result.tier3Count ?? tier3Students.length;
   const rateMultiplier = lookup.group?.recruitmentType === "fes" ? 0.5 : 1;
   const hasTrial = result.trial !== null;
 
   return {
     totalTrial: result.trial,
-    tier3Count: tier3Students.length,
-    tier3DrawCount: tier3Students.length,
-    tier3RateCount: hasTrial ? tier3Students.length * rateMultiplier : 0,
+    tier3Count,
+    tier3DrawCount: tier3Count,
+    tier3RateCount: hasTrial ? tier3Count * rateMultiplier : 0,
     pickupCount: pickupStudents.length,
     pickupDrawCount: pickupStudents.length,
     pickupRateCount: hasTrial ? pickupStudents.length * rateMultiplier : 0,

--- a/app/models/recruitment-result-stats.ts
+++ b/app/models/recruitment-result-stats.ts
@@ -108,6 +108,7 @@ export function getRecruitmentResultCountStats(
 ): RecruitmentResultCountStats {
   const recruitedStudents = resolveRecruitmentResultStudents(result.recruitedStudents, lookup);
   const tier3Students = recruitedStudents.filter(({ tier }) => tier === 3);
+  // Count-only entries intentionally cannot contribute to pickup counts because no student identity is recorded.
   const pickupStudents = tier3Students.filter(({ pickup }) => pickup);
   const tier3Count = result.tier3Count ?? tier3Students.length;
   const rateMultiplier = lookup.group?.recruitmentType === "fes" ? 0.5 : 1;

--- a/app/models/recruitment-result.ts
+++ b/app/models/recruitment-result.ts
@@ -3,7 +3,7 @@ import { drizzle } from "drizzle-orm/d1";
 import { int, sqliteTable, text } from "drizzle-orm/sqlite-core";
 import { nanoid } from "nanoid/non-secure";
 import type { RecruitmentTypeEnum } from "~/graphql/graphql";
-import { nowUtcIso, type UtcIsoString } from "~/lib/date-time";
+import { type UtcIsoString, nowUtcIso } from "~/lib/date-time";
 import {
   communityPostsTable,
   createRecruitmentResultCommunityPost,
@@ -13,8 +13,8 @@ import {
   upsertRecruitmentResultCommunityPost,
 } from "./community";
 import type { PickupHistory } from "./pickup-history";
-import { resolveRecruitmentResultStudent, type StudentLookup } from "./recruitment-result-stats";
 import { upsertRecruitedStudentFromRecruitmentResult } from "./recruited-student";
+import { type StudentLookup, resolveRecruitmentResultStudent } from "./recruitment-result-stats";
 
 const IN_QUERY_BATCH_SIZE = 90;
 
@@ -27,6 +27,7 @@ export const recruitmentResultsTable = sqliteTable("recruitment_results", {
   completedAt: text(),
   recruitedStudents: text().notNull().default("[]"),
   exchangedStudents: text().notNull().default("[]"),
+  tier3Count: int(),
   trial: int(),
   rawResult: text(),
   commentPostUid: text(),
@@ -54,6 +55,7 @@ export type RecruitmentResult = {
   completedAt: UtcIsoString | null;
   recruitedStudents: RecruitmentResultStudent[];
   exchangedStudents: RecruitmentResultStudent[];
+  tier3Count?: number | null;
   trial: number | null;
   rawResult: string | null;
   commentPostUid: string | null;
@@ -68,6 +70,7 @@ export type UpsertRecruitmentResultInput = {
   completedAt?: UtcIsoString | null;
   recruitedStudents?: RecruitmentResultStudent[];
   exchangedStudents?: RecruitmentResultStudent[];
+  tier3Count?: number | null;
   trial?: number | null;
   rawResult?: string | null;
   comment?: string | null;
@@ -114,6 +117,7 @@ function toModel(row: RecruitmentResultRow): RecruitmentResult {
     completedAt: row.completedAt as UtcIsoString | null,
     recruitedStudents: parseRecruitedStudents(row.recruitedStudents),
     exchangedStudents: parseRecruitedStudents(row.exchangedStudents),
+    tier3Count: row.tier3Count ?? null,
     trial: row.trial ?? null,
     rawResult: row.rawResult ?? null,
     commentPostUid: row.commentPostUid ?? null,
@@ -243,11 +247,11 @@ export function getRecruitmentResultTrialFromPickupHistory(history: Pick<PickupH
   return Math.max(...history.result.map((trial) => trial.trial));
 }
 
-export async function getRecruitmentResult(
-  env: Env,
-  userId: number,
-  uid: string,
-): Promise<RecruitmentResult | null> {
+export function getRecruitmentResultTier3CountFromPickupHistory(history: Pick<PickupHistory, "result">): number {
+  return history.result.reduce((sum, trial) => sum + trial.tier3Count, 0);
+}
+
+export async function getRecruitmentResult(env: Env, userId: number, uid: string): Promise<RecruitmentResult | null> {
   const db = drizzle(env.DB);
   const row = await db
     .select()
@@ -260,11 +264,7 @@ export async function getRecruitmentResult(
 
 export async function getRecruitmentResults(env: Env, userId: number): Promise<RecruitmentResult[]> {
   const db = drizzle(env.DB);
-  const rows = await db
-    .select()
-    .from(recruitmentResultsTable)
-    .where(eq(recruitmentResultsTable.userId, userId))
-    .all();
+  const rows = await db.select().from(recruitmentResultsTable).where(eq(recruitmentResultsTable.userId, userId)).all();
 
   return rows.map(toModel);
 }
@@ -286,7 +286,12 @@ export async function getRecruitmentResultsByRecruitmentGroupUids(
         db
           .select()
           .from(recruitmentResultsTable)
-          .where(and(eq(recruitmentResultsTable.userId, userId), inArray(recruitmentResultsTable.recruitmentGroupUid, batch)))
+          .where(
+            and(
+              eq(recruitmentResultsTable.userId, userId),
+              inArray(recruitmentResultsTable.recruitmentGroupUid, batch),
+            ),
+          )
           .all(),
       ),
     )
@@ -329,7 +334,11 @@ export async function getRecruitmentResultComments(
     await Promise.all(
       splitIntoBatches(uniqueUids).map((batch) =>
         db
-          .select({ uid: communityPostsTable.uid, blocks: communityPostsTable.blocks, createdAt: communityPostsTable.createdAt })
+          .select({
+            uid: communityPostsTable.uid,
+            blocks: communityPostsTable.blocks,
+            createdAt: communityPostsTable.createdAt,
+          })
           .from(communityPostsTable)
           .where(and(eq(communityPostsTable.userId, userId), inArray(communityPostsTable.uid, batch)))
           .all(),
@@ -340,7 +349,9 @@ export async function getRecruitmentResultComments(
   return new Map(
     posts.flatMap((post) => {
       const comment = getPrimaryPlaintextBlockText(parseCommunityPostBlocks(post.blocks))?.trim();
-      return comment ? [[post.uid, { uid: post.uid, body: comment, createdAt: post.createdAt as UtcIsoString }] as const] : [];
+      return comment
+        ? [[post.uid, { uid: post.uid, body: comment, createdAt: post.createdAt as UtcIsoString }] as const]
+        : [];
     }),
   );
 }
@@ -350,7 +361,9 @@ async function syncRecruitedStudents(env: Env, userId: number, students: Recruit
   // Cancelling completion or removing a result must not auto-delete from recruited_students,
   // because that table is also edited manually and feeds parties, growth, shops, and ranks.
   await Promise.all(
-    students.map((student) => upsertRecruitedStudentFromRecruitmentResult(env, userId, student.studentUid, student.tier)),
+    students.map((student) =>
+      upsertRecruitedStudentFromRecruitmentResult(env, userId, student.studentUid, student.tier),
+    ),
   );
 }
 
@@ -364,13 +377,12 @@ export async function upsertRecruitmentResult(
   const existingByUid = input.uid ? await getRecruitmentResult(env, userId, input.uid) : null;
   const existing =
     existingByUid ??
-    (
-      await getRecruitmentResultsByRecruitmentGroupUids(env, userId, [input.recruitmentGroupUid])
-    )[0] ??
+    (await getRecruitmentResultsByRecruitmentGroupUids(env, userId, [input.recruitmentGroupUid]))[0] ??
     null;
   const uid = existing?.uid ?? input.uid ?? nanoid(8);
   const recruitedStudents = sanitizeRecruitmentResultStudents(input.recruitedStudents ?? existing?.recruitedStudents);
   const exchangedStudents = sanitizeRecruitmentResultStudents(input.exchangedStudents ?? existing?.exchangedStudents);
+  const tier3Count = input.tier3Count !== undefined ? input.tier3Count : existing?.tier3Count;
   const completedAt = input.completedAt !== undefined ? input.completedAt : (existing?.completedAt ?? now);
   const contentUid = input.contentUid !== undefined ? input.contentUid : existing?.contentUid;
   const trial = input.trial !== undefined ? input.trial : existing?.trial;
@@ -386,6 +398,7 @@ export async function upsertRecruitmentResult(
       completedAt,
       recruitedStudents: JSON.stringify(recruitedStudents),
       exchangedStudents: JSON.stringify(exchangedStudents),
+      tier3Count: tier3Count ?? null,
       trial: trial ?? null,
       rawResult: rawResult ?? null,
       commentPostUid: existing?.commentPostUid ?? null,
@@ -398,13 +411,18 @@ export async function upsertRecruitmentResult(
         completedAt,
         recruitedStudents: JSON.stringify(recruitedStudents),
         exchangedStudents: JSON.stringify(exchangedStudents),
+        tier3Count: tier3Count ?? null,
         trial: trial ?? null,
         rawResult: rawResult ?? null,
         updatedAt: now,
       },
     });
 
-  await syncRecruitedStudents(env, userId, normalizeRecruitmentResultStudents([...recruitedStudents, ...exchangedStudents]));
+  await syncRecruitedStudents(
+    env,
+    userId,
+    normalizeRecruitmentResultStudents([...recruitedStudents, ...exchangedStudents]),
+  );
 
   const comment = input.comment?.trim();
   if (comment && contentUid) {
@@ -465,9 +483,7 @@ export async function addRecruitedStudentToResult(
   const db = drizzle(env.DB);
   const now = nowUtcIso();
   const existing =
-    (
-      await getRecruitmentResultsByRecruitmentGroupUids(env, userId, [input.recruitmentGroupUid])
-    )[0] ?? null;
+    (await getRecruitmentResultsByRecruitmentGroupUids(env, userId, [input.recruitmentGroupUid]))[0] ?? null;
   const uid = existing?.uid ?? nanoid(8);
   const student = sanitizeRecruitmentResultStudents([
     {
@@ -495,6 +511,7 @@ export async function addRecruitedStudentToResult(
       completedAt,
       recruitedStudents: JSON.stringify(recruitedStudents),
       exchangedStudents: JSON.stringify(existing?.exchangedStudents ?? []),
+      tier3Count: existing?.tier3Count ?? null,
       trial: existing?.trial ?? null,
       rawResult: existing?.rawResult ?? null,
       commentPostUid: existing?.commentPostUid ?? null,
@@ -507,6 +524,7 @@ export async function addRecruitedStudentToResult(
         completedAt,
         recruitedStudents: JSON.stringify(recruitedStudents),
         exchangedStudents: JSON.stringify(existing?.exchangedStudents ?? []),
+        tier3Count: existing?.tier3Count ?? null,
         updatedAt: now,
       },
     });
@@ -527,10 +545,7 @@ export async function removeRecruitedStudentFromResult(
   recruitmentGroupUid: string,
   studentUid: string,
 ): Promise<RecruitmentResult | null> {
-  const existing =
-    (
-      await getRecruitmentResultsByRecruitmentGroupUids(env, userId, [recruitmentGroupUid])
-    )[0] ?? null;
+  const existing = (await getRecruitmentResultsByRecruitmentGroupUids(env, userId, [recruitmentGroupUid]))[0] ?? null;
   if (!existing) {
     return null;
   }
@@ -538,7 +553,8 @@ export async function removeRecruitedStudentFromResult(
   const db = drizzle(env.DB);
   const now = nowUtcIso();
   const recruitedStudents = removeRecruitmentResultStudent(existing.recruitedStudents, studentUid);
-  const completedAt = recruitedStudents.length > 0 || existing.exchangedStudents.length > 0 ? existing.completedAt : null;
+  const completedAt =
+    recruitedStudents.length > 0 || existing.exchangedStudents.length > 0 ? existing.completedAt : null;
 
   await db
     .update(recruitmentResultsTable)

--- a/app/routes/$username.pickups._components/PickupHistoryEditor.tsx
+++ b/app/routes/$username.pickups._components/PickupHistoryEditor.tsx
@@ -78,11 +78,7 @@ export default function PickupHistoryEditor({
             label="모집한 ★3 학생"
             description="모집한 ★3 학생을 선택해주세요"
             descriptionAction={
-              <Checkbox
-                label="★3 학생 목록 입력하지 않기"
-                checked={skipTier3StudentList}
-                onChange={onSkipTier3StudentListChange}
-              />
+              <Checkbox label="선택하지 않기" checked={skipTier3StudentList} onChange={onSkipTier3StudentListChange} />
             }
             students={tier3Students}
             initialStudentUids={tier3StudentIds}

--- a/app/routes/$username.pickups._components/PickupHistoryEditor.tsx
+++ b/app/routes/$username.pickups._components/PickupHistoryEditor.tsx
@@ -1,5 +1,5 @@
 import { StudentSelectForm } from "~/components/features/forms";
-import { Button, Input } from "~/components/primitives";
+import { Checkbox, Input } from "~/components/primitives";
 
 type PickupHistoryEditorProps = {
   tier3Students: {
@@ -78,11 +78,10 @@ export default function PickupHistoryEditor({
             label="모집한 ★3 학생"
             description="모집한 ★3 학생을 선택해주세요"
             descriptionAction={
-              <Button
-                text={skipTier3StudentList ? "★3 학생 목록 입력하기" : "★3 학생 목록 입력하지 않기"}
-                variant="tint"
-                size="xs"
-                onClick={() => onSkipTier3StudentListChange(!skipTier3StudentList)}
+              <Checkbox
+                label="★3 학생 목록 입력하지 않기"
+                checked={skipTier3StudentList}
+                onChange={onSkipTier3StudentListChange}
               />
             }
             students={tier3Students}

--- a/app/routes/$username.pickups._components/PickupHistoryEditor.tsx
+++ b/app/routes/$username.pickups._components/PickupHistoryEditor.tsx
@@ -1,5 +1,5 @@
 import { StudentSelectForm } from "~/components/features/forms";
-import { Input } from "~/components/primitives";
+import { Checkbox, Input } from "~/components/primitives";
 
 type PickupHistoryEditorProps = {
   tier3Students: {
@@ -14,29 +14,32 @@ type PickupHistoryEditorProps = {
   totalCount?: number;
   tier3Count?: number;
   tier3StudentIds: string[];
+  skipTier3StudentList: boolean;
   exchangedStudentIds: string[];
 
   onTotalCountChange: (value?: number) => void;
   onTier3CountChange: (value?: number) => void;
   onTier3StudentIdsChange: (value: string[]) => void;
+  onSkipTier3StudentListChange: (value: boolean) => void;
   onExchangedStudentIdsChange: (value: string[]) => void;
 };
 
-export default function PickupHistoryEditor(
-  {
-    tier3Students,
-    exchangeableStudents,
-    totalCount,
-    tier3Count,
-    tier3StudentIds,
-    exchangedStudentIds,
-    onTotalCountChange,
-    onTier3CountChange,
-    onTier3StudentIdsChange,
-    onExchangedStudentIdsChange,
-  }: PickupHistoryEditorProps,
-) {
+export default function PickupHistoryEditor({
+  tier3Students,
+  exchangeableStudents,
+  totalCount,
+  tier3Count,
+  tier3StudentIds,
+  skipTier3StudentList,
+  exchangedStudentIds,
+  onTotalCountChange,
+  onTier3CountChange,
+  onTier3StudentIdsChange,
+  onSkipTier3StudentListChange,
+  onExchangedStudentIdsChange,
+}: PickupHistoryEditorProps) {
   const exchangeCountLimit = Math.floor((totalCount ?? 0) / 200);
+  const canSkipTier3StudentList = tier3Count !== undefined && tier3Count > 0;
 
   return (
     <div className="space-y-6">
@@ -55,26 +58,31 @@ export default function PickupHistoryEditor(
           className="max-w-none"
           containerClassName="mt-0 mb-0"
         />
-        <Input
-          type="number"
-          label="모집한 ★3 횟수"
-          description="모집한 ★3 학생의 수를 입력해주세요"
-          placeholder="6"
-          value={tier3Count?.toString() ?? ""}
-          onChange={(value) => {
-            const newCount = Number.parseInt(value);
-            onTier3CountChange(Number.isNaN(newCount) ? undefined : newCount);
-            if (!Number.isNaN(newCount) && tier3StudentIds.length > newCount) {
-              onTier3StudentIdsChange(tier3StudentIds.slice(0, newCount));
-            }
-          }}
-          descriptionClassName="text-muted-foreground/75"
-          className="max-w-none"
-          containerClassName="mt-0 mb-0"
-        />
+        <div className="space-y-2">
+          <Input
+            type="number"
+            label="모집한 ★3 횟수"
+            description="모집한 ★3 학생의 수를 입력해주세요"
+            placeholder="6"
+            value={tier3Count?.toString() ?? ""}
+            onChange={(value) => {
+              const newCount = Number.parseInt(value);
+              onTier3CountChange(Number.isNaN(newCount) ? undefined : newCount);
+            }}
+            descriptionClassName="text-muted-foreground/75"
+            className="max-w-none"
+            containerClassName="mt-0 mb-0"
+          />
+          <Checkbox
+            label="★3 학생 목록 입력하지 않기"
+            checked={canSkipTier3StudentList && skipTier3StudentList}
+            disabled={!canSkipTier3StudentList}
+            onChange={onSkipTier3StudentListChange}
+          />
+        </div>
       </div>
       <div>
-        {tier3Count !== undefined && tier3Count > 0 && (
+        {tier3Count !== undefined && tier3Count > 0 && !skipTier3StudentList && (
           <StudentSelectForm
             label="모집한 ★3 학생"
             description="모집한 ★3 학생을 선택해주세요"
@@ -107,4 +115,4 @@ export default function PickupHistoryEditor(
       </div>
     </div>
   );
-};
+}

--- a/app/routes/$username.pickups._components/PickupHistoryEditor.tsx
+++ b/app/routes/$username.pickups._components/PickupHistoryEditor.tsx
@@ -1,5 +1,5 @@
 import { StudentSelectForm } from "~/components/features/forms";
-import { Checkbox, Input } from "~/components/primitives";
+import { Button, Input } from "~/components/primitives";
 
 type PickupHistoryEditorProps = {
   tier3Students: {
@@ -39,7 +39,6 @@ export default function PickupHistoryEditor({
   onExchangedStudentIdsChange,
 }: PickupHistoryEditorProps) {
   const exchangeCountLimit = Math.floor((totalCount ?? 0) / 200);
-  const canSkipTier3StudentList = tier3Count !== undefined && tier3Count > 0;
 
   return (
     <div className="space-y-6">
@@ -58,36 +57,37 @@ export default function PickupHistoryEditor({
           className="max-w-none"
           containerClassName="mt-0 mb-0"
         />
-        <div className="space-y-2">
-          <Input
-            type="number"
-            label="모집한 ★3 횟수"
-            description="모집한 ★3 학생의 수를 입력해주세요"
-            placeholder="6"
-            value={tier3Count?.toString() ?? ""}
-            onChange={(value) => {
-              const newCount = Number.parseInt(value);
-              onTier3CountChange(Number.isNaN(newCount) ? undefined : newCount);
-            }}
-            descriptionClassName="text-muted-foreground/75"
-            className="max-w-none"
-            containerClassName="mt-0 mb-0"
-          />
-          <Checkbox
-            label="★3 학생 목록 입력하지 않기"
-            checked={canSkipTier3StudentList && skipTier3StudentList}
-            disabled={!canSkipTier3StudentList}
-            onChange={onSkipTier3StudentListChange}
-          />
-        </div>
+        <Input
+          type="number"
+          label="모집한 ★3 횟수"
+          description="모집한 ★3 학생의 수를 입력해주세요"
+          placeholder="6"
+          value={tier3Count?.toString() ?? ""}
+          onChange={(value) => {
+            const newCount = Number.parseInt(value);
+            onTier3CountChange(Number.isNaN(newCount) ? undefined : newCount);
+          }}
+          descriptionClassName="text-muted-foreground/75"
+          className="max-w-none"
+          containerClassName="mt-0 mb-0"
+        />
       </div>
       <div>
-        {tier3Count !== undefined && tier3Count > 0 && !skipTier3StudentList && (
+        {tier3Count !== undefined && tier3Count > 0 && (
           <StudentSelectForm
             label="모집한 ★3 학생"
             description="모집한 ★3 학생을 선택해주세요"
+            descriptionAction={
+              <Button
+                text={skipTier3StudentList ? "★3 학생 목록 입력하기" : "★3 학생 목록 입력하지 않기"}
+                variant="tint"
+                size="xs"
+                onClick={() => onSkipTier3StudentListChange(!skipTier3StudentList)}
+              />
+            }
             students={tier3Students}
             initialStudentUids={tier3StudentIds}
+            hideInput={skipTier3StudentList}
             onSelect={(value) => onTier3StudentIdsChange(value as string[])}
             multiple
             allowDuplicateSelection

--- a/app/routes/$username.pickups._components/PickupHistoryView.tsx
+++ b/app/routes/$username.pickups._components/PickupHistoryView.tsx
@@ -1,10 +1,10 @@
-import { Form, Link } from "react-router";
-import { Button } from "~/components/primitives";
 import { ChevronRightIcon } from "@heroicons/react/16/solid";
+import { Form, Link } from "react-router";
 import ContentCommentView from "~/components/features/contents/ContentCommentView";
 import { StudentCards } from "~/components/features/students";
+import { Button } from "~/components/primitives";
 import { useDisplayTimeZone } from "~/contexts/TimeZoneProvider";
-import { formatInstant, type UtcIsoString } from "~/lib/date-time";
+import { type UtcIsoString, formatInstant } from "~/lib/date-time";
 import { pickupGroupTypeLocale } from "~/locales/ko";
 
 type PickupHistoryViewProps = {
@@ -66,6 +66,7 @@ export default function PickupHistoryView({
 }: PickupHistoryViewProps) {
   const tier3Students = recruitedStudents.filter(({ tier }) => tier === 3);
   const tier3ExchangedStudents = exchangedStudents.filter(({ tier }) => tier === 3);
+  const tier3StudentListMissing = stats.tier3Count > 0 && tier3Students.length === 0;
   const visibleComment = comment?.body.trim() ? comment : null;
 
   return (
@@ -74,6 +75,7 @@ export default function PickupHistoryView({
         <div className="min-w-0 flex-1 space-y-4">
           <PickupHeader event={event} />
           {tier3Students.length > 0 && <Tier3StudentList students={tier3Students} />}
+          {tier3StudentListMissing && <Tier3StudentListMissing />}
           {tier3ExchangedStudents.length > 0 && <ExchangedStudentList students={tier3ExchangedStudents} />}
           {visibleComment && <PickupComment comment={visibleComment} />}
         </div>
@@ -145,6 +147,15 @@ function Tier3StudentList({ students }: { students: PickupHistoryViewProps["recr
   );
 }
 
+function Tier3StudentListMissing() {
+  return (
+    <div className="space-y-2.5">
+      <p className="text-sm font-semibold text-neutral-700 dark:text-neutral-300">모집한 ★3 학생</p>
+      <p className="text-sm text-neutral-500 dark:text-neutral-400">학생 목록 미입력</p>
+    </div>
+  );
+}
+
 function ExchangedStudentList({ students }: { students: PickupHistoryViewProps["exchangedStudents"] }) {
   const cardStudents = students.map(({ uid, name }) => ({
     uid,
@@ -167,12 +178,7 @@ type PickupStatsProps = {
   trialMissing: boolean;
 };
 
-function PickupStats({
-  totalTrial,
-  tier3Count,
-  pickupCount,
-  trialMissing,
-}: PickupStatsProps) {
+function PickupStats({ totalTrial, tier3Count, pickupCount, trialMissing }: PickupStatsProps) {
   const hasTrial = !trialMissing && totalTrial !== null;
   const statsGridClassName = hasTrial ? "grid-cols-3 divide-x md:divide-y" : "grid-cols-1";
   const stats = [
@@ -181,7 +187,12 @@ function PickupStats({
 
   if (hasTrial) {
     stats.push(
-      <PickupStat key="tier3" label="★3 학생" value={`${tier3Count}회`} detail={formatPercentage(tier3Count / totalTrial)} />,
+      <PickupStat
+        key="tier3"
+        label="★3 학생"
+        value={`${tier3Count}회`}
+        detail={formatPercentage(tier3Count / totalTrial)}
+      />,
       <PickupStat
         key="pickup"
         label="픽업 학생"

--- a/app/routes/$username.pickups.edit.$id.tsx
+++ b/app/routes/$username.pickups.edit.$id.tsx
@@ -118,6 +118,10 @@ export function getVisibleTier3StudentUids(studentUids: string[], tier3Count?: n
   return studentUids.slice(0, Math.max(0, tier3Count));
 }
 
+export function shouldSkipTier3StudentListInitially(tier3Count?: number, tier3StudentUids: string[] = []) {
+  return (tier3Count ?? 0) > 0 && tier3StudentUids.length === 0;
+}
+
 export const loader = async ({ context, request, params }: LoaderFunctionArgs) => {
   const env = context.cloudflare.env;
   const sensei = await getActiveSensei(env, request);
@@ -372,7 +376,7 @@ export default function EditPickup() {
   const [tier3Count, setTier3Count] = useState(initialTier3Count);
   const [tier3StudentUids, setTier3StudentUids] = useState(initialTier3StudentUids ?? []);
   const [skipTier3StudentList, setSkipTier3StudentList] = useState(
-    (initialTier3Count ?? 0) > 0 && (initialTier3StudentUids?.length ?? 0) < (initialTier3Count ?? 0),
+    shouldSkipTier3StudentListInitially(initialTier3Count, initialTier3StudentUids),
   );
   const [exchangedStudentUids, setExchangedStudentUids] = useState(currentPickupHistory?.exchangedStudentIds ?? []);
 

--- a/app/routes/$username.pickups.edit.$id.tsx
+++ b/app/routes/$username.pickups.edit.$id.tsx
@@ -13,6 +13,7 @@ import {
   createRecruitmentResultStudentsFromPickupHistory,
   getRecruitmentResult,
   getRecruitmentResultComment,
+  getRecruitmentResultTier3CountFromPickupHistory,
   getRecruitmentResultTrialFromPickupHistory,
   mergeEditableRecruitmentResultStudents,
   upsertRecruitmentResult,
@@ -76,12 +77,14 @@ function getSaveUnavailableReason({
   totalCount,
   tier3Count,
   tier3StudentCount,
+  skipTier3StudentList,
   exchangedStudentCount,
 }: {
   eventUid: string | null;
   totalCount?: number;
   tier3Count?: number;
   tier3StudentCount: number;
+  skipTier3StudentList: boolean;
   exchangedStudentCount: number;
 }) {
   if (!eventUid) {
@@ -96,7 +99,7 @@ function getSaveUnavailableReason({
   if (tier3Count > totalCount) {
     return "모집한 ★3 횟수는 총 모집 횟수보다 클 수 없어요.";
   }
-  if (tier3StudentCount !== tier3Count) {
+  if (!skipTier3StudentList && tier3StudentCount !== tier3Count) {
     return `모집한 ★3 학생을 ${tier3Count}명 선택해주세요. 현재 ${tier3StudentCount}명이 선택됐어요.`;
   }
   const maxExchangedStudentCount = Math.floor(totalCount / 200);
@@ -105,6 +108,14 @@ function getSaveUnavailableReason({
   }
 
   return null;
+}
+
+export function getVisibleTier3StudentUids(studentUids: string[], tier3Count?: number) {
+  if (tier3Count === undefined) {
+    return studentUids;
+  }
+
+  return studentUids.slice(0, Math.max(0, tier3Count));
 }
 
 export const loader = async ({ context, request, params }: LoaderFunctionArgs) => {
@@ -195,7 +206,7 @@ export const loader = async ({ context, request, params }: LoaderFunctionArgs) =
         result: [
           {
             trial: currentRecruitmentResult.trial,
-            tier3Count: tier3StudentIds.length,
+            tier3Count: currentRecruitmentResult.tier3Count ?? tier3StudentIds.length,
             tier3StudentIds,
           },
         ],
@@ -307,6 +318,7 @@ export const action = async ({ context, request, params }: ActionFunctionArgs) =
         pickupStudentUids,
         groupStudentInitialTiers,
       );
+  const tier3Count = getRecruitmentResultTier3CountFromPickupHistory({ result: data.result });
 
   await upsertRecruitmentResult(env, sensei.id, {
     uid: params.id && params.id !== "new" ? params.id : undefined,
@@ -315,6 +327,7 @@ export const action = async ({ context, request, params }: ActionFunctionArgs) =
     completedAt: nowUtcIso(),
     recruitedStudents,
     exchangedStudents,
+    tier3Count,
     trial,
     rawResult: data.rawResult ?? null,
     comment: data.comment ?? null,
@@ -358,15 +371,21 @@ export default function EditPickup() {
   const [totalCount, setTotalCount] = useState(initialTotalCount);
   const [tier3Count, setTier3Count] = useState(initialTier3Count);
   const [tier3StudentUids, setTier3StudentUids] = useState(initialTier3StudentUids ?? []);
+  const [skipTier3StudentList, setSkipTier3StudentList] = useState(
+    (initialTier3Count ?? 0) > 0 && (initialTier3StudentUids?.length ?? 0) < (initialTier3Count ?? 0),
+  );
   const [exchangedStudentUids, setExchangedStudentUids] = useState(currentPickupHistory?.exchangedStudentIds ?? []);
 
   const [showImporter, setShowImporter] = useState(false);
   const [comment, setComment] = useState(currentPickupHistory?.comment ?? "");
+  const visibleTier3StudentUids = getVisibleTier3StudentUids(tier3StudentUids, tier3Count);
+  const submittedTier3StudentUids = skipTier3StudentList ? [] : visibleTier3StudentUids;
   const saveUnavailableReason = getSaveUnavailableReason({
     eventUid,
     totalCount,
     tier3Count,
-    tier3StudentCount: tier3StudentUids.length,
+    tier3StudentCount: submittedTier3StudentUids.length,
+    skipTier3StudentList,
     exchangedStudentCount: exchangedStudentUids.length,
   });
 
@@ -381,9 +400,6 @@ export default function EditPickup() {
   };
   const handleTier3CountChange = (value?: number) => {
     setTier3Count(value);
-    if (value !== undefined && tier3StudentUids.length > value) {
-      setTier3StudentUids((prev) => prev.slice(0, value));
-    }
   };
   const handleSave = () => {
     if (saveUnavailableReason || !eventUid || totalCount === undefined || tier3Count === undefined) {
@@ -396,7 +412,7 @@ export default function EditPickup() {
         {
           trial: totalCount,
           tier3Count,
-          tier3StudentIds: tier3StudentUids,
+          tier3StudentIds: submittedTier3StudentUids,
         },
       ],
       exchangedStudentIds: exchangedStudentUids,
@@ -462,7 +478,8 @@ export default function EditPickup() {
         tier3Students={tier3Students}
         totalCount={totalCount}
         tier3Count={tier3Count}
-        tier3StudentIds={tier3StudentUids}
+        tier3StudentIds={visibleTier3StudentUids}
+        skipTier3StudentList={skipTier3StudentList}
         exchangedStudentIds={exchangedStudentUids}
         exchangeableStudents={
           selectedEvent?.recruitments.flatMap((recruitment) =>
@@ -472,6 +489,7 @@ export default function EditPickup() {
         onTotalCountChange={handleTotalCountChange}
         onTier3CountChange={handleTier3CountChange}
         onTier3StudentIdsChange={setTier3StudentUids}
+        onSkipTier3StudentListChange={setSkipTier3StudentList}
         onExchangedStudentIdsChange={setExchangedStudentUids}
       />
 

--- a/db/migrations/20260615000100_add_tier3_count_to_recruitment_results.sql
+++ b/db/migrations/20260615000100_add_tier3_count_to_recruitment_results.sql
@@ -1,0 +1,1 @@
+alter table recruitment_results add column tier3Count integer;

--- a/test/app/models/community-feed.test.ts
+++ b/test/app/models/community-feed.test.ts
@@ -40,6 +40,7 @@ type FakeRecruitmentResultRow = {
   completedAt: string | null;
   recruitedStudents: string;
   exchangedStudents: string;
+  tier3Count?: number | null;
   trial: number | null;
   rawResult: string | null;
   commentPostUid: string | null;
@@ -89,7 +90,13 @@ class FakeCommunityFeedD1Database {
       const commentPostUids = params.filter((param): param is string => typeof param === "string");
       return this.recruitmentResults
         .filter((result) => result.commentPostUid !== null && commentPostUids.includes(result.commentPostUid))
-        .map((result) => [result.userId, result.recruitedStudents, result.trial, result.commentPostUid]);
+        .map((result) => [
+          result.userId,
+          result.recruitedStudents,
+          result.tier3Count ?? null,
+          result.trial,
+          result.commentPostUid,
+        ]);
     }
 
     throw new Error(`Unexpected SELECT SQL: ${sql}\nparams: ${JSON.stringify(params)}`);

--- a/test/app/models/recruitment-result.test.ts
+++ b/test/app/models/recruitment-result.test.ts
@@ -3,12 +3,14 @@ import { RecruitmentTypeEnum } from "../../../app/graphql/graphql";
 import {
   appendRecruitmentResultStudent,
   createRecruitmentResultStudentsFromPickupHistory,
+  getRecruitmentResultTier3CountFromPickupHistory,
   getRecruitmentResultTrialFromPickupHistory,
   mergeEditableRecruitmentResultStudents,
   normalizeRecruitmentResultStudents,
   removeRecruitmentResultStudent,
   sanitizeRecruitmentResultStudents,
 } from "../../../app/models/recruitment-result";
+import { getRecruitmentResultCountStats } from "../../../app/models/recruitment-result-stats";
 
 describe("recruitment-result", () => {
   it("preserves recruited student order and duplicates for pickup history display", () => {
@@ -40,6 +42,35 @@ describe("recruitment-result", () => {
         ],
       }),
     ).toBe(80);
+  });
+
+  it("sums explicit tier3 count from pickup history results", () => {
+    expect(
+      getRecruitmentResultTier3CountFromPickupHistory({
+        result: [
+          { trial: 10, tier3Count: 2, tier3StudentIds: [] },
+          { trial: 20, tier3Count: 1, tier3StudentIds: ["hina"] },
+        ],
+      }),
+    ).toBe(3);
+  });
+
+  it("uses explicit tier3 count for stats when student names are omitted", () => {
+    expect(
+      getRecruitmentResultCountStats(
+        {
+          recruitedStudents: [],
+          tier3Count: 4,
+          trial: 100,
+        },
+        {},
+      ),
+    ).toMatchObject({
+      tier3Count: 4,
+      tier3DrawCount: 4,
+      tier3RateCount: 4,
+      pickupCount: 0,
+    });
   });
 
   it("deduplicates only for recruited_students projection sync", () => {

--- a/test/app/routes/pickup-history-edit.test.ts
+++ b/test/app/routes/pickup-history-edit.test.ts
@@ -11,7 +11,7 @@ import {
 import { getAllStudents } from "~/models/student";
 import { getTimelineContentsByRecruitmentGroupUids } from "~/models/timeline-content";
 import { RecruitmentRepository } from "~/repositories";
-import { action, loader } from "../../../app/routes/$username.pickups.edit.$id";
+import { action, getVisibleTier3StudentUids, loader } from "../../../app/routes/$username.pickups.edit.$id";
 
 jest.mock("~/auth/authenticator.server", () => ({
   getActiveSensei: jest.fn(),
@@ -24,8 +24,18 @@ jest.mock("~/models/pickup-history", () => ({
 jest.mock("~/models/recruitment-result", () => ({
   getRecruitmentResult: jest.fn(),
   getRecruitmentResultComment: jest.fn(),
-  createRecruitmentResultStudentsFromPickupHistory: jest.fn(),
-  getRecruitmentResultTrialFromPickupHistory: jest.fn(),
+  createRecruitmentResultStudentsFromPickupHistory: jest.fn((history: { result: { tier3StudentIds: string[] }[] }) =>
+    history.result.flatMap((trial) =>
+      trial.tier3StudentIds.map((studentUid) => ({ studentUid, tier: 3, pickup: false })),
+    ),
+  ),
+  getRecruitmentResultTrialFromPickupHistory: jest.fn((history: { result: { trial: number | null }[] }) => {
+    const trials = history.result.map((trial) => trial.trial).filter((trial): trial is number => trial !== null);
+    return trials.length > 0 ? Math.max(...trials) : null;
+  }),
+  getRecruitmentResultTier3CountFromPickupHistory: jest.fn((history: { result: { tier3Count: number }[] }) =>
+    history.result.reduce((sum, trial) => sum + trial.tier3Count, 0),
+  ),
   mergeEditableRecruitmentResultStudents: jest.fn(),
   upsertRecruitmentResult: jest.fn(),
 }));
@@ -102,6 +112,17 @@ function createGroup(uid: string, startAt: string) {
 afterEach(() => {
   jest.useRealTimers();
   jest.clearAllMocks();
+});
+
+describe("pickup history editor state helpers", () => {
+  it("derives visible tier3 students without mutating the preserved selection buffer", () => {
+    const selectedStudentUids = ["hina", "aru", "mika"];
+
+    expect(getVisibleTier3StudentUids(selectedStudentUids, 1)).toEqual(["hina"]);
+    expect(selectedStudentUids).toEqual(["hina", "aru", "mika"]);
+    expect(getVisibleTier3StudentUids(selectedStudentUids, 4)).toEqual(["hina", "aru", "mika"]);
+    expect(getVisibleTier3StudentUids(selectedStudentUids, 0)).toEqual([]);
+  });
 });
 
 describe("pickup history editor loader", () => {
@@ -401,6 +422,46 @@ describe("pickup history editor loader", () => {
       init: { status: 400 },
     });
     expect(mockedUpsertRecruitmentResult).not.toHaveBeenCalled();
+  });
+
+  it("saves explicit tier3 count even when tier3 student names are omitted", async () => {
+    const historicalGroup = createGroup("decagrammaton-armed", "2026-05-26T02:00:00Z");
+    mockGetByUid.mockResolvedValue(historicalGroup);
+    mockedGetActiveSensei.mockResolvedValue({
+      id: 1,
+      uid: "sensei-1",
+      username: "sensei",
+    } as Awaited<ReturnType<typeof getActiveSensei>>);
+    mockedGetRecruitmentResult.mockResolvedValue(null);
+    mockedGetTimelineContentsByRecruitmentGroupUids.mockResolvedValue([
+      {
+        uid: "content-decagrammaton-armed",
+        name: "데카그라마톤 무장",
+        recruitmentGroupUid: "decagrammaton-armed",
+      },
+    ] as Awaited<ReturnType<typeof getTimelineContentsByRecruitmentGroupUids>>);
+
+    await action({
+      context: { cloudflare: { env } },
+      request: new Request("https://mollulog.net/@sensei/pickups/edit/new", {
+        method: "POST",
+        body: JSON.stringify({
+          eventUid: "decagrammaton-armed",
+          result: [{ trial: 100, tier3Count: 3, tier3StudentIds: [] }],
+          exchangedStudentIds: [],
+        }),
+      }),
+      params: { username: "@sensei", id: "new" },
+    } as never);
+
+    expect(mockedUpsertRecruitmentResult).toHaveBeenCalledWith(
+      env,
+      1,
+      expect.objectContaining({
+        tier3Count: 3,
+        recruitedStudents: [],
+      }),
+    );
   });
 
   it("preserves existing non-tier3 recruited students when editing an existing result", async () => {

--- a/test/app/routes/pickup-history-edit.test.ts
+++ b/test/app/routes/pickup-history-edit.test.ts
@@ -11,7 +11,12 @@ import {
 import { getAllStudents } from "~/models/student";
 import { getTimelineContentsByRecruitmentGroupUids } from "~/models/timeline-content";
 import { RecruitmentRepository } from "~/repositories";
-import { action, getVisibleTier3StudentUids, loader } from "../../../app/routes/$username.pickups.edit.$id";
+import {
+  action,
+  getVisibleTier3StudentUids,
+  loader,
+  shouldSkipTier3StudentListInitially,
+} from "../../../app/routes/$username.pickups.edit.$id";
 
 jest.mock("~/auth/authenticator.server", () => ({
   getActiveSensei: jest.fn(),
@@ -122,6 +127,12 @@ describe("pickup history editor state helpers", () => {
     expect(selectedStudentUids).toEqual(["hina", "aru", "mika"]);
     expect(getVisibleTier3StudentUids(selectedStudentUids, 4)).toEqual(["hina", "aru", "mika"]);
     expect(getVisibleTier3StudentUids(selectedStudentUids, 0)).toEqual([]);
+  });
+
+  it("only initializes count-only mode for non-zero counts with no student names", () => {
+    expect(shouldSkipTier3StudentListInitially(5, [])).toBe(true);
+    expect(shouldSkipTier3StudentListInitially(5, ["hina", "aru", "mika"])).toBe(false);
+    expect(shouldSkipTier3StudentListInitially(0, [])).toBe(false);
   });
 });
 

--- a/test/app/routes/pickup-history-index.test.ts
+++ b/test/app/routes/pickup-history-index.test.ts
@@ -264,6 +264,65 @@ describe("pickup history index loader", () => {
     expect(result.recruitmentHistories[0].recruitedStudents).toEqual([]);
   });
 
+  it("counts explicit tier3 results even when the student list is omitted", async () => {
+    mockedGetSenseiByUsername.mockResolvedValue({
+      id: 1,
+      uid: "sensei-1",
+      username: "sensei",
+    } as Awaited<ReturnType<typeof getSenseiByUsername>>);
+    mockedGetActiveSensei.mockResolvedValue({
+      id: 1,
+      uid: "sensei-1",
+      username: "sensei",
+    } as Awaited<ReturnType<typeof getActiveSensei>>);
+    mockedGetRecruitmentResults.mockResolvedValue([
+      {
+        uid: "history-tier3-count-only",
+        userId: 1,
+        recruitmentGroupUid: "decagrammaton-armed",
+        contentUid: "content-decagrammaton-armed",
+        completedAt: "2026-05-26T02:00:00.000Z",
+        recruitedStudents: [],
+        exchangedStudents: [],
+        tier3Count: 4,
+        trial: 100,
+        rawResult: null,
+        commentPostUid: null,
+        createdAt: "2026-05-26T02:00:00.000Z",
+        updatedAt: "2026-05-26T02:00:00.000Z",
+      },
+    ]);
+    mockedGetAllStudentsMap.mockResolvedValue({} as Awaited<ReturnType<typeof getAllStudentsMap>>);
+    mockGetByUids.mockResolvedValue([
+      {
+        uid: "decagrammaton-armed",
+        recruitmentType: "usual",
+        recruitments: [],
+      },
+    ]);
+    mockedGetTimelineContentsByRecruitmentGroupUids.mockResolvedValue([
+      {
+        uid: "content-decagrammaton-armed",
+        name: "데카그라마톤 무장",
+        recruitmentGroupUid: "decagrammaton-armed",
+        startAt: "2026-05-26T02:00:00.000Z",
+      },
+    ] as Awaited<ReturnType<typeof getTimelineContentsByRecruitmentGroupUids>>);
+
+    const result = await loader(createLoaderArgs() as never);
+
+    expect(result.recruitmentStats).toMatchObject({
+      trial: 100,
+      tier3Count: 4,
+      tier3DrawCount: 4,
+      pickupCount: 0,
+    });
+    expect(result.recruitmentHistories[0]).toMatchObject({
+      recruitedStudents: [],
+      stats: { tier3Count: 4 },
+    });
+  });
+
   it("resolves stored recruited students from the recruitment pool when the student catalog has no matching row", async () => {
     mockedGetSenseiByUsername.mockResolvedValue({
       id: 1,


### PR DESCRIPTION
## Summary

Allow recruitment history entries to record the ★3 acquisition count without requiring users to select every acquired ★3 student.

## Changes

- Add nullable `tier3Count` storage to recruitment results so count-only entries can still contribute to stats.
- Add a `Skip ★3 student list` checkbox under the ★3 count input in the recruitment history editor.
- Preserve the existing selected-student buffer while only submitting the visible/active list when student names are provided.
- Show `Student list not entered` on recruitment history cards when a count-only entry has no student cards to display.
- Update recruitment history, community feed, and shared recruitment stats calculations to use explicit ★3 counts when present.
- Keep pickup counts based on recorded student identities only; count-only entries intentionally cannot infer pickup acquisitions.
- Add regression tests for count-only saves, count-only history stats, partial-list edit initialization, and explicit count aggregation.

## Verification

- [ ] Manually verified the related behavior.
- [x] Ran required checks such as `pnpm typecheck`, `pnpm exec biome check .`, or relevant tests.
- [ ] If AI tools were used, the generated content was sufficiently reviewed by a human.

Validated with:

- `mise exec -- pnpm test -- recruitment-result.test.ts pickup-history-edit.test.ts pickup-history-index.test.ts community-feed.test.ts`
- `mise exec -- pnpm run typecheck`
- `git diff --check`

## Related Issues

N/A
