### PR TITLE
fix: preserve community feed after engagement

### DIFF
--- a/app/components/features/community/CommunityFeed.tsx
+++ b/app/components/features/community/CommunityFeed.tsx
@@ -14,6 +14,10 @@ import { useSignIn } from "~/contexts/SignInProvider";
 import { useDisplayTimeZone } from "~/contexts/TimeZoneProvider";
 import { compareInstantDesc, formatInstant, parseUtcTimestamp } from "~/lib/date-time";
 import type { CommunityFeedPost, CommunityPostBlock } from "~/models/community";
+import type {
+  CommunityPostCommentsChangedActionResult,
+  CommunityPostLikeChangedActionResult,
+} from "~/models/community-engagement";
 import type { EnrichedCommunityFeedPost } from "~/models/community-feed";
 import { STUDENT_GRADING_TAG_DISPLAY, sortStudentGradingTags } from "~/models/student-grading-tag";
 import { StudentCards } from "../students";
@@ -138,8 +142,8 @@ function CommunityPostCard({
   const [liked, setLiked] = useState(post.liked);
   const [likeCount, setLikeCount] = useState(post.likeCount);
   const [commentEditing, setCommentEditing] = useState(false);
-  const commentFetcher = useFetcher();
-  const likeFetcher = useFetcher<{ likeCount: number; liked: boolean }>();
+  const commentFetcher = useFetcher<CommunityPostCommentsChangedActionResult>();
+  const likeFetcher = useFetcher<CommunityPostLikeChangedActionResult>();
   const timestamp = getPostTimestampMeta(post, displayTimeZone);
   const visibilityLabel = getVisibilityLabel(post.visibility);
   const canComment =
@@ -157,13 +161,13 @@ function CommunityPostCard({
   }, [post.liked, post.likeCount]);
 
   useEffect(() => {
-    if (Array.isArray(commentFetcher.data)) {
-      setComments(commentFetcher.data);
+    if (commentFetcher.data?.kind === "communityPostCommentsChanged") {
+      setComments(commentFetcher.data.comments);
     }
   }, [commentFetcher.data]);
 
   useEffect(() => {
-    if (likeFetcher.data) {
+    if (likeFetcher.data?.kind === "communityPostLikeChanged") {
       setLiked(likeFetcher.data.liked);
       setLikeCount(likeFetcher.data.likeCount);
     }

--- a/app/models/community-engagement.ts
+++ b/app/models/community-engagement.ts
@@ -1,0 +1,43 @@
+import type { NestedCommunityComment } from "./community";
+
+export type CommunityPostCommentsChangedActionResult = {
+  kind: "communityPostCommentsChanged";
+  postUid: string;
+  comments: NestedCommunityComment[];
+};
+
+export type CommunityPostLikeChangedActionResult = {
+  kind: "communityPostLikeChanged";
+  postUid: string;
+  likeCount: number;
+  liked: boolean;
+};
+
+export type CommunityEngagementActionResult =
+  | CommunityPostCommentsChangedActionResult
+  | CommunityPostLikeChangedActionResult;
+
+export function isCommunityEngagementActionResult(value: unknown): value is CommunityEngagementActionResult {
+  if (!value || typeof value !== "object" || !("kind" in value)) {
+    return false;
+  }
+
+  if (value.kind === "communityPostCommentsChanged") {
+    return (
+      "postUid" in value && typeof value.postUid === "string" && "comments" in value && Array.isArray(value.comments)
+    );
+  }
+
+  if (value.kind === "communityPostLikeChanged") {
+    return (
+      "postUid" in value &&
+      typeof value.postUid === "string" &&
+      "likeCount" in value &&
+      typeof value.likeCount === "number" &&
+      "liked" in value &&
+      typeof value.liked === "boolean"
+    );
+  }
+
+  return false;
+}

--- a/app/routes/$username._index.tsx
+++ b/app/routes/$username._index.tsx
@@ -1,12 +1,13 @@
-import type { LoaderFunctionArgs, MetaFunction } from "react-router";
-import { Link, useFetcher, useLoaderData, useSearchParams } from "react-router";
 import { PencilSquareIcon, UserMinusIcon, UserPlusIcon, UsersIcon } from "@heroicons/react/20/solid";
 import { useCallback } from "react";
+import type { LoaderFunctionArgs, MetaFunction, ShouldRevalidateFunction } from "react-router";
+import { Link, useFetcher, useLoaderData, useSearchParams } from "react-router";
 import { getActiveSensei } from "~/auth/authenticator.server";
 import { CommunityInfiniteFeed } from "~/components/features/community";
 import { ProfileImage } from "~/components/primitives";
 import { useSignIn } from "~/contexts/SignInProvider";
 import { getCommunityFeedPage } from "~/models/community";
+import { isCommunityEngagementActionResult } from "~/models/community-engagement";
 import {
   COMMUNITY_FEED_PAGE_SIZE,
   COMMUNITY_VISIBLE_POST_TYPES,
@@ -82,6 +83,14 @@ export const loader = async ({ context, request, params }: LoaderFunctionArgs) =
   };
 };
 
+export const shouldRevalidate: ShouldRevalidateFunction = ({ actionResult, defaultShouldRevalidate }) => {
+  if (isCommunityEngagementActionResult(actionResult)) {
+    return false;
+  }
+
+  return defaultShouldRevalidate;
+};
+
 export const meta: MetaFunction = ({ params }) => {
   return [
     { title: `${params.username || ""} - 프로필 | 몰루로그`.trim() },
@@ -104,7 +113,9 @@ export default function UserIndex() {
   const loaderData = useLoaderData<typeof loader>();
   const { sensei, currentUsername, posts, signedIn, studentsByUid, page, totalPages } = loaderData;
 
-  let followability: ProfileHeaderProps["followability"] = loaderData.relationship.following ? "following" : "followable";
+  let followability: ProfileHeaderProps["followability"] = loaderData.relationship.following
+    ? "following"
+    : "followable";
   if (currentUsername === sensei.username) {
     followability = "unable";
   }
@@ -112,13 +123,16 @@ export default function UserIndex() {
   const fetcher = useFetcher<ActionData>();
   const { showSignIn } = useSignIn();
   const [searchParams] = useSearchParams();
-  const getPageUrl = useCallback((nextPage: number) => {
-    const nextSearchParams = new URLSearchParams(searchParams);
-    nextSearchParams.set("page", String(nextPage));
+  const getPageUrl = useCallback(
+    (nextPage: number) => {
+      const nextSearchParams = new URLSearchParams(searchParams);
+      nextSearchParams.set("page", String(nextPage));
 
-    const query = nextSearchParams.toString();
-    return query ? `/@${sensei.username}?${query}` : `/@${sensei.username}`;
-  }, [searchParams, sensei.username]);
+      const query = nextSearchParams.toString();
+      return query ? `/@${sensei.username}?${query}` : `/@${sensei.username}`;
+    },
+    [searchParams, sensei.username],
+  );
 
   return (
     <div className="my-6 space-y-5">
@@ -208,7 +222,11 @@ function ProfileHeader({
       </div>
 
       <div className="mt-4">
-        {bio && <p className="whitespace-pre-wrap text-left text-sm leading-6 text-neutral-800 dark:text-neutral-100">{bio}</p>}
+        {bio && (
+          <p className="whitespace-pre-wrap text-left text-sm leading-6 text-neutral-800 dark:text-neutral-100">
+            {bio}
+          </p>
+        )}
 
         <div className={`${bio ? "mt-3" : ""} flex flex-wrap items-center gap-x-4 gap-y-2 text-left text-sm`}>
           <Link to={`/@${username}/friends?tab=following`} className="hover:underline">
@@ -274,18 +292,16 @@ function RecruitmentSummaryBar({
         </span>
       </div>
       <div className="flex h-2.5 overflow-hidden rounded-full bg-neutral-200 dark:bg-neutral-700">
-        {recruitedCount > 0 ? (
-          visibleTiers.map((tier) => (
-            <div
-              key={tier}
-              className={recruitmentTierStyles[tier]}
-              style={{ width: `${((tierCounts[tier] ?? 0) / widthBase) * 100}%` }}
-              title={`${tier <= 5 ? `★${tier}` : `고유 ${tier - 5}`} - ${tierCounts[tier]}명`}
-            />
-          ))
-        ) : (
-          null
-        )}
+        {recruitedCount > 0
+          ? visibleTiers.map((tier) => (
+              <div
+                key={tier}
+                className={recruitmentTierStyles[tier]}
+                style={{ width: `${((tierCounts[tier] ?? 0) / widthBase) * 100}%` }}
+                title={`${tier <= 5 ? `★${tier}` : `고유 ${tier - 5}`} - ${tierCounts[tier]}명`}
+              />
+            ))
+          : null}
         {unrecruitedCount > 0 && (
           <div
             className="bg-neutral-300 dark:bg-neutral-700"

--- a/app/routes/api.community.posts.$uid.comments.tsx
+++ b/app/routes/api.community.posts.$uid.comments.tsx
@@ -1,4 +1,4 @@
-import { redirect, type ActionFunctionArgs, type LoaderFunctionArgs } from "react-router";
+import { type ActionFunctionArgs, type LoaderFunctionArgs, redirect } from "react-router";
 import { getActiveSensei } from "~/auth/authenticator.server";
 import {
   createCommunityComment,
@@ -6,6 +6,7 @@ import {
   getNestedCommunityComments,
   updateCommunityComment,
 } from "~/models/community";
+import type { CommunityPostCommentsChangedActionResult } from "~/models/community-engagement";
 
 export const loader = async ({ request, params, context }: LoaderFunctionArgs) => {
   const postUid = params.uid;
@@ -50,14 +51,7 @@ export const action = async ({ request, params, context }: ActionFunctionArgs) =
       throw new Response("Body and parentCommentUid are required", { status: 400 });
     }
 
-    await createCommunityComment(
-      env,
-      currentUser.id,
-      postUid,
-      actionData.body,
-      "public",
-      actionData.parentCommentUid,
-    );
+    await createCommunityComment(env, currentUser.id, postUid, actionData.body, "public", actionData.parentCommentUid);
   } else if (actionData.action === "update") {
     if (!actionData.commentUid || !actionData.body) {
       throw new Response("CommentUid and body are required", { status: 400 });
@@ -80,5 +74,9 @@ export const action = async ({ request, params, context }: ActionFunctionArgs) =
     throw new Response("Invalid action", { status: 400 });
   }
 
-  return getNestedCommunityComments(env, postUid, currentUser.id);
+  return {
+    kind: "communityPostCommentsChanged",
+    postUid,
+    comments: await getNestedCommunityComments(env, postUid, currentUser.id),
+  } satisfies CommunityPostCommentsChangedActionResult;
 };

--- a/app/routes/api.community.posts.$uid.likes.tsx
+++ b/app/routes/api.community.posts.$uid.likes.tsx
@@ -1,6 +1,7 @@
-import { redirect, type ActionFunctionArgs, type LoaderFunctionArgs } from "react-router";
+import { type ActionFunctionArgs, type LoaderFunctionArgs, redirect } from "react-router";
 import { getActiveSensei } from "~/auth/authenticator.server";
 import { getCommunityLikeCountsByPostUids, getLikedCommunityPostUids, setCommunityPostLike } from "~/models/community";
+import type { CommunityPostLikeChangedActionResult } from "~/models/community-engagement";
 
 export const loader = async ({ request, params, context }: LoaderFunctionArgs) => {
   const postUid = params.uid;
@@ -46,7 +47,9 @@ export const action = async ({ request, params, context }: ActionFunctionArgs) =
   ]);
 
   return {
+    kind: "communityPostLikeChanged",
+    postUid,
     likeCount: counts[postUid] ?? 0,
     liked: likedPostUids.has(postUid),
-  };
+  } satisfies CommunityPostLikeChangedActionResult;
 };

--- a/app/routes/community.tsx
+++ b/app/routes/community.tsx
@@ -1,25 +1,26 @@
+import { ChevronDownIcon } from "@heroicons/react/16/solid";
 import {
   ChatBubbleLeftRightIcon,
-  SparklesIcon,
   PlayCircleIcon,
-  UsersIcon,
+  SparklesIcon,
   Squares2X2Icon,
+  UsersIcon,
 } from "@heroicons/react/24/outline";
-import { ChevronDownIcon } from "@heroicons/react/16/solid";
 import { type ElementType, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
-import type { LoaderFunctionArgs, MetaFunction } from "react-router";
+import type { LoaderFunctionArgs, MetaFunction, ShouldRevalidateFunction } from "react-router";
 import { useLoaderData } from "react-router";
 import { getActiveSensei } from "~/auth/authenticator.server";
 import { CommunityInfiniteFeed } from "~/components/features/community";
 import { Page } from "~/components/features/layout";
+import { cn } from "~/lib/utils";
 import { getCommunityFeedPage } from "~/models/community";
+import { isCommunityEngagementActionResult } from "~/models/community-engagement";
 import {
   COMMUNITY_FEED_PAGE_SIZE,
   COMMUNITY_VISIBLE_POST_TYPES,
   enrichCommunityFeedPosts,
 } from "~/models/community-feed";
-import { cn } from "~/lib/utils";
 
 type CommunityVisiblePostType = (typeof COMMUNITY_VISIBLE_POST_TYPES)[number];
 
@@ -96,6 +97,14 @@ export const loader = async ({ context, request }: LoaderFunctionArgs) => {
   };
 };
 
+export const shouldRevalidate: ShouldRevalidateFunction = ({ actionResult, defaultShouldRevalidate }) => {
+  if (isCommunityEngagementActionResult(actionResult)) {
+    return false;
+  }
+
+  return defaultShouldRevalidate;
+};
+
 export const meta: MetaFunction = () => {
   const title = "평가/의견 | 몰루로그";
   const description = "블루 아카이브의 학생 평가와 이벤트 의견을 확인해보세요.";
@@ -112,13 +121,16 @@ export const meta: MetaFunction = () => {
 export default function CommunityPage() {
   const { posts, signedIn, studentsByUid, postTypes, page, totalPages } = useLoaderData<typeof loader>();
   const [searchParams] = useSearchParams();
-  const getPageUrl = useCallback((nextPage: number) => {
-    const nextSearchParams = new URLSearchParams(searchParams);
-    nextSearchParams.set("page", String(nextPage));
+  const getPageUrl = useCallback(
+    (nextPage: number) => {
+      const nextSearchParams = new URLSearchParams(searchParams);
+      nextSearchParams.set("page", String(nextPage));
 
-    const query = nextSearchParams.toString();
-    return query ? `/community?${query}` : "/community";
-  }, [searchParams]);
+      const query = nextSearchParams.toString();
+      return query ? `/community?${query}` : "/community";
+    },
+    [searchParams],
+  );
 
   return (
     <Page

--- a/test/app/models/community-engagement.test.ts
+++ b/test/app/models/community-engagement.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "@jest/globals";
+import { isCommunityEngagementActionResult } from "~/models/community-engagement";
+
+describe("isCommunityEngagementActionResult", () => {
+  it("accepts community comment and like action results", () => {
+    expect(
+      isCommunityEngagementActionResult({
+        kind: "communityPostCommentsChanged",
+        postUid: "post-1",
+        comments: [],
+      }),
+    ).toBe(true);
+
+    expect(
+      isCommunityEngagementActionResult({
+        kind: "communityPostLikeChanged",
+        postUid: "post-1",
+        likeCount: 1,
+        liked: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects unrelated action results", () => {
+    expect(isCommunityEngagementActionResult(null)).toBe(false);
+    expect(isCommunityEngagementActionResult({ kind: "listChange" })).toBe(false);
+    expect(isCommunityEngagementActionResult({ kind: "communityPostCommentsChanged", postUid: "post-1" })).toBe(false);
+    expect(
+      isCommunityEngagementActionResult({ kind: "communityPostLikeChanged", postUid: "post-1", likeCount: 1 }),
+    ).toBe(false);
+    expect(isCommunityEngagementActionResult({})).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the community feed resetting to page 1 after users comment on or like posts that were loaded through pagination.

## Changes

- Added typed community engagement action results for comment and like mutations.
- Updated community comment and like actions to return domain-level `kind` values instead of anonymous response shapes.
- Skipped feed route revalidation for self-contained engagement mutations on the community page and user profile feed.
- Updated feed card fetchers to consume the new action result shapes.
- Added coverage for the engagement action result type guard.

## Verification

- [ ] Manually verified the related behavior.
- [x] Ran `mise exec -- pnpm test -- test/app/models/community-engagement.test.ts`.
- [x] Ran `mise exec -- pnpm run typecheck`.
- [x] Ran targeted `mise exec -- pnpm exec biome check ...`.
- [x] Reviewed AI-assisted changes.

## Related Issues

N/A
