### PR TITLE
feat: add monthly pyroxene buy recurrence

### DIFF
--- a/app/components/features/futures/PyroxenePlannerSourcePanel.tsx
+++ b/app/components/features/futures/PyroxenePlannerSourcePanel.tsx
@@ -9,7 +9,11 @@ import {
   PanelOptionIconButton,
 } from "~/components/primitives";
 import { cn } from "~/lib/utils";
-import type { PyroxenePlannerOptions, TimelineSourceType } from "~/models/pyroxene-planner";
+import type {
+  PyroxenePlannerOptions,
+  PyroxeneTimelineRepeatType,
+  TimelineSourceType,
+} from "~/models/pyroxene-planner";
 import { PYROXENE_AP_CHARGE_MAX_COUNT } from "~/models/pyroxene-planner-source-config";
 import type { PyroxeneMonthlyPackageType } from "~/models/pyroxene-planner-source-config";
 import {
@@ -27,7 +31,11 @@ import { PYROXENE_SOURCE_ROW_DEFINITIONS, PYROXENE_SOURCE_ROW_GROUP_LABELS } fro
 type PyroxenePlannerSourcePanelProps = {
   options: PyroxenePlannerOptions;
   onOptionsChange: (options: PyroxenePlannerOptions) => void;
-  onSaveBuy: (quantity: number, date: Date) => void;
+  onSaveBuy: (
+    quantity: number,
+    date: Date,
+    options?: { repeatType?: PyroxeneTimelineRepeatType; monthlyCount?: number },
+  ) => void;
   onSaveMonthlyPackage: (startDate: Date, packageType: PyroxeneMonthlyPackageType, autoRepurchase: boolean) => void;
   onSaveApPackage: (startDate: Date, autoRepurchase: boolean) => void;
   onSaveAttendance: (startDate: Date) => void;
@@ -158,8 +166,8 @@ export default function PyroxenePlannerSourcePanel({
             options={options}
             onOptionsChange={onOptionsChange}
             onClose={() => setOpenRowId(null)}
-            onSaveBuy={(quantity, date) => {
-              onSaveBuy(quantity, date);
+            onSaveBuy={(quantity, date, options) => {
+              onSaveBuy(quantity, date, options);
               setOpenRowId(null);
             }}
             onSaveMonthlyPackage={(startDate, packageType, autoRepurchase) => {

--- a/app/components/features/futures/planner-input/BuyInput.tsx
+++ b/app/components/features/futures/planner-input/BuyInput.tsx
@@ -1,19 +1,26 @@
 import dayjs from "dayjs";
 import { useState } from "react";
 import { CheckIcon } from "@heroicons/react/16/solid";
-import { Button, Field, Input } from "~/components/primitives";
+import { Button, Field, Input, NumberInput, Toggle } from "~/components/primitives";
 import { cn } from "~/lib/utils";
 import {
   DEFAULT_BUY_PYROXENE_QUANTITY,
   PYROXENE_BUY_PRESET_GROUPS,
 } from "~/models/pyroxene-planner-source-config";
+import type { PyroxeneTimelineRepeatType } from "~/models/pyroxene-planner";
 
 type BuyInputProps = {
-  onSaveBuy: (quantity: number, date: Date) => void;
+  onSaveBuy: (
+    quantity: number,
+    date: Date,
+    options?: { repeatType?: PyroxeneTimelineRepeatType; monthlyCount?: number },
+  ) => void;
 };
 
 export default function BuyInput({ onSaveBuy }: BuyInputProps) {
+  const [monthlyRepeat, setMonthlyRepeat] = useState(false);
   const [quantity, setQuantity] = useState(DEFAULT_BUY_PYROXENE_QUANTITY);
+  const [monthlyCount, setMonthlyCount] = useState(1);
   const [date, setDate] = useState(new Date());
   const [showMorePresets, setShowMorePresets] = useState(false);
 
@@ -78,12 +85,41 @@ export default function BuyInput({ onSaveBuy }: BuyInputProps) {
             </button>
           )}
         </Field>
+        <Field label="구매 주기">
+          <Toggle
+            label="매월 반복 구매"
+            initialState={monthlyRepeat}
+            className="my-2"
+            onChange={setMonthlyRepeat}
+          />
+        </Field>
+        {monthlyRepeat && (
+          <div className="space-y-2">
+            <NumberInput
+              label="월 구매 횟수"
+              size="sm"
+              minValue={1}
+              value={monthlyCount}
+              onChange={(value) => setMonthlyCount(Math.max(1, Math.floor(value)))}
+            />
+            <p className="text-xs text-muted-foreground">
+              입력한 날짜에 {(quantity * monthlyCount).toLocaleString()}개를 반영하고, 다음 달부터 매월 1일 같은 수량을
+              반복 반영해요
+            </p>
+          </div>
+        )}
         <Button
           text="저장"
           variant="tint-blue"
           fullWidth
           className="mt-2"
-          onClick={() => onSaveBuy(quantity, date)}
+          onClick={() =>
+            onSaveBuy(
+              quantity,
+              date,
+              monthlyRepeat ? { repeatType: "monthly_first", monthlyCount } : undefined,
+            )
+          }
         />
       </div>
     </>

--- a/app/components/features/futures/types.ts
+++ b/app/components/features/futures/types.ts
@@ -1,7 +1,7 @@
 import type { RecruitmentTypeEnum } from "~/graphql/graphql";
 import type { UtcIsoString } from "~/lib/date-time";
 import type { RaidType } from "~/models/content.d";
-import type { TimelineSourceType } from "~/models/pyroxene-planner";
+import type { PyroxeneTimelineRepeatType, TimelineSourceType } from "~/models/pyroxene-planner";
 
 export type PyroxeneScheduleItem = {
   event?: {
@@ -46,7 +46,8 @@ export type PyroxeneScheduleItem = {
     pyroxeneDelta?: number;
     oneTimeTicketDelta?: number;
     tenTimeTicketDelta?: number;
-    repeatIntervalDays: number;
+    repeatType?: PyroxeneTimelineRepeatType;
+    repeatIntervalDays?: number;
     repeatCount?: number;
     autoRepurchase?: boolean;
   };

--- a/app/components/features/futures/usePyroxeneScheduleItems.ts
+++ b/app/components/features/futures/usePyroxeneScheduleItems.ts
@@ -47,15 +47,29 @@ export function usePyroxeneScheduleItems(
 
     for (const item of timelineItems) {
       if (item.source === "buy") {
-        items.push({
-          onetimeGain: {
-            uid: item.uid,
-            source: "buy",
-            description: item.description,
-            date: new Date(item.eventAt),
-            pyroxeneDelta: item.pyroxeneDelta,
-          },
-        });
+        if (item.repeatType === "monthly_first") {
+          items.push({
+            repeatedGain: {
+              uid: item.uid,
+              source: "buy",
+              description: item.description,
+              date: new Date(item.eventAt),
+              pyroxeneDelta: item.pyroxeneDelta,
+              repeatType: item.repeatType,
+              repeatCount: item.repeatCount ?? undefined,
+            },
+          });
+        } else {
+          items.push({
+            onetimeGain: {
+              uid: item.uid,
+              source: "buy",
+              description: item.description,
+              date: new Date(item.eventAt),
+              pyroxeneDelta: item.pyroxeneDelta,
+            },
+          });
+        }
       } else if (item.source === "package_onetime" || item.source === "package_ap") {
         if (item.autoRepurchase && item.repeatIntervalDays) {
           items.push({
@@ -65,6 +79,7 @@ export function usePyroxeneScheduleItems(
               description: item.description,
               date: new Date(item.eventAt),
               pyroxeneDelta: item.pyroxeneDelta,
+              repeatType: item.repeatType,
               repeatIntervalDays: item.repeatIntervalDays,
               repeatCount: item.repeatCount ?? undefined,
               autoRepurchase: item.autoRepurchase,
@@ -90,6 +105,7 @@ export function usePyroxeneScheduleItems(
             description: item.description,
             date: new Date(item.eventAt),
             pyroxeneDelta: item.pyroxeneDelta,
+            repeatType: item.repeatType,
             repeatIntervalDays: item.repeatIntervalDays ?? 0,
             repeatCount: item.repeatCount ?? undefined,
             autoRepurchase: item.autoRepurchase,
@@ -103,6 +119,7 @@ export function usePyroxeneScheduleItems(
             description: item.description,
             date: new Date(item.eventAt),
             pyroxeneDelta: item.pyroxeneDelta,
+            repeatType: item.repeatType,
             repeatIntervalDays: item.repeatIntervalDays ?? 0,
           },
         });

--- a/app/models/pyroxene-planner.ts
+++ b/app/models/pyroxene-planner.ts
@@ -229,6 +229,7 @@ export const pyroxeneTimelineItemsTable = sqliteTable("pyroxene_timeline_items",
   userId: int().notNull(),
   eventAt: text().notNull(),
   source: text().notNull(),
+  repeatType: text(),
   repeatIntervalDays: int(),
   repeatCount: int(),
   autoRepurchase: int().notNull().default(0),
@@ -240,11 +241,14 @@ export const pyroxeneTimelineItemsTable = sqliteTable("pyroxene_timeline_items",
   updatedAt: text().notNull().default(sql`current_timestamp`),
 });
 
+export type PyroxeneTimelineRepeatType = "fixed_days" | "monthly_first";
+
 export type PyroxeneTimelineItem = {
   uid: string;
   userId: number;
   eventAt: string;
   source: TimelineSourceType;
+  repeatType: PyroxeneTimelineRepeatType;
   repeatIntervalDays: number | null;
   repeatCount: number | null;
   autoRepurchase: boolean;
@@ -254,12 +258,17 @@ export type PyroxeneTimelineItem = {
   tenTimeTicketDelta: number;
 };
 
+function toTimelineRepeatType(repeatType: string | null): PyroxeneTimelineRepeatType {
+  return repeatType === "monthly_first" ? "monthly_first" : "fixed_days";
+}
+
 function toTimelineItemModel(item: typeof pyroxeneTimelineItemsTable.$inferSelect): PyroxeneTimelineItem {
   return {
     uid: item.uid,
     userId: item.userId,
     eventAt: item.eventAt,
     source: item.source as TimelineSourceType,
+    repeatType: toTimelineRepeatType(item.repeatType),
     repeatIntervalDays: item.repeatIntervalDays,
     repeatCount: item.repeatCount,
     autoRepurchase: item.autoRepurchase === 1,
@@ -280,17 +289,39 @@ export async function getPyroxeneTimelineItems(env: Env, userId: number): Promis
   return items.map(toTimelineItemModel);
 }
 
-export async function createBuyPyroxene(env: Env, userId: number, date: Date | string, quantity: number): Promise<void> {
+type CreateBuyPyroxeneOptions = {
+  repeatType?: PyroxeneTimelineRepeatType;
+  monthlyCount?: number;
+};
+
+function normalizeMonthlyCount(monthlyCount: number | undefined): number {
+  if (monthlyCount === undefined || !Number.isFinite(monthlyCount)) {
+    return 1;
+  }
+  return Math.max(1, Math.floor(monthlyCount));
+}
+
+export async function createBuyPyroxene(
+  env: Env,
+  userId: number,
+  date: Date | string,
+  quantity: number,
+  options: CreateBuyPyroxeneOptions = {},
+): Promise<void> {
   const uid = nanoid(8);
   const eventAt = normalizePyroxeneTimelineEventAt(date);
+  const repeatType = options.repeatType ?? "fixed_days";
+  const normalizedMonthlyCount = normalizeMonthlyCount(options.monthlyCount);
+  const pyroxeneDelta = quantity * normalizedMonthlyCount;
   const db = drizzle(env.DB);
   await db.insert(pyroxeneTimelineItemsTable).values({
     uid,
     userId,
     eventAt,
     source: "buy",
+    repeatType: repeatType === "fixed_days" ? null : repeatType,
     description: "청휘석 구매",
-    pyroxeneDelta: quantity,
+    pyroxeneDelta,
     oneTimeTicketDelta: 0,
     tenTimeTicketDelta: 0,
   });

--- a/app/models/pyroxene-sources.ts
+++ b/app/models/pyroxene-sources.ts
@@ -11,7 +11,7 @@ import {
   calculateDailyApChargePyroxene,
   normalizePyroxeneTimelineEventAt,
 } from "~/models/pyroxene-planner-source-config";
-import type { PyroxeneTimelineItem, TimelineSourceType } from "./pyroxene-planner";
+import type { PyroxeneTimelineItem, PyroxeneTimelineRepeatType, TimelineSourceType } from "./pyroxene-planner";
 import type { PickupResources } from "./pyroxene-timeline";
 export {
   DEFAULT_PYROXENE_TIMELINE_DISPLAY,
@@ -56,6 +56,7 @@ type OptimisticTimelineItemInput = {
   pyroxeneDelta?: number;
   oneTimeTicketDelta?: number;
   tenTimeTicketDelta?: number;
+  repeatType?: PyroxeneTimelineRepeatType;
   repeatIntervalDays?: number | null;
   repeatCount?: number | null;
   autoRepurchase?: boolean;
@@ -71,19 +72,39 @@ function createOptimisticTimelineItem(input: OptimisticTimelineItemInput): Pyrox
     pyroxeneDelta: input.pyroxeneDelta ?? 0,
     oneTimeTicketDelta: input.oneTimeTicketDelta ?? 0,
     tenTimeTicketDelta: input.tenTimeTicketDelta ?? 0,
+    repeatType: input.repeatType ?? "fixed_days",
     repeatIntervalDays: input.repeatIntervalDays ?? null,
     repeatCount: input.repeatCount ?? null,
     autoRepurchase: input.autoRepurchase ?? false,
   };
 }
 
-export function createOptimisticBuyTimelineItems(quantity: number, date: Date): PyroxeneTimelineItem[] {
+type OptimisticBuyTimelineOptions = {
+  repeatType?: PyroxeneTimelineRepeatType;
+  monthlyCount?: number;
+};
+
+function normalizeMonthlyCount(monthlyCount: number | undefined): number {
+  if (monthlyCount === undefined || !Number.isFinite(monthlyCount)) {
+    return 1;
+  }
+  return Math.max(1, Math.floor(monthlyCount));
+}
+
+export function createOptimisticBuyTimelineItems(
+  quantity: number,
+  date: Date,
+  options: OptimisticBuyTimelineOptions = {},
+): PyroxeneTimelineItem[] {
+  const normalizedMonthlyCount = normalizeMonthlyCount(options.monthlyCount);
+
   return [
     createOptimisticTimelineItem({
       eventAt: date,
       source: "buy",
       description: "청휘석 구매",
-      pyroxeneDelta: quantity,
+      pyroxeneDelta: quantity * normalizedMonthlyCount,
+      repeatType: options.repeatType,
     }),
   ];
 }

--- a/app/models/pyroxene-timeline.ts
+++ b/app/models/pyroxene-timeline.ts
@@ -61,6 +61,17 @@ const TIMELINE_DELTA_PRIORITY = {
   TICKET_EXPIRY: 20,
 } as const;
 
+function getNextMonthlyFirstDate(date: dayjs.Dayjs): dayjs.Dayjs {
+  return date.add(1, "month").startOf("month");
+}
+
+function getNextRepeatedGainDate(repeatedGain: NonNullable<PyroxeneScheduleItem["repeatedGain"]>, date: dayjs.Dayjs) {
+  if (repeatedGain.repeatType === "monthly_first") {
+    return getNextMonthlyFirstDate(date);
+  }
+  return date.add(repeatedGain.repeatIntervalDays ?? 0, "day");
+}
+
 function getEliminationTicketExpiresAt(raidUntil: Date | string): dayjs.Dayjs {
   return dayjs(raidUntil).add(1, "month").endOf("month");
 }
@@ -232,11 +243,15 @@ export function buildTimeline(
       });
     } else if (scheduleItem.repeatedGain) {
       const { repeatedGain } = scheduleItem;
+      if (repeatedGain.repeatType !== "monthly_first" && (!repeatedGain.repeatIntervalDays || repeatedGain.repeatIntervalDays <= 0)) {
+        continue;
+      }
+
       let repeatedGainCount = 0;
       for (
         let date = dayjs(repeatedGain.date);
         date.isBefore(maxDate) && repeatedGainCount < (repeatedGain.repeatCount ?? MAX_REPEATED_ENTRIES);
-        date = date.add(repeatedGain.repeatIntervalDays, "day")
+        date = getNextRepeatedGainDate(repeatedGain, date)
       ) {
         timelineDeltas.push({
           date,

--- a/app/routes/utils.pyroxene.tsx
+++ b/app/routes/utils.pyroxene.tsx
@@ -16,7 +16,12 @@ import {
   usePyroxeneScheduleItems,
 } from "~/components/features/futures";
 import type { PickupResources } from "~/components/features/futures";
-import type { PyroxenePlannerOptions, PyroxeneTimelineItem, PyroxeneEventData } from "~/models/pyroxene-planner";
+import type {
+  PyroxenePlannerOptions,
+  PyroxeneTimelineItem,
+  PyroxeneEventData,
+  PyroxeneTimelineRepeatType,
+} from "~/models/pyroxene-planner";
 import Page from "~/components/features/layout/Page";
 import { getUserFavoritedStudents } from "~/models/favorite-students";
 import {
@@ -128,6 +133,8 @@ export type ActionData = {
     buy?: {
       quantity: number;
       date: string;
+      repeatType?: PyroxeneTimelineRepeatType;
+      monthlyCount?: number;
     };
     monthlyPackage?: {
       startDate: string;
@@ -207,7 +214,10 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
         }
       }
       if (createData.buy?.quantity !== undefined) {
-        await createBuyPyroxene(env, currentUser.id, createData.buy.date, createData.buy.quantity);
+        await createBuyPyroxene(env, currentUser.id, createData.buy.date, createData.buy.quantity, {
+          repeatType: createData.buy.repeatType,
+          monthlyCount: createData.buy.monthlyCount,
+        });
       }
       if (createData.monthlyPackage?.startDate !== undefined) {
         await createPyroxeneMonthlyPackage(
@@ -394,14 +404,18 @@ export default function PyroxenePlanner() {
     fetcher.submit({ deleteData: { itemUid } }, { method: "DELETE", encType: "application/json" });
   };
 
-  const handleSaveBuy = (quantity: number, date: Date) => {
+  const handleSaveBuy = (
+    quantity: number,
+    date: Date,
+    options?: { repeatType?: PyroxeneTimelineRepeatType; monthlyCount?: number },
+  ) => {
     if (fetcher.state !== "idle" || timelineSaveInFlight.current) {
       return;
     }
     timelineSaveInFlight.current = true;
-    setLocalTimelineItems((prev) => [...prev, ...createOptimisticBuyTimelineItems(quantity, date)]);
+    setLocalTimelineItems((prev) => [...prev, ...createOptimisticBuyTimelineItems(quantity, date, options)]);
     fetcher.submit(
-      { createData: { buy: { quantity, date: date.toISOString() } } },
+      { createData: { buy: { quantity, date: date.toISOString(), ...options } } },
       { method: "POST", encType: "application/json" },
     );
   };
@@ -562,7 +576,7 @@ export default function PyroxenePlanner() {
               <PyroxenePlannerSourcePanel
                 options={options}
                 onOptionsChange={handleOptionsChange}
-                onSaveBuy={(quantity, date) => handleSaveBuy(quantity, date)}
+                onSaveBuy={(quantity, date, options) => handleSaveBuy(quantity, date, options)}
                 onSaveMonthlyPackage={(startDate, packageType, autoRepurchase) =>
                   handleSaveMonthlyPackage(startDate, packageType, autoRepurchase)
                 }

--- a/db/migrations/20260615000200_add_repeat_type_to_pyroxene_timeline_items.sql
+++ b/db/migrations/20260615000200_add_repeat_type_to_pyroxene_timeline_items.sql
@@ -1,0 +1,1 @@
+alter table pyroxene_timeline_items add column repeatType text;

--- a/test/app/components/features/futures/pyroxene-sources.test.ts
+++ b/test/app/components/features/futures/pyroxene-sources.test.ts
@@ -274,6 +274,25 @@ describe("pyroxene-sources", () => {
     ]);
   });
 
+  it("creates monthly-first buy optimistic items with multiplied quantity", () => {
+    const items = createOptimisticBuyTimelineItems(6600, new Date("2026-06-15T12:34:56.000Z"), {
+      monthlyCount: 2,
+      repeatType: "monthly_first",
+    });
+
+    expect(items).toEqual([
+      expect.objectContaining({
+        eventAt: normalizePyroxeneTimelineEventAt("2026-06-15T12:34:56.000Z"),
+        source: "buy",
+        description: "청휘석 구매",
+        pyroxeneDelta: 13200,
+        repeatType: "monthly_first",
+        repeatIntervalDays: null,
+        repeatCount: null,
+      }),
+    ]);
+  });
+
   it("creates other optimistic items with all resource deltas", () => {
     const items = createOptimisticOtherTimelineItems(
       { pyroxene: 120, oneTimeTicket: 1, tenTimeTicket: 2 },

--- a/test/app/components/features/futures/pyroxene-timeline.test.ts
+++ b/test/app/components/features/futures/pyroxene-timeline.test.ts
@@ -71,6 +71,66 @@ describe("pyroxene-timeline", () => {
     );
   });
 
+  it("expands monthly-first buy gains from the next month after the purchase date", () => {
+    const timeline = buildTimeline(
+      initialResources,
+      new Date("2026-06-01T00:00:00.000Z"),
+      new Map(),
+      [
+        futureEvent("2026-09-15T00:00:00.000Z"),
+        {
+          repeatedGain: {
+            uid: "monthly-buy",
+            source: "buy",
+            date: new Date("2026-06-15T00:00:00.000Z"),
+            description: "청휘석 구매",
+            pyroxeneDelta: 13200,
+            repeatType: "monthly_first",
+          },
+        },
+      ],
+      defaultOptions,
+    );
+
+    const buyEntries = timeline.filter((entry) => entry.source.uid === "monthly-buy");
+
+    expect(buyEntries.map((entry) => [entry.date.format("YYYY-MM-DD"), entry.resourceDelta.pyroxene])).toEqual([
+      ["2026-06-15", 13200],
+      ["2026-07-01", 13200],
+      ["2026-08-01", 13200],
+      ["2026-09-01", 13200],
+    ]);
+  });
+
+  it("expands monthly-first buy gains from the following month when purchased on the 1st", () => {
+    const timeline = buildTimeline(
+      initialResources,
+      new Date("2026-06-01T00:00:00.000Z"),
+      new Map(),
+      [
+        futureEvent("2026-08-15T00:00:00.000Z"),
+        {
+          repeatedGain: {
+            uid: "monthly-buy-first-day",
+            source: "buy",
+            date: new Date("2026-06-01T00:00:00.000Z"),
+            description: "청휘석 구매",
+            pyroxeneDelta: 6600,
+            repeatType: "monthly_first",
+          },
+        },
+      ],
+      defaultOptions,
+    );
+
+    const buyEntries = timeline.filter((entry) => entry.source.uid === "monthly-buy-first-day");
+
+    expect(buyEntries.map((entry) => [entry.date.format("YYYY-MM-DD"), entry.resourceDelta.pyroxene])).toEqual([
+      ["2026-07-01", 6600],
+      ["2026-08-01", 6600],
+    ]);
+  });
+
   it("expands repeated gains until repeat count within the event horizon", () => {
     const timeline = buildTimeline(
       initialResources,


### PR DESCRIPTION
## Summary

- Add a monthly-first recurrence mode to pyroxene purchase planner entries.
- Add a monthly purchase count input that stores the selected product quantity multiplied by the count.
- Extend pyroxene timeline recurrence with `repeatType` and cover monthly-first expansion with tests.

## Details

The pyroxene purchase sheet now supports both one-time purchases and recurring purchases. In recurring mode, the entered purchase date is applied once, then the same monthly total is applied on the 1st day of each following month.

Example: entering `6,600` with monthly count `2` on `2026-06-15` produces `13,200` on `2026-06-15`, then `13,200` on `2026-07-01`, `2026-08-01`, and onward.

## Test Plan

- [x] `pnpm test -- test/app/components/features/futures/pyroxene-sources.test.ts test/app/components/features/futures/pyroxene-timeline.test.ts`
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm test`
