### PR TITLE
feat: personalize navigation red dots

### DIFF
--- a/app/components/features/layout/NavigationBar.tsx
+++ b/app/components/features/layout/NavigationBar.tsx
@@ -44,7 +44,8 @@ type NavigationBarProps = {
   setDarkMode: (fn: (prev: boolean) => boolean) => void;
   upcomingEvent: { uid: string; since: UtcIsoString; until: UtcIsoString } | null;
   hasRecentNews: boolean;
-  hasActiveCoupons: boolean;
+  hasUnconsumedCoupons: boolean;
+  hasUnreadFeedbackReplies: boolean;
 };
 
 type NavigationSearchVariant = "desktop" | "mobile";
@@ -250,7 +251,8 @@ export default function NavigationBar({
   setDarkMode,
   upcomingEvent,
   hasRecentNews,
-  hasActiveCoupons,
+  hasUnconsumedCoupons,
+  hasUnreadFeedbackReplies,
 }: NavigationBarProps) {
   const matches = useMatches();
   const location = useLocation();
@@ -288,7 +290,8 @@ export default function NavigationBar({
             pathname={pathname}
             hasRecentNews={hasRecentNews}
             upcomingEvent={upcomingEvent}
-            hasActiveCoupons={hasActiveCoupons}
+            hasUnconsumedCoupons={hasUnconsumedCoupons}
+            hasUnreadFeedbackReplies={hasUnreadFeedbackReplies}
             sectionStates={sectionStates}
           />
         </div>
@@ -307,6 +310,7 @@ export default function NavigationBar({
         darkMode={darkMode}
         setDarkMode={setDarkMode}
         hasRecentNews={hasRecentNews}
+        hasUnreadFeedbackReplies={hasUnreadFeedbackReplies}
         searchResetKey={searchResetKey}
       />
 
@@ -326,12 +330,14 @@ function MobileBrandHeader({
   darkMode,
   setDarkMode,
   hasRecentNews,
+  hasUnreadFeedbackReplies,
   searchResetKey,
 }: {
   currentUsername: string | null;
   darkMode: boolean;
   setDarkMode: NavigationBarProps["setDarkMode"];
   hasRecentNews: boolean;
+  hasUnreadFeedbackReplies: boolean;
   searchResetKey: string;
 }) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -456,6 +462,7 @@ function MobileBrandHeader({
               to="/contact"
               Icon={EnvelopeIcon}
               label="제안/문의"
+              showRedDot={hasUnreadFeedbackReplies}
               onClick={() => setIsMenuOpen(false)}
             />
             <MobileHeaderMenuButton
@@ -622,7 +629,8 @@ interface DesktopMenuContentProps {
   pathname: string;
   hasRecentNews: boolean;
   upcomingEvent: NavigationBarProps["upcomingEvent"];
-  hasActiveCoupons: boolean;
+  hasUnconsumedCoupons: boolean;
+  hasUnreadFeedbackReplies: boolean;
   sectionStates: NavigationSectionStates;
 }
 
@@ -631,13 +639,14 @@ function DesktopMenuContent({
   pathname,
   hasRecentNews,
   upcomingEvent,
-  hasActiveCoupons,
+  hasUnconsumedCoupons,
+  hasUnreadFeedbackReplies,
   sectionStates,
 }: DesktopMenuContentProps) {
   const menuSections = getNavigationSections({
     pathname,
     upcomingEvent,
-    hasActiveCoupons,
+    hasUnconsumedCoupons,
     sectionStates,
   });
   const contentSection = menuSections.find((section) => section.name === "컨텐츠");
@@ -702,7 +711,7 @@ function DesktopMenuContent({
       <DesktopMenuGroupLabel>서비스</DesktopMenuGroupLabel>
       <div className="space-y-0.5">
         <DesktopMenuLink to="/news" label="업데이트 소식" Icon={MegaphoneIcon} showRedDot={hasRecentNews} />
-        <DesktopMenuLink to="/contact" label="제안/문의" Icon={EnvelopeIcon} />
+        <DesktopMenuLink to="/contact" label="제안/문의" Icon={EnvelopeIcon} showRedDot={hasUnreadFeedbackReplies} />
       </div>
     </nav>
   );

--- a/app/components/features/layout/navigation-menu.ts
+++ b/app/components/features/layout/navigation-menu.ts
@@ -106,13 +106,13 @@ export function getNavigationSections({
   pathname,
   upcomingEvent,
   now = nowUtcIso(),
-  hasActiveCoupons,
+  hasUnconsumedCoupons,
   sectionStates = getNavigationSectionStates(pathname, upcomingEvent),
 }: {
   pathname: string;
   upcomingEvent: UpcomingNavigationEvent;
   now?: UtcIsoString;
-  hasActiveCoupons: boolean;
+  hasUnconsumedCoupons: boolean;
   sectionStates?: NavigationSectionStates;
 }): NavigationSection[] {
   return [
@@ -246,7 +246,7 @@ export function getNavigationSections({
           OutlineIcon: TicketIconOutline,
           SolidIcon: TicketIconSolid,
           isActive: pathname.startsWith("/coupons"),
-          showRedDot: hasActiveCoupons,
+          showRedDot: hasUnconsumedCoupons,
         },
       ],
     },
@@ -257,7 +257,7 @@ export function getSearchableMenuItems(): SearchableMenuItem[] {
   const sections = getNavigationSections({
     pathname: "",
     upcomingEvent: null,
-    hasActiveCoupons: false,
+    hasUnconsumedCoupons: false,
     sectionStates: {
       isCommunityActive: false,
       isContentActive: false,

--- a/app/models/content.ts
+++ b/app/models/content.ts
@@ -11,8 +11,9 @@ import {
 import { RaidRepository, type RaidSchedule, RecruitmentRepository } from "~/repositories";
 import { fetchCached } from "./base";
 import type { RaidType, Role } from "./content.d";
-import { getAllCoupons } from "./coupon";
+import { getAllCoupons, hasUnregisteredActiveCoupons } from "./coupon";
 import { getFavoritedCounts } from "./favorite-students";
+import { hasUnreadAdminFeedbackReplies } from "./feedback";
 import { normalizeFutureContentDates } from "./future-content";
 import { getLatestPostTime } from "./post";
 import { getFutureRaidContents, getTimelineContents, getTimelineContentsByContentTypes } from "./timeline-content";
@@ -358,6 +359,8 @@ type NavigationBarContents = {
   } | null;
   hasRecentNews: boolean;
   hasActiveCoupons: boolean;
+  hasUnconsumedCoupons: boolean;
+  hasUnreadFeedbackReplies: boolean;
 };
 
 type NavigationBarContentsRaw = {
@@ -404,9 +407,22 @@ export async function getNavigationBarContentsRaw(env: Env, forceRefresh = false
   );
 }
 
-export async function getNavigationBarContents(env: Env, forceRefresh = false): Promise<NavigationBarContents> {
+export async function getNavigationBarContents(
+  env: Env,
+  forceRefresh = false,
+  userId?: number,
+): Promise<NavigationBarContents> {
   const now = nowUtcIso();
-  const raw = await getNavigationBarContentsRaw(env, forceRefresh);
+  const [raw, personalRedDots] = await Promise.all([
+    getNavigationBarContentsRaw(env, forceRefresh),
+    userId
+      ? Promise.all([
+          hasUnregisteredActiveCoupons(env, userId),
+          hasUnreadAdminFeedbackReplies(env, userId),
+        ])
+      : Promise.resolve([false, false] as const),
+  ]);
+  const [hasUnconsumedCoupons, hasUnreadFeedbackReplies] = personalRedDots;
   const upcomingEventContent = raw.eventCandidates
     .filter((content) => content.endAt && isInstantAfter(content.endAt, now))
     .sort((a, b) => compareInstantAsc(a.startAt, b.startAt))[0];
@@ -427,5 +443,7 @@ export async function getNavigationBarContents(env: Env, forceRefresh = false): 
     hasActiveCoupons: raw.couponActivePeriods.some(
       (period) => period.endAt === null || isInstantAfter(period.endAt, now),
     ),
+    hasUnconsumedCoupons,
+    hasUnreadFeedbackReplies,
   };
 }

--- a/app/models/coupon.ts
+++ b/app/models/coupon.ts
@@ -74,6 +74,28 @@ export async function hasActiveCoupons(env: Env): Promise<boolean> {
   return rows.length > 0;
 }
 
+export async function hasUnregisteredActiveCoupons(env: Env, userId: number): Promise<boolean> {
+  const db = drizzle(env.DB);
+  const nowIso = new Date().toISOString();
+  const row = await db
+    .select({ exists: sql<number>`1` })
+    .from(couponsTable)
+    .where(
+      and(
+        or(isNull(couponsTable.expiresAt), gt(couponsTable.expiresAt, nowIso)),
+        sql`not exists (
+          select 1
+          from ${couponRegistrationsTable}
+          where ${couponRegistrationsTable.userId} = ${userId}
+            and ${couponRegistrationsTable.couponId} = ${couponsTable.id}
+        )`,
+      ),
+    )
+    .limit(1)
+    .get();
+  return row !== undefined;
+}
+
 export async function getCouponRegistrations(env: Env, userId: number): Promise<number[]> {
   const db = drizzle(env.DB);
   const rows = await db

--- a/app/models/feedback.ts
+++ b/app/models/feedback.ts
@@ -15,6 +15,7 @@ export const feedbackTicketsTable = sqliteTable(
     content: text().notNull(),
     status: text().notNull().default("waiting"),
     replyEmail: text(),
+    lastSeenAdminReplyId: int().notNull().default(0),
     createdAt: text().notNull().default(sql`current_timestamp`),
     updatedAt: text().notNull().default(sql`current_timestamp`),
   },
@@ -49,6 +50,7 @@ export type FeedbackTicket = {
   content: string;
   status: FeedbackTicketStatus;
   replyEmail: string | null;
+  lastSeenAdminReplyId: number;
   createdAt: string;
   updatedAt: string;
 };
@@ -85,6 +87,7 @@ function toFeedbackTicket(row: typeof feedbackTicketsTable.$inferSelect): Feedba
     content: row.content,
     status: toFeedbackTicketStatus(row.status),
     replyEmail: row.replyEmail,
+    lastSeenAdminReplyId: row.lastSeenAdminReplyId,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };
@@ -145,6 +148,51 @@ export async function getFeedbackThreadByUidForUser(env: Env, uid: string, userI
     ticket,
     replies: await getFeedbackRepliesByTicketId(env, ticket.id),
   };
+}
+
+export async function hasUnreadAdminFeedbackReplies(env: Env, userId: number): Promise<boolean> {
+  const db = drizzle(env.DB);
+  const row = await db
+    .select({ exists: sql<number>`1` })
+    .from(feedbackTicketsTable)
+    .innerJoin(
+      feedbackRepliesTable,
+      and(
+        eq(feedbackRepliesTable.ticketId, feedbackTicketsTable.id),
+        eq(feedbackRepliesTable.isAdmin, 1),
+        sql`${feedbackRepliesTable.id} > ${feedbackTicketsTable.lastSeenAdminReplyId}`,
+      ),
+    )
+    .where(eq(feedbackTicketsTable.userId, userId))
+    .limit(1)
+    .get();
+  return row !== undefined;
+}
+
+export function getLatestAdminFeedbackReplyId(replies: FeedbackReply[]): number {
+  return replies.reduce((latestId, reply) => (reply.isAdmin ? Math.max(latestId, reply.id) : latestId), 0);
+}
+
+export async function markFeedbackTicketAdminRepliesSeen(
+  env: Env,
+  ticket: Pick<FeedbackTicket, "id" | "userId" | "lastSeenAdminReplyId">,
+  latestAdminReplyId: number,
+): Promise<void> {
+  if (latestAdminReplyId <= ticket.lastSeenAdminReplyId) {
+    return;
+  }
+
+  const db = drizzle(env.DB);
+  await db
+    .update(feedbackTicketsTable)
+    .set({ lastSeenAdminReplyId: latestAdminReplyId })
+    .where(
+      and(
+        eq(feedbackTicketsTable.id, ticket.id),
+        eq(feedbackTicketsTable.userId, ticket.userId),
+        sql`${feedbackTicketsTable.lastSeenAdminReplyId} < ${latestAdminReplyId}`,
+      ),
+    );
 }
 
 export async function createFeedbackTicket(

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -45,7 +45,7 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
   const sensei = await getActiveSensei(env, request);
   const preference = await getPreference(env, request);
 
-  const navigationBarContents = await getNavigationBarContents(env);
+  const navigationBarContents = await getNavigationBarContents(env, false, sensei?.id);
   return {
     currentUsername: sensei?.username ?? null,
     currentProfileStudentId: sensei?.profileStudentId ?? null,
@@ -190,7 +190,8 @@ export default function App() {
             setDarkMode={setDarkMode}
             upcomingEvent={navigationBarContents.upcomingEvent}
             hasRecentNews={navigationBarContents.hasRecentNews}
-            hasActiveCoupons={navigationBarContents.hasActiveCoupons}
+            hasUnconsumedCoupons={navigationBarContents.hasUnconsumedCoupons}
+            hasUnreadFeedbackReplies={navigationBarContents.hasUnreadFeedbackReplies}
           />
           <div className="mllg-content-area w-full overflow-y-scroll pt-[var(--mobile-header-height)] lg:pt-0">
             <div className="lg:h-screen mx-auto w-full px-4 md:px-8 pt-2 pb-6 lg:py-6">

--- a/app/routes/contact.$uid.tsx
+++ b/app/routes/contact.$uid.tsx
@@ -6,7 +6,13 @@ import { Title } from "~/components/primitives";
 import { publishEvent } from "~/lib/events.server";
 import { routeError } from "~/lib/http-errors";
 import { getLogger } from "~/lib/observability.server";
-import { createFeedbackReply, getFeedbackThreadByUidForUser, getFeedbackTicketByUidForUser } from "~/models/feedback";
+import {
+  createFeedbackReply,
+  getLatestAdminFeedbackReplyId,
+  getFeedbackThreadByUidForUser,
+  getFeedbackTicketByUidForUser,
+  markFeedbackTicketAdminRepliesSeen,
+} from "~/models/feedback";
 import ReplyForm from "./contact._components/ReplyForm";
 import ThreadView from "./contact._components/ThreadView";
 
@@ -37,6 +43,8 @@ export const loader = async ({ context, request, params }: LoaderFunctionArgs) =
   if (!thread) {
     throw notFoundResponse();
   }
+
+  await markFeedbackTicketAdminRepliesSeen(env, thread.ticket, getLatestAdminFeedbackReplyId(thread.replies));
 
   return thread;
 };

--- a/app/routes/utils._index.tsx
+++ b/app/routes/utils._index.tsx
@@ -31,7 +31,7 @@ export default function UtilsIndexPage() {
   const utilSection = getNavigationSections({
     pathname: "/utils",
     upcomingEvent,
-    hasActiveCoupons: false,
+    hasUnconsumedCoupons: false,
   }).find((section) => section.name === "플래너 & 계산기");
 
   return (

--- a/db/migrations/20260619000100_add_personal_navigation_read_state.sql
+++ b/db/migrations/20260619000100_add_personal_navigation_read_state.sql
@@ -1,0 +1,12 @@
+alter table feedback_tickets add column lastSeenAdminReplyId integer not null default 0;
+
+create index if not exists coupons_expiresAt on coupons (expiresAt);
+create index if not exists feedback_replies_ticket_admin_id on feedback_replies (ticketId, isAdmin, id);
+
+update feedback_tickets
+set lastSeenAdminReplyId = coalesce((
+  select max(feedback_replies.id)
+  from feedback_replies
+  where feedback_replies.ticketId = feedback_tickets.id
+    and feedback_replies.isAdmin = 1
+), 0);

--- a/test/app/models/content.test.ts
+++ b/test/app/models/content.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import { fetchCached } from "~/models/base";
-import { getAllCoupons } from "~/models/coupon";
+import { getAllCoupons, hasUnregisteredActiveCoupons } from "~/models/coupon";
+import { hasUnreadAdminFeedbackReplies } from "~/models/feedback";
 import { getLatestPostTime } from "~/models/post";
 import { getTimelineContentsByContentTypes } from "~/models/timeline-content";
 
@@ -11,6 +12,11 @@ jest.mock("~/models/base", () => ({
 
 jest.mock("~/models/coupon", () => ({
   getAllCoupons: jest.fn(),
+  hasUnregisteredActiveCoupons: jest.fn(),
+}));
+
+jest.mock("~/models/feedback", () => ({
+  hasUnreadAdminFeedbackReplies: jest.fn(),
 }));
 
 jest.mock("~/models/post", () => ({
@@ -37,6 +43,12 @@ import { getNavigationBarContents } from "../../../app/models/content";
 
 const mockedFetchCached = fetchCached as jest.MockedFunction<typeof fetchCached>;
 const mockedGetAllCoupons = getAllCoupons as jest.MockedFunction<typeof getAllCoupons>;
+const mockedHasUnregisteredActiveCoupons = hasUnregisteredActiveCoupons as jest.MockedFunction<
+  typeof hasUnregisteredActiveCoupons
+>;
+const mockedHasUnreadAdminFeedbackReplies = hasUnreadAdminFeedbackReplies as jest.MockedFunction<
+  typeof hasUnreadAdminFeedbackReplies
+>;
 const mockedGetLatestPostTime = getLatestPostTime as jest.MockedFunction<typeof getLatestPostTime>;
 const mockedGetTimelineContentsByContentTypes = getTimelineContentsByContentTypes as jest.MockedFunction<
   typeof getTimelineContentsByContentTypes
@@ -76,6 +88,8 @@ describe("getNavigationBarContents (raw + request-time filter)", () => {
     mockedFetchCached.mockImplementation(<T>(_env: Env, _key: string, fn: () => Promise<T>) => fn());
     mockedGetLatestPostTime.mockResolvedValue(null);
     mockedGetAllCoupons.mockResolvedValue([]);
+    mockedHasUnregisteredActiveCoupons.mockResolvedValue(false);
+    mockedHasUnreadAdminFeedbackReplies.mockResolvedValue(false);
   });
 
   it("picks the upcomingEvent against the request-time clock, not the cached snapshot time", async () => {
@@ -159,5 +173,23 @@ describe("getNavigationBarContents (raw + request-time filter)", () => {
     } finally {
       jest.useRealTimers();
     }
+  });
+
+  it("adds personal red dots only for authenticated navigation requests", async () => {
+    mockedGetTimelineContentsByContentTypes.mockResolvedValue([]);
+    mockedHasUnregisteredActiveCoupons.mockResolvedValue(true);
+    mockedHasUnreadAdminFeedbackReplies.mockResolvedValue(true);
+
+    const anonymousResult = await getNavigationBarContents(env);
+    expect(anonymousResult.hasUnconsumedCoupons).toBe(false);
+    expect(anonymousResult.hasUnreadFeedbackReplies).toBe(false);
+    expect(mockedHasUnregisteredActiveCoupons).not.toHaveBeenCalled();
+    expect(mockedHasUnreadAdminFeedbackReplies).not.toHaveBeenCalled();
+
+    const authenticatedResult = await getNavigationBarContents(env, false, 42);
+    expect(authenticatedResult.hasUnconsumedCoupons).toBe(true);
+    expect(authenticatedResult.hasUnreadFeedbackReplies).toBe(true);
+    expect(mockedHasUnregisteredActiveCoupons).toHaveBeenCalledWith(env, 42);
+    expect(mockedHasUnreadAdminFeedbackReplies).toHaveBeenCalledWith(env, 42);
   });
 });

--- a/test/app/models/coupon.test.ts
+++ b/test/app/models/coupon.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "@jest/globals";
+import { hasUnregisteredActiveCoupons } from "~/models/coupon";
+
+type CouponRow = {
+  id: number;
+  expiresAt: string | null;
+};
+
+class FakeD1Statement {
+  private params: unknown[] = [];
+
+  constructor(
+    private readonly db: FakeCouponD1Database,
+    private readonly sql: string,
+  ) {}
+
+  bind(...params: unknown[]): FakeD1Statement {
+    this.params = params;
+    return this;
+  }
+
+  async all(): Promise<{ results: Record<string, unknown>[] }> {
+    return { results: this.db.selectRows(this.sql, this.params) };
+  }
+
+  async raw(): Promise<unknown[][]> {
+    return this.db.selectRows(this.sql, this.params).map((row) => Object.values(row));
+  }
+
+  async get(): Promise<Record<string, unknown> | undefined> {
+    return this.db.selectRows(this.sql, this.params)[0];
+  }
+
+  async first(): Promise<Record<string, unknown> | undefined> {
+    return this.get();
+  }
+}
+
+class FakeCouponD1Database {
+  readonly coupons: CouponRow[] = [];
+  readonly registrations = new Set<string>();
+
+  prepare(sql: string): FakeD1Statement {
+    return new FakeD1Statement(this, sql);
+  }
+
+  selectRows(sql: string, params: unknown[]): Record<string, unknown>[] {
+    const normalizedSql = normalizeSql(sql);
+    if (!normalizedSql.includes("from coupons")) {
+      throw new Error(`Unexpected SELECT SQL: ${sql}\nparams: ${JSON.stringify(params)}`);
+    }
+
+    const nowIso = params.find((param): param is string => typeof param === "string") ?? new Date().toISOString();
+    const userId = Number(params.find((param) => typeof param === "number" && Number(param) > 1));
+    return this.coupons.some(
+      (coupon) =>
+        (coupon.expiresAt === null || coupon.expiresAt > nowIso) && !this.registrations.has(`${userId}:${coupon.id}`),
+    )
+      ? [{ exists: 1 }]
+      : [];
+  }
+}
+
+function createEnv() {
+  const db = new FakeCouponD1Database();
+  return {
+    db,
+    env: { DB: db } as unknown as Env,
+  };
+}
+
+function normalizeSql(sql: string): string {
+  return sql.replaceAll('"', "").replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+describe("coupon personal navigation state", () => {
+  it("returns true only when the user has an active coupon without a registration record", async () => {
+    const { db, env } = createEnv();
+    db.coupons.push(
+      { id: 1, expiresAt: "2000-01-01T00:00:00.000Z" },
+      { id: 2, expiresAt: null },
+      { id: 3, expiresAt: "2999-01-01T00:00:00.000Z" },
+    );
+    db.registrations.add("7:2");
+    db.registrations.add("7:3");
+
+    await expect(hasUnregisteredActiveCoupons(env, 7)).resolves.toBe(false);
+
+    db.registrations.delete("7:3");
+    await expect(hasUnregisteredActiveCoupons(env, 7)).resolves.toBe(true);
+  });
+});

--- a/test/app/models/feedback.test.ts
+++ b/test/app/models/feedback.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  getLatestAdminFeedbackReplyId,
+  hasUnreadAdminFeedbackReplies,
+  markFeedbackTicketAdminRepliesSeen,
+} from "~/models/feedback";
+
+type FeedbackTicketRow = {
+  id: number;
+  userId: number;
+  lastSeenAdminReplyId: number;
+};
+
+type FeedbackReplyRow = {
+  id: number;
+  ticketId: number;
+  isAdmin: number;
+};
+
+class FakeD1Statement {
+  private params: unknown[] = [];
+
+  constructor(
+    private readonly db: FakeFeedbackD1Database,
+    private readonly sql: string,
+  ) {}
+
+  bind(...params: unknown[]): FakeD1Statement {
+    this.params = params;
+    return this;
+  }
+
+  async all(): Promise<{ results: Record<string, unknown>[] }> {
+    return { results: this.db.selectRows(this.sql, this.params) };
+  }
+
+  async raw(): Promise<unknown[][]> {
+    return this.db.selectRows(this.sql, this.params).map((row) => Object.values(row));
+  }
+
+  async get(): Promise<Record<string, unknown> | undefined> {
+    return this.db.selectRows(this.sql, this.params)[0];
+  }
+
+  async first(): Promise<Record<string, unknown> | undefined> {
+    return this.get();
+  }
+
+  async run(): Promise<{ success: true; meta: { changes: number } }> {
+    return { success: true, meta: { changes: this.db.execute(this.sql, this.params) } };
+  }
+}
+
+class FakeFeedbackD1Database {
+  readonly tickets: FeedbackTicketRow[] = [];
+  readonly replies: FeedbackReplyRow[] = [];
+  readonly executedSql: string[] = [];
+  writeCount = 0;
+
+  prepare(sql: string): FakeD1Statement {
+    this.executedSql.push(sql);
+    return new FakeD1Statement(this, sql);
+  }
+
+  selectRows(sql: string, params: unknown[]): Record<string, unknown>[] {
+    const normalizedSql = normalizeSql(sql);
+
+    if (normalizedSql.includes("from feedback_tickets") && normalizedSql.includes("join feedback_replies")) {
+      const userId = Number(params[1]);
+      return this.hasUnreadAdminReply(userId) ? [{ exists: 1 }] : [];
+    }
+
+    throw new Error(`Unexpected SELECT SQL: ${sql}\nparams: ${JSON.stringify(params)}`);
+  }
+
+  execute(sql: string, params: unknown[]): number {
+    const normalizedSql = normalizeSql(sql);
+    if (!normalizedSql.startsWith("update feedback_tickets")) {
+      throw new Error(`Unexpected write SQL: ${sql}`);
+    }
+
+    const ticketId = Number(params[1]);
+    const userId = Number(params[2]);
+    const latestAdminReplyId = Number(params[0]);
+    const ticket = this.tickets.find((candidate) => candidate.id === ticketId && candidate.userId === userId);
+    if (!ticket) {
+      return 0;
+    }
+
+    if (ticket.lastSeenAdminReplyId >= latestAdminReplyId) {
+      return 0;
+    }
+
+    ticket.lastSeenAdminReplyId = latestAdminReplyId;
+    this.writeCount += 1;
+    return 1;
+  }
+
+  private hasUnreadAdminReply(userId: number): boolean {
+    return this.tickets.some(
+      (ticket) =>
+        ticket.userId === userId &&
+        this.replies.some(
+          (reply) => reply.ticketId === ticket.id && reply.isAdmin === 1 && reply.id > ticket.lastSeenAdminReplyId,
+        ),
+    );
+  }
+}
+
+function createEnv() {
+  const db = new FakeFeedbackD1Database();
+  return {
+    db,
+    env: { DB: db } as unknown as Env,
+  };
+}
+
+function normalizeSql(sql: string): string {
+  return sql.replaceAll('"', "").replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+describe("feedback personal navigation state", () => {
+  it("detects unread admin replies only when an admin reply is past the ticket cursor", async () => {
+    const { db, env } = createEnv();
+    db.tickets.push({ id: 10, userId: 1, lastSeenAdminReplyId: 100 });
+    db.replies.push({ id: 101, ticketId: 10, isAdmin: 0 }, { id: 102, ticketId: 10, isAdmin: 1 });
+
+    await expect(hasUnreadAdminFeedbackReplies(env, 1)).resolves.toBe(true);
+    await expect(hasUnreadAdminFeedbackReplies(env, 2)).resolves.toBe(false);
+
+    db.tickets[0].lastSeenAdminReplyId = 102;
+    await expect(hasUnreadAdminFeedbackReplies(env, 1)).resolves.toBe(false);
+  });
+
+  it("finds the latest admin reply id without counting user replies", () => {
+    expect(
+      getLatestAdminFeedbackReplyId([
+        { id: 10, uid: "reply-user", ticketId: 1, userId: 1, isAdmin: false, content: "user", createdAt: "" },
+        { id: 11, uid: "reply-admin-a", ticketId: 1, userId: 2, isAdmin: true, content: "admin", createdAt: "" },
+        { id: 12, uid: "reply-user-b", ticketId: 1, userId: 1, isAdmin: false, content: "user", createdAt: "" },
+      ]),
+    ).toBe(11);
+  });
+
+  it("advances the ticket cursor once and skips the update statement after the reply is seen", async () => {
+    const { db, env } = createEnv();
+    const unreadTicket = { id: 10, userId: 1, lastSeenAdminReplyId: 100 };
+    const seenTicket = { id: 10, userId: 1, lastSeenAdminReplyId: 105 };
+    db.tickets.push({ ...unreadTicket });
+
+    await markFeedbackTicketAdminRepliesSeen(env, unreadTicket, 105);
+    await markFeedbackTicketAdminRepliesSeen(env, seenTicket, 105);
+
+    expect(db.tickets[0].lastSeenAdminReplyId).toBe(105);
+    expect(db.writeCount).toBe(1);
+    expect(db.executedSql.filter((sql) => normalizeSql(sql).startsWith("update feedback_tickets"))).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Personalize left navigation red dot indicators based on each signed-in user's actionable state instead of global active-content state.

## Changes

- Show the coupon menu red dot only when the signed-in user has active coupons they have not marked as registered.
- Show the contact menu red dot when the signed-in user has unread admin replies.
- Add a feedback ticket admin-reply read cursor and supporting D1 indexes.
- Mark admin replies as seen from the contact detail loader only when there is a newer admin reply, avoiding repeated write statements for already-seen threads.
- Add model and navigation tests for personalized red dot behavior.

## Verification

- [x] Manually verified the relevant behavior.
- [x] Ran the required typecheck, lint, and test commands.
- [x] Reviewed AI-generated changes before submission.

Commands run:

- `pnpm run lint`
- `pnpm test`
- `pnpm run typecheck`
- `git diff --check`

## Related Issues

None
