### PR TITLE
fix: prevent duplicate pyroxene reward counting

### DIFF
--- a/app/components/features/futures/PyroxeneInitialResources.tsx
+++ b/app/components/features/futures/PyroxeneInitialResources.tsx
@@ -1,10 +1,11 @@
 import { Transition } from "@headlessui/react";
 import { useEffect, useState } from "react";
-import { Button, ResourceCard } from "~/components/primitives";
+import { Button, Checkbox, ResourceCard } from "~/components/primitives";
 import { ResourceTypeEnum } from "~/graphql/graphql";
 import { PYROXENE_RESOURCE_UIDS } from "~/models/pyroxene-planner-source-config";
 import type { PickupResources } from "~/models/pyroxene-timeline";
 import ResourcesInput from "./planner-input/ResourcesInput";
+import type { PyroxeneCollectedSourceCandidate } from "./types";
 
 const resourceItems = [
   {
@@ -29,12 +30,18 @@ const resourceItems = [
 
 type PyroxeneInitialResourcesProps = {
   resources: PickupResources;
-  onUpdateResources: (resources: PickupResources) => void;
+  collectedSourceCandidates: PyroxeneCollectedSourceCandidate[];
+  onUpdateResources: (resources: PickupResources, collectedSourceKeys: string[]) => void;
 };
 
-export default function PyroxeneInitialResources({ resources, onUpdateResources }: PyroxeneInitialResourcesProps) {
+export default function PyroxeneInitialResources({
+  resources,
+  collectedSourceCandidates,
+  onUpdateResources,
+}: PyroxeneInitialResourcesProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [editedResources, setEditedResources] = useState<PickupResources>(resources);
+  const [selectedCollectedSourceKeys, setSelectedCollectedSourceKeys] = useState<string[]>([]);
 
   useEffect(() => {
     if (!isEditing) {
@@ -44,7 +51,17 @@ export default function PyroxeneInitialResources({ resources, onUpdateResources 
 
   const handleCancel = () => {
     setEditedResources(resources);
+    setSelectedCollectedSourceKeys([]);
     setIsEditing(false);
+  };
+
+  const handleToggleCollectedSource = (sourceKey: string, checked: boolean) => {
+    setSelectedCollectedSourceKeys((prev) => {
+      if (checked) {
+        return prev.includes(sourceKey) ? prev : [...prev, sourceKey];
+      }
+      return prev.filter((key) => key !== sourceKey);
+    });
   };
 
   return (
@@ -85,10 +102,34 @@ export default function PyroxeneInitialResources({ resources, onUpdateResources 
             description="현재 보유한 재화 수량을 입력해주세요."
             initialResources={editedResources}
             onSaveResources={(resources) => {
-              onUpdateResources(resources);
+              onUpdateResources(resources, selectedCollectedSourceKeys);
+              setSelectedCollectedSourceKeys([]);
               setIsEditing(false);
             }}
           />
+          {collectedSourceCandidates.length > 0 && (
+            <div className="mt-4 border-t border-neutral-200 pt-4 dark:border-neutral-700">
+              <p className="text-sm font-semibold">진행 중 보상 정합</p>
+              <p className="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
+                이미 받아 현재 보유 재화에 포함된 보상만 체크해주세요. 체크한 항목은 그래프에서 중복 제외됩니다.
+              </p>
+              <div className="mt-3 space-y-2">
+                {collectedSourceCandidates.map((candidate) => (
+                  <Checkbox
+                    key={candidate.sourceKey}
+                    checked={selectedCollectedSourceKeys.includes(candidate.sourceKey)}
+                    onChange={(checked) => handleToggleCollectedSource(candidate.sourceKey, checked)}
+                    label={
+                      <span className="flex flex-col">
+                        <span className="font-medium">{candidate.title}</span>
+                        <span className="text-xs text-neutral-500 dark:text-neutral-400">{candidate.description}</span>
+                      </span>
+                    }
+                  />
+                ))}
+              </div>
+            </div>
+          )}
         </div>
       </Transition>
     </div>

--- a/app/components/features/futures/PyroxeneResourceChip.tsx
+++ b/app/components/features/futures/PyroxeneResourceChip.tsx
@@ -1,0 +1,47 @@
+import { ResourceCard } from "~/components/primitives";
+import type { ResourceTypeEnum } from "~/graphql/graphql";
+import { cn } from "~/lib/utils";
+
+type PyroxeneResourceChipTone = "positive" | "negative" | "neutral" | "muted";
+
+type PyroxeneResourceChipProps = {
+  resourceType: ResourceTypeEnum;
+  itemUid: string;
+  value: number | string;
+  caption?: string;
+  tone?: PyroxeneResourceChipTone;
+  variant?: "solid" | "plain";
+  className?: string;
+};
+
+export default function PyroxeneResourceChip({
+  resourceType,
+  itemUid,
+  value,
+  caption,
+  tone = "neutral",
+  variant = "solid",
+  className,
+}: PyroxeneResourceChipProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex min-w-0 items-center gap-1 text-xs",
+        variant === "solid" &&
+          "rounded-md border border-neutral-200 bg-white/70 px-1.5 py-1 dark:border-neutral-700 dark:bg-neutral-950/40",
+        variant === "plain" && "py-0.5",
+        tone === "positive" && "text-green-600 dark:text-green-400",
+        tone === "negative" && "text-red-500 dark:text-red-400",
+        tone === "neutral" && "text-neutral-900 dark:text-neutral-100",
+        tone === "muted" && "text-neutral-500 dark:text-neutral-400",
+        className,
+      )}
+    >
+      <ResourceCard resourceType={resourceType} itemUid={itemUid} size="sm" />
+      <span className={cn("min-w-0 leading-tight", variant === "plain" && "inline-flex items-baseline gap-1")}>
+        <span className="block truncate font-semibold">{value}</span>
+        {caption && <span className="block truncate text-neutral-500 dark:text-neutral-400">{caption}</span>}
+      </span>
+    </span>
+  );
+}

--- a/app/components/features/futures/PyroxeneSchedule.tsx
+++ b/app/components/features/futures/PyroxeneSchedule.tsx
@@ -3,7 +3,7 @@ import { useMemo } from "react";
 import { EmptyView, SubTitle } from "~/components/primitives";
 import { collectedSourceKeyForEventReward, collectedSourceKeyForRaid } from "~/models/pyroxene-collected-source";
 import type { PyroxeneCalculationOptions, PyroxenePlannerOptions } from "~/models/pyroxene-planner";
-import type { PickupResources } from "~/models/pyroxene-timeline";
+import { PYROXENE, type PickupResources } from "~/models/pyroxene-timeline";
 import PyroxeneAvailableOneTimePackages from "./PyroxeneAvailableOneTimePackages";
 import PyroxeneChart from "./PyroxeneChart";
 import PyroxeneInitialResources from "./PyroxeneInitialResources";
@@ -143,6 +143,55 @@ export default function PyroxeneSchedule({
   }, [initialDate, scheduleItems]);
 
   const collectedSourceKeySet = useMemo(() => new Set(collectedSourceKeys), [collectedSourceKeys]);
+  const collectableSourceKeySet = useMemo(() => {
+    const currentDate = dayjs();
+    const sourceKeys = new Set<string>();
+
+    for (const item of scheduleItems) {
+      if (item.event?.earnablePyroxene && !dayjs(item.event.since).isAfter(currentDate)) {
+        sourceKeys.add(collectedSourceKeyForEventReward(item.event.uid));
+      }
+
+      if (
+        item.raid &&
+        (item.raid.type === "total_assault" || item.raid.type === "elimination") &&
+        !dayjs(item.raid.since).isAfter(currentDate)
+      ) {
+        sourceKeys.add(collectedSourceKeyForRaid(item.raid.uid));
+      }
+    }
+
+    return sourceKeys;
+  }, [scheduleItems]);
+  const collectedSourceDisplayResources = useMemo(() => {
+    const resourcesBySourceKey = new Map<string, PickupResources>();
+
+    for (const item of scheduleItems) {
+      if (item.event?.earnablePyroxene) {
+        resourcesBySourceKey.set(collectedSourceKeyForEventReward(item.event.uid), {
+          pyroxene: item.event.earnablePyroxene,
+          oneTimeTicket: 0,
+          tenTimeTicket: 0,
+        });
+      }
+
+      if (item.raid?.type === "total_assault") {
+        resourcesBySourceKey.set(collectedSourceKeyForRaid(item.raid.uid), {
+          pyroxene: PYROXENE.RAID_TOTAL_ASSAULT_BASE + PYROXENE.RAID_TOTAL_ASSAULT_TIER[options.raid.tier],
+          oneTimeTicket: 0,
+          tenTimeTicket: 0,
+        });
+      } else if (item.raid?.type === "elimination") {
+        resourcesBySourceKey.set(collectedSourceKeyForRaid(item.raid.uid), {
+          pyroxene: PYROXENE.RAID_ELIMINATION_BASE,
+          oneTimeTicket: 0,
+          tenTimeTicket: 1,
+        });
+      }
+    }
+
+    return resourcesBySourceKey;
+  }, [scheduleItems, options.raid.tier]);
   const collectedSourceCandidates = useMemo<PyroxeneCollectedSourceCandidate[]>(() => {
     const currentDate = dayjs();
     const isOngoing = (
@@ -266,6 +315,10 @@ export default function PyroxeneSchedule({
               ? source.collectedSourceKey
               : undefined;
           const collected = collectedSourceKey ? collectedSourceKeySet.has(collectedSourceKey) : false;
+          const displayResources =
+            collected && collectedSourceKey
+              ? (collectedSourceDisplayResources.get(collectedSourceKey) ?? resourceDelta)
+              : resourceDelta;
           return (
             <PyroxeneTimelineResources
               key={
@@ -275,10 +328,11 @@ export default function PyroxeneSchedule({
               }
               date={date}
               description={source.description}
-              resources={resourceDelta}
+              resources={displayResources}
               itemUid={itemUid}
               onDeleteItem={onDeleteItem}
               collectedSourceKey={collectedSourceKey}
+              collectable={collectedSourceKey ? collectableSourceKeySet.has(collectedSourceKey) : false}
               collected={collected}
               onCollectedSourceChange={onCollectedSourceChange}
             />

--- a/app/components/features/futures/PyroxeneSchedule.tsx
+++ b/app/components/features/futures/PyroxeneSchedule.tsx
@@ -1,6 +1,7 @@
 import dayjs from "dayjs";
 import { useMemo } from "react";
 import { EmptyView, SubTitle } from "~/components/primitives";
+import { collectedSourceKeyForEventReward, collectedSourceKeyForRaid } from "~/models/pyroxene-collected-source";
 import type { PyroxeneCalculationOptions, PyroxenePlannerOptions } from "~/models/pyroxene-planner";
 import type { PickupResources } from "~/models/pyroxene-timeline";
 import PyroxeneAvailableOneTimePackages from "./PyroxeneAvailableOneTimePackages";
@@ -155,7 +156,7 @@ export default function PyroxeneSchedule({
 
     return scheduleItems.flatMap((item) => {
       if (item.event?.earnablePyroxene && isOngoing(item.event.since, item.event.until)) {
-        const sourceKey = `event_reward:${item.event.uid}`;
+        const sourceKey = collectedSourceKeyForEventReward(item.event.uid);
         if (collectedSourceKeySet.has(sourceKey)) {
           return [];
         }
@@ -173,7 +174,7 @@ export default function PyroxeneSchedule({
         (item.raid.type === "total_assault" || item.raid.type === "elimination") &&
         isOngoing(item.raid.since, item.raid.until)
       ) {
-        const sourceKey = `raid:${item.raid.uid}`;
+        const sourceKey = collectedSourceKeyForRaid(item.raid.uid);
         if (collectedSourceKeySet.has(sourceKey)) {
           return [];
         }

--- a/app/components/features/futures/PyroxeneSchedule.tsx
+++ b/app/components/features/futures/PyroxeneSchedule.tsx
@@ -8,7 +8,7 @@ import PyroxeneChart from "./PyroxeneChart";
 import PyroxeneInitialResources from "./PyroxeneInitialResources";
 import PyroxeneTimelineEvent from "./PyroxeneTimelineEvent";
 import PyroxeneTimelineResources from "./PyroxeneTimelineResources";
-import type { PyroxeneScheduleItem } from "./types";
+import type { PyroxeneCollectedSourceCandidate, PyroxeneScheduleItem } from "./types";
 import { usePyroxeneTimeline } from "./usePyroxeneTimeline";
 
 type PyroxeneScheduleProps = {
@@ -17,11 +17,13 @@ type PyroxeneScheduleProps = {
   eventDataMap: Map<string, { completed: boolean; expectedTrials: number | null }>;
   scheduleItems: PyroxeneScheduleItem[];
   options: PyroxenePlannerOptions;
+  collectedSourceKeys: string[];
 
-  onPickupComplete: (eventUid: string | null, resources: PickupResources) => void;
+  onPickupComplete: (eventUid: string | null, resources: PickupResources, collectedSourceKeys?: string[]) => void;
   onDeletePickupComplete: (eventUid: string) => void;
   onDeleteItem: (itemUid: string) => void;
   onUpdateEventData: (eventUid: string, data: { expectedTrials?: number | null }) => void;
+  onCollectedSourceChange: (sourceKey: string, collected: boolean) => void;
 };
 
 const deletableTimelineSourceTypes = new Set([
@@ -61,10 +63,12 @@ export default function PyroxeneSchedule({
   eventDataMap,
   scheduleItems,
   options,
+  collectedSourceKeys,
   onPickupComplete,
   onDeletePickupComplete,
   onDeleteItem,
   onUpdateEventData,
+  onCollectedSourceChange,
 }: PyroxeneScheduleProps) {
   // 표시 필터(timeline.display)는 계산 결과에 영향을 주지 않으므로 계산 입력에서 제외합니다.
   // 이렇게 하면 표시 토글이 무거운 재계산을 유발하지 않습니다.
@@ -84,6 +88,7 @@ export default function PyroxeneSchedule({
     eventDataMap,
     scheduleItems,
     options: calcOptions,
+    collectedSourceKeys,
   });
   const simulationDescription =
     options.event.pickupChance === "ceil"
@@ -136,6 +141,55 @@ export default function PyroxeneSchedule({
       });
   }, [initialDate, scheduleItems]);
 
+  const collectedSourceKeySet = useMemo(() => new Set(collectedSourceKeys), [collectedSourceKeys]);
+  const collectedSourceCandidates = useMemo<PyroxeneCollectedSourceCandidate[]>(() => {
+    const currentDate = dayjs();
+    const isOngoing = (
+      since: NonNullable<PyroxeneScheduleItem["event"]>["since"],
+      until: NonNullable<PyroxeneScheduleItem["event"]>["until"],
+    ) => {
+      const sinceDate = dayjs(since);
+      const untilDate = dayjs(until);
+      return !sinceDate.isAfter(currentDate) && untilDate.isAfter(currentDate);
+    };
+
+    return scheduleItems.flatMap((item) => {
+      if (item.event?.earnablePyroxene && isOngoing(item.event.since, item.event.until)) {
+        const sourceKey = `event_reward:${item.event.uid}`;
+        if (collectedSourceKeySet.has(sourceKey)) {
+          return [];
+        }
+        return [
+          {
+            sourceKey,
+            title: `이벤트 클리어 보상 · ${item.event.name}`,
+            description: "이미 받아 현재 보유 재화에 포함됨 → 그래프에서 중복 제외",
+          },
+        ];
+      }
+
+      if (
+        item.raid &&
+        (item.raid.type === "total_assault" || item.raid.type === "elimination") &&
+        isOngoing(item.raid.since, item.raid.until)
+      ) {
+        const sourceKey = `raid:${item.raid.uid}`;
+        if (collectedSourceKeySet.has(sourceKey)) {
+          return [];
+        }
+        return [
+          {
+            sourceKey,
+            title: `${item.raid.type === "total_assault" ? "총력전" : "대결전"} 보상 · ${item.raid.name}`,
+            description: "이미 받아 현재 보유 재화에 포함됨 → 그래프에서 중복 제외",
+          },
+        ];
+      }
+
+      return [];
+    });
+  }, [scheduleItems, collectedSourceKeySet]);
+
   return (
     <>
       <SubTitle
@@ -153,7 +207,10 @@ export default function PyroxeneSchedule({
       )}
       <PyroxeneInitialResources
         resources={initialResources}
-        onUpdateResources={(resources) => onPickupComplete(null, resources)}
+        collectedSourceCandidates={collectedSourceCandidates}
+        onUpdateResources={(resources, selectedCollectedSourceKeys) =>
+          onPickupComplete(null, resources, selectedCollectedSourceKeys)
+        }
       />
       {availableOneTimePackages.length > 0 && (
         <PyroxeneAvailableOneTimePackages packages={availableOneTimePackages} onDeleteItem={onDeleteItem} />
@@ -203,6 +260,11 @@ export default function PyroxeneSchedule({
         }
         if (source.description) {
           const itemUid = source.uid && deletableTimelineSourceTypes.has(source.type) ? source.uid : undefined;
+          const collectedSourceKey =
+            source.collectedSourceKey && !source.uid?.endsWith("::ten-time-ticket-expiry")
+              ? source.collectedSourceKey
+              : undefined;
+          const collected = collectedSourceKey ? collectedSourceKeySet.has(collectedSourceKey) : false;
           return (
             <PyroxeneTimelineResources
               key={
@@ -215,6 +277,9 @@ export default function PyroxeneSchedule({
               resources={resourceDelta}
               itemUid={itemUid}
               onDeleteItem={onDeleteItem}
+              collectedSourceKey={collectedSourceKey}
+              collected={collected}
+              onCollectedSourceChange={onCollectedSourceChange}
             />
           );
         }

--- a/app/components/features/futures/PyroxeneTimelineEvent.tsx
+++ b/app/components/features/futures/PyroxeneTimelineEvent.tsx
@@ -57,8 +57,8 @@ export default function PyroxeneTimelineEvent({
       : pickupChance === "ceil"
         ? "모든 픽업 천장"
         : pickupChance === "average_pity"
-          ? "천장 포함 기댓값"
-          : "픽업 확률 기댓값";
+          ? "기댓값 (천장 반영)"
+          : "기댓값 (단순 확률)";
 
   const handleDeletePickupComplete = () => {
     if (confirmingPickupDelete) {

--- a/app/components/features/futures/PyroxeneTimelineResources.tsx
+++ b/app/components/features/futures/PyroxeneTimelineResources.tsx
@@ -1,10 +1,9 @@
 import type dayjs from "dayjs";
-import { useState } from "react";
-import { Button, ResourceCard } from "~/components/primitives";
+import { Button } from "~/components/primitives";
 import { ResourceTypeEnum } from "~/graphql/graphql";
-import { cn } from "~/lib/utils";
-import type { PickupResources } from "~/models/pyroxene-timeline";
 import { PYROXENE_RESOURCE_UIDS } from "~/models/pyroxene-planner-source-config";
+import type { PickupResources } from "~/models/pyroxene-timeline";
+import PyroxeneResourceChip from "./PyroxeneResourceChip";
 
 type PyroxeneTimelineResourcesProps = {
   date: dayjs.Dayjs;
@@ -13,6 +12,7 @@ type PyroxeneTimelineResourcesProps = {
   itemUid?: string;
   onDeleteItem?: (itemUid: string) => void;
   collectedSourceKey?: string;
+  collectable?: boolean;
   collected?: boolean;
   onCollectedSourceChange?: (sourceKey: string, collected: boolean) => void;
 };
@@ -24,92 +24,117 @@ export default function PyroxeneTimelineResources({
   itemUid,
   onDeleteItem,
   collectedSourceKey,
+  collectable = false,
   collected = false,
   onCollectedSourceChange,
 }: PyroxeneTimelineResourcesProps) {
-  const [confirmingDelete, setConfirmingDelete] = useState(false);
-
   const handleDeleteClick = () => {
     if (!itemUid || !onDeleteItem) {
       return;
     }
 
-    if (confirmingDelete) {
+    if (window.confirm("정말 삭제할까요?")) {
       onDeleteItem(itemUid);
-      return;
     }
-
-    setConfirmingDelete(true);
-    setTimeout(() => setConfirmingDelete(false), 3000);
   };
 
-  const formatResourceDelta = (value: number) => (value > 0 ? value.toLocaleString() : `-${Math.abs(value).toLocaleString()}`);
-  const labelColor = (value: number) => (value < 0 ? "red" : "white");
+  const formatResourceDelta = (value: number) =>
+    value > 0 ? value.toLocaleString() : `-${Math.abs(value).toLocaleString()}`;
+  const resourceTone = (value: number) => {
+    if (collected) {
+      return "muted";
+    }
+    return value < 0 ? "negative" : "neutral";
+  };
+  const showCollectedAction = collectable && collectedSourceKey && onCollectedSourceChange;
 
   return (
-    <div
-      className={cn(
-        "my-3 flex items-center gap-3 rounded-lg border border-neutral-200 px-3 py-2 transition-opacity dark:border-neutral-700",
-        collected && "opacity-60",
-      )}
-    >
+    <div className="my-2 grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 rounded-lg border border-neutral-200 px-3 py-2 transition-opacity dark:border-neutral-700">
       <div className="min-w-0 flex-1">
-        <p className="text-sm font-semibold">
-          {date.format("YYYY-MM-DD")}({date.format("ddd")})
-        </p>
-        <p className="line-clamp-1 text-xs text-neutral-500 dark:text-neutral-400">{description}</p>
-        {(collectedSourceKey || (itemUid && onDeleteItem)) && (
-          <div className="mt-2 flex flex-wrap items-center gap-1.5">
-            {collectedSourceKey && onCollectedSourceChange && (
-              <Button
-                text={collected ? "되돌리기" : "수급 완료"}
-                variant={collected ? "tint" : "tint-blue"}
-                size="xs"
-                onClick={() => onCollectedSourceChange(collectedSourceKey, !collected)}
-              />
-            )}
-            {itemUid && onDeleteItem && (
-              <button
-                type="button"
-                onClick={handleDeleteClick}
-                className={`cursor-pointer whitespace-nowrap rounded-sm border px-2 py-1 text-xs font-medium transition ${
-                  confirmingDelete
-                    ? "animate-pulse border-red-300 bg-red-100 text-red-700 dark:border-red-700 dark:bg-red-900/40 dark:text-red-300"
-                    : "border-red-200 bg-red-50 text-red-600 hover:bg-red-100 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400 dark:hover:bg-red-900/30"
-                }`}
-              >
-                {confirmingDelete ? "정말 삭제할까요?" : "삭제"}
-              </button>
-            )}
+        <div className="flex flex-col gap-0.5 sm:flex-row sm:items-baseline sm:gap-3">
+          <p className="shrink-0 text-xs font-semibold sm:text-sm">
+            {date.format("YYYY-MM-DD")}({date.format("ddd")})
+          </p>
+          <TimelineResourceDescription description={description} />
+        </div>
+      </div>
+      <div className="flex min-w-0 flex-col items-end gap-1.5 sm:flex-row sm:items-center sm:justify-end sm:gap-3">
+        <div className="flex min-w-0 flex-wrap items-center justify-end gap-1.5">
+          {resources.pyroxene !== 0 && (
+            <PyroxeneResourceChip
+              resourceType={ResourceTypeEnum.Currency}
+              itemUid={PYROXENE_RESOURCE_UIDS.pyroxene}
+              value={formatResourceDelta(resources.pyroxene)}
+              tone={resourceTone(resources.pyroxene)}
+              variant="plain"
+              className={collected ? "opacity-60" : undefined}
+            />
+          )}
+          {resources.oneTimeTicket !== 0 && (
+            <PyroxeneResourceChip
+              resourceType={ResourceTypeEnum.Item}
+              itemUid={PYROXENE_RESOURCE_UIDS.oneTimeTicket}
+              value={formatResourceDelta(resources.oneTimeTicket)}
+              tone={resourceTone(resources.oneTimeTicket)}
+              variant="plain"
+              className={collected ? "opacity-60" : undefined}
+            />
+          )}
+          {resources.tenTimeTicket !== 0 && (
+            <PyroxeneResourceChip
+              resourceType={ResourceTypeEnum.Item}
+              itemUid={PYROXENE_RESOURCE_UIDS.tenTimeTicket}
+              value={formatResourceDelta(resources.tenTimeTicket)}
+              tone={resourceTone(resources.tenTimeTicket)}
+              variant="plain"
+              className={collected ? "opacity-60" : undefined}
+            />
+          )}
+        </div>
+        {showCollectedAction && (
+          <div className="flex justify-end">
+            <Button
+              variant={collected ? "tint" : "tint-blue"}
+              size="xs"
+              onClick={() => onCollectedSourceChange(collectedSourceKey, !collected)}
+              className="group"
+            >
+              {collected ? (
+                <>
+                  <span className="group-hover:hidden">수급 완료</span>
+                  <span className="hidden group-hover:inline">되돌리기</span>
+                </>
+              ) : (
+                "수급 완료"
+              )}
+            </Button>
+          </div>
+        )}
+        {itemUid && onDeleteItem && (
+          <div className="flex justify-end">
+            <Button text="삭제" variant="tint-red" size="xs" onClick={handleDeleteClick} />
           </div>
         )}
       </div>
-      <div className="ml-auto flex shrink-0 items-center justify-end gap-1.5">
-        {resources.pyroxene !== 0 && (
-          <ResourceCard
-            resourceType={ResourceTypeEnum.Currency}
-            itemUid={PYROXENE_RESOURCE_UIDS.pyroxene}
-            label={formatResourceDelta(resources.pyroxene)}
-            labelColor={labelColor(resources.pyroxene)}
-          />
-        )}
-        {resources.oneTimeTicket !== 0 && (
-          <ResourceCard
-            resourceType={ResourceTypeEnum.Item}
-            itemUid={PYROXENE_RESOURCE_UIDS.oneTimeTicket}
-            label={formatResourceDelta(resources.oneTimeTicket)}
-            labelColor={labelColor(resources.oneTimeTicket)}
-          />
-        )}
-        {resources.tenTimeTicket !== 0 && (
-          <ResourceCard
-            resourceType={ResourceTypeEnum.Item}
-            itemUid={PYROXENE_RESOURCE_UIDS.tenTimeTicket}
-            label={formatResourceDelta(resources.tenTimeTicket)}
-            labelColor={labelColor(resources.tenTimeTicket)}
-          />
-        )}
-      </div>
+    </div>
+  );
+}
+
+function TimelineResourceDescription({ description }: { description: string }) {
+  let offset = 0;
+  const lines = description.split("\n").map((line) => {
+    const key = `${offset}:${line}`;
+    offset += line.length + 1;
+    return { key, line };
+  });
+
+  return (
+    <div className="min-w-0 text-xs leading-snug text-neutral-500 dark:text-neutral-400 sm:text-sm">
+      {lines.map(({ key, line }) => (
+        <span key={key} className="block truncate">
+          {line}
+        </span>
+      ))}
     </div>
   );
 }

--- a/app/components/features/futures/PyroxeneTimelineResources.tsx
+++ b/app/components/features/futures/PyroxeneTimelineResources.tsx
@@ -1,8 +1,9 @@
 import type dayjs from "dayjs";
 import { useState } from "react";
+import { Button, ResourceCard } from "~/components/primitives";
 import { ResourceTypeEnum } from "~/graphql/graphql";
+import { cn } from "~/lib/utils";
 import type { PickupResources } from "~/models/pyroxene-timeline";
-import { ResourceCard } from "~/components/primitives";
 import { PYROXENE_RESOURCE_UIDS } from "~/models/pyroxene-planner-source-config";
 
 type PyroxeneTimelineResourcesProps = {
@@ -11,6 +12,9 @@ type PyroxeneTimelineResourcesProps = {
   resources: PickupResources;
   itemUid?: string;
   onDeleteItem?: (itemUid: string) => void;
+  collectedSourceKey?: string;
+  collected?: boolean;
+  onCollectedSourceChange?: (sourceKey: string, collected: boolean) => void;
 };
 
 export default function PyroxeneTimelineResources({
@@ -19,6 +23,9 @@ export default function PyroxeneTimelineResources({
   resources,
   itemUid,
   onDeleteItem,
+  collectedSourceKey,
+  collected = false,
+  onCollectedSourceChange,
 }: PyroxeneTimelineResourcesProps) {
   const [confirmingDelete, setConfirmingDelete] = useState(false);
 
@@ -40,12 +47,22 @@ export default function PyroxeneTimelineResources({
   const labelColor = (value: number) => (value < 0 ? "red" : "white");
 
   return (
-    <div className="my-3 flex items-center justify-between rounded-lg border border-neutral-200 px-3 py-2 dark:border-neutral-700">
+    <div
+      className={cn(
+        "my-3 flex items-center justify-between rounded-lg border border-neutral-200 px-3 py-2 transition-opacity dark:border-neutral-700",
+        collected && "opacity-60",
+      )}
+    >
       <div className="min-w-0 flex-1">
         <p className="text-sm font-semibold">
           {date.format("YYYY-MM-DD")}({date.format("ddd")})
         </p>
         <p className="line-clamp-1 text-xs text-neutral-500 dark:text-neutral-400">{description}</p>
+        {collectedSourceKey && (
+          <p className="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
+            이미 받아 현재 보유 재화에 포함됨 → 그래프에서 중복 제외
+          </p>
+        )}
       </div>
       <div className="ml-3 flex shrink-0 items-center gap-1.5">
         {resources.pyroxene !== 0 && (
@@ -73,6 +90,15 @@ export default function PyroxeneTimelineResources({
           />
         )}
       </div>
+      {collectedSourceKey && onCollectedSourceChange && (
+        <Button
+          text={collected ? "되돌리기" : "수급 완료"}
+          variant={collected ? "tint" : "tint-blue"}
+          size="xs"
+          className="ml-2 shrink-0"
+          onClick={() => onCollectedSourceChange(collectedSourceKey, !collected)}
+        />
+      )}
       {itemUid && onDeleteItem && (
         <button
           type="button"

--- a/app/components/features/futures/PyroxeneTimelineResources.tsx
+++ b/app/components/features/futures/PyroxeneTimelineResources.tsx
@@ -49,7 +49,7 @@ export default function PyroxeneTimelineResources({
   return (
     <div
       className={cn(
-        "my-3 flex items-center justify-between rounded-lg border border-neutral-200 px-3 py-2 transition-opacity dark:border-neutral-700",
+        "my-3 flex items-center gap-3 rounded-lg border border-neutral-200 px-3 py-2 transition-opacity dark:border-neutral-700",
         collected && "opacity-60",
       )}
     >
@@ -58,13 +58,33 @@ export default function PyroxeneTimelineResources({
           {date.format("YYYY-MM-DD")}({date.format("ddd")})
         </p>
         <p className="line-clamp-1 text-xs text-neutral-500 dark:text-neutral-400">{description}</p>
-        {collectedSourceKey && (
-          <p className="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
-            이미 받아 현재 보유 재화에 포함됨 → 그래프에서 중복 제외
-          </p>
+        {(collectedSourceKey || (itemUid && onDeleteItem)) && (
+          <div className="mt-2 flex flex-wrap items-center gap-1.5">
+            {collectedSourceKey && onCollectedSourceChange && (
+              <Button
+                text={collected ? "되돌리기" : "수급 완료"}
+                variant={collected ? "tint" : "tint-blue"}
+                size="xs"
+                onClick={() => onCollectedSourceChange(collectedSourceKey, !collected)}
+              />
+            )}
+            {itemUid && onDeleteItem && (
+              <button
+                type="button"
+                onClick={handleDeleteClick}
+                className={`cursor-pointer whitespace-nowrap rounded-sm border px-2 py-1 text-xs font-medium transition ${
+                  confirmingDelete
+                    ? "animate-pulse border-red-300 bg-red-100 text-red-700 dark:border-red-700 dark:bg-red-900/40 dark:text-red-300"
+                    : "border-red-200 bg-red-50 text-red-600 hover:bg-red-100 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400 dark:hover:bg-red-900/30"
+                }`}
+              >
+                {confirmingDelete ? "정말 삭제할까요?" : "삭제"}
+              </button>
+            )}
+          </div>
         )}
       </div>
-      <div className="ml-3 flex shrink-0 items-center gap-1.5">
+      <div className="ml-auto flex shrink-0 items-center justify-end gap-1.5">
         {resources.pyroxene !== 0 && (
           <ResourceCard
             resourceType={ResourceTypeEnum.Currency}
@@ -90,28 +110,6 @@ export default function PyroxeneTimelineResources({
           />
         )}
       </div>
-      {collectedSourceKey && onCollectedSourceChange && (
-        <Button
-          text={collected ? "되돌리기" : "수급 완료"}
-          variant={collected ? "tint" : "tint-blue"}
-          size="xs"
-          className="ml-2 shrink-0"
-          onClick={() => onCollectedSourceChange(collectedSourceKey, !collected)}
-        />
-      )}
-      {itemUid && onDeleteItem && (
-        <button
-          type="button"
-          onClick={handleDeleteClick}
-          className={`ml-2 shrink-0 whitespace-nowrap rounded-sm border px-2 py-1 text-xs font-medium transition ${
-            confirmingDelete
-              ? "animate-pulse border-red-300 bg-red-100 text-red-700 dark:border-red-700 dark:bg-red-900/40 dark:text-red-300"
-              : "border-red-200 bg-red-50 text-red-600 hover:bg-red-100 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400 dark:hover:bg-red-900/30"
-          }`}
-        >
-          {confirmingDelete ? "정말 삭제할까요?" : "삭제"}
-        </button>
-      )}
     </div>
   );
 }

--- a/app/components/features/futures/pyroxene-timeline-worker.shared.ts
+++ b/app/components/features/futures/pyroxene-timeline-worker.shared.ts
@@ -23,6 +23,7 @@ export type PyroxeneTimelineWorkerRequest = {
   eventDataMap: Map<string, { completed: boolean; expectedTrials: number | null }>;
   scheduleItems: PyroxeneScheduleItem[];
   options: PyroxeneCalculationOptions;
+  collectedSourceKeys: string[];
 };
 
 export type PyroxeneTimelineWorkerResponse = {

--- a/app/components/features/futures/pyroxene-timeline.worker.ts
+++ b/app/components/features/futures/pyroxene-timeline.worker.ts
@@ -12,7 +12,15 @@ const workerScope = self as unknown as {
 };
 
 workerScope.onmessage = (event) => {
-  const { id, initialResources, initialDate, eventDataMap, scheduleItems, options } = event.data;
-  const timeline = buildTimeline(initialResources, initialDate ?? new Date(), eventDataMap, scheduleItems, options);
+  const { id, initialResources, initialDate, eventDataMap, scheduleItems, options, collectedSourceKeys } = event.data;
+  const timeline = buildTimeline(
+    initialResources,
+    initialDate ?? new Date(),
+    eventDataMap,
+    scheduleItems,
+    options,
+    undefined,
+    collectedSourceKeys,
+  );
   workerScope.postMessage({ id, timeline: serializeTimeline(timeline) });
 };

--- a/app/components/features/futures/types.ts
+++ b/app/components/features/futures/types.ts
@@ -56,3 +56,9 @@ export type PyroxeneScheduleItem = {
     autoRepurchase?: boolean;
   };
 };
+
+export type PyroxeneCollectedSourceCandidate = {
+  sourceKey: string;
+  title: string;
+  description: string;
+};

--- a/app/components/features/futures/usePyroxeneTimeline.ts
+++ b/app/components/features/futures/usePyroxeneTimeline.ts
@@ -14,6 +14,7 @@ type UsePyroxeneTimelineArgs = {
   eventDataMap: Map<string, { completed: boolean; expectedTrials: number | null }>;
   scheduleItems: PyroxeneScheduleItem[];
   options: PyroxeneCalculationOptions;
+  collectedSourceKeys: string[];
 };
 
 /**
@@ -28,10 +29,20 @@ export function usePyroxeneTimeline({
   eventDataMap,
   scheduleItems,
   options,
+  collectedSourceKeys,
 }: UsePyroxeneTimelineArgs): { timeline: Timeline; pending: boolean } {
   const computeSync = useCallback(
-    () => buildTimeline(initialResources, initialDate ?? new Date(), eventDataMap, scheduleItems, options),
-    [initialResources, initialDate, eventDataMap, scheduleItems, options],
+    () =>
+      buildTimeline(
+        initialResources,
+        initialDate ?? new Date(),
+        eventDataMap,
+        scheduleItems,
+        options,
+        undefined,
+        collectedSourceKeys,
+      ),
+    [initialResources, initialDate, eventDataMap, scheduleItems, options, collectedSourceKeys],
   );
 
   const [timeline, setTimeline] = useState<Timeline>([]);
@@ -92,9 +103,10 @@ export function usePyroxeneTimeline({
       eventDataMap,
       scheduleItems,
       options,
+      collectedSourceKeys,
     };
     worker.postMessage(request);
-  }, [initialResources, initialDate, eventDataMap, scheduleItems, options, computeSync]);
+  }, [initialResources, initialDate, eventDataMap, scheduleItems, options, collectedSourceKeys, computeSync]);
 
   return { timeline, pending };
 }

--- a/app/components/primitives/ResourceCard.tsx
+++ b/app/components/primitives/ResourceCard.tsx
@@ -11,7 +11,7 @@ type ResourceCardProps = {
   labelColor?: "white" | "yellow" | "red";
   labelBgColor?: "black" | "red";
   name?: string;
-  size?: "md" | "lg";
+  size?: "sm" | "md" | "lg";
 } & (
   | {
       itemUid: string;
@@ -50,7 +50,10 @@ function ResourceCard({
 
   let sizeClass = "size-10";
   let imageSizeClass = "size-8";
-  if (size === "lg") {
+  if (size === "sm") {
+    sizeClass = "size-6";
+    imageSizeClass = "size-5";
+  } else if (size === "lg") {
     sizeClass = "size-12 md:size-14";
     imageSizeClass = "size-10";
   }

--- a/app/models/pyroxene-collected-source.ts
+++ b/app/models/pyroxene-collected-source.ts
@@ -1,0 +1,7 @@
+export function collectedSourceKeyForEventReward(eventUid: string): string {
+  return `event_reward:${eventUid}`;
+}
+
+export function collectedSourceKeyForRaid(raidUid: string): string {
+  return `raid:${raidUid}`;
+}

--- a/app/models/pyroxene-planner.ts
+++ b/app/models/pyroxene-planner.ts
@@ -1,7 +1,7 @@
 import dayjs from "dayjs";
 import { and, eq, like, or, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
-import { int, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { int, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
 import { nanoid } from "nanoid/non-secure";
 import type { RecruitmentTypeEnum } from "~/graphql/graphql";
 import { type UtcIsoString, compareInstantAsc, compareInstantDesc, nowUtcIso, toUtcIso } from "~/lib/date-time";
@@ -230,6 +230,68 @@ export async function deletePyroxeneOwnedResourceByUid(env: Env, userId: number,
   await db
     .delete(pyroxeneOwnedResourcesTable)
     .where(and(eq(pyroxeneOwnedResourcesTable.userId, userId), eq(pyroxeneOwnedResourcesTable.uid, uid)));
+}
+
+/**
+ * Pyroxene Collected Sources
+ */
+export const pyroxeneCollectedSourcesTable = sqliteTable(
+  "pyroxene_collected_sources",
+  {
+    id: int().primaryKey({ autoIncrement: true }),
+    uid: text().notNull(),
+    userId: int().notNull(),
+    sourceKey: text().notNull(),
+    collectedAt: text().notNull(),
+    createdAt: text().notNull().default(sql`current_timestamp`),
+  },
+  (table) => [
+    uniqueIndex("pyroxene_collected_sources_uid").on(table.uid),
+    uniqueIndex("pyroxene_collected_sources_userId_sourceKey").on(table.userId, table.sourceKey),
+  ],
+);
+
+export async function getCollectedSourceKeys(env: Env, userId: number): Promise<Set<string>> {
+  const db = drizzle(env.DB);
+  const rows = await db
+    .select({ sourceKey: pyroxeneCollectedSourcesTable.sourceKey })
+    .from(pyroxeneCollectedSourcesTable)
+    .where(eq(pyroxeneCollectedSourcesTable.userId, userId));
+
+  return new Set(rows.map((row) => row.sourceKey));
+}
+
+export async function upsertCollectedSource(env: Env, userId: number, sourceKey: string): Promise<void> {
+  const db = drizzle(env.DB);
+  const collectedAt = nowUtcIso();
+  await db
+    .insert(pyroxeneCollectedSourcesTable)
+    .values({ uid: nanoid(8), userId, sourceKey, collectedAt })
+    .onConflictDoUpdate({
+      target: [pyroxeneCollectedSourcesTable.userId, pyroxeneCollectedSourcesTable.sourceKey],
+      set: { collectedAt },
+    });
+}
+
+export async function upsertCollectedSources(env: Env, userId: number, sourceKeys: string[]): Promise<void> {
+  const uniqueSourceKeys = [...new Set(sourceKeys)].filter((sourceKey) => sourceKey.length > 0);
+  if (uniqueSourceKeys.length === 0) {
+    return;
+  }
+
+  await Promise.all(uniqueSourceKeys.map((sourceKey) => upsertCollectedSource(env, userId, sourceKey)));
+}
+
+export async function deleteCollectedSource(env: Env, userId: number, sourceKey: string): Promise<void> {
+  const db = drizzle(env.DB);
+  await db
+    .delete(pyroxeneCollectedSourcesTable)
+    .where(
+      and(
+        eq(pyroxeneCollectedSourcesTable.userId, userId),
+        eq(pyroxeneCollectedSourcesTable.sourceKey, sourceKey),
+      ),
+    );
 }
 
 /**

--- a/app/models/pyroxene-timeline.test.ts
+++ b/app/models/pyroxene-timeline.test.ts
@@ -55,6 +55,7 @@ function eventItem({
   uid,
   since = "2026-07-02T00:00:00.000Z",
   until = "2026-07-03T00:00:00.000Z",
+  earnablePyroxene = null,
   recruitments = [pickupRecruitment()],
   recruitmentPool = { tier2Count: 150, tier3Count: 202 },
   tags = [],
@@ -62,6 +63,7 @@ function eventItem({
   uid: string;
   since?: string;
   until?: string;
+  earnablePyroxene?: number | null;
   recruitments?: NonNullable<PyroxeneScheduleItem["event"]>["recruitments"];
   recruitmentPool?: NonNullable<PyroxeneScheduleItem["event"]>["recruitmentPool"];
   tags?: string[];
@@ -72,7 +74,7 @@ function eventItem({
       name: uid,
       since,
       until,
-      earnablePyroxene: null,
+      earnablePyroxene,
       tags,
       recruitments,
       recruitmentPool,
@@ -80,26 +82,55 @@ function eventItem({
   };
 }
 
+function raidItem({
+  uid,
+  type,
+  name,
+  since = "2026-07-02T00:00:00.000Z",
+  until = "2026-07-03T00:00:00.000Z",
+}: {
+  uid: string;
+  type: NonNullable<PyroxeneScheduleItem["raid"]>["type"];
+  name: string;
+  since?: string;
+  until?: string;
+}): PyroxeneScheduleItem {
+  return {
+    raid: {
+      uid,
+      type,
+      name,
+      since,
+      until,
+    },
+  };
+}
+
 function buildTestTimeline({
   initialResources = { pyroxene: 100_000, oneTimeTicket: 0, tenTimeTicket: 0 },
+  initialDate = new Date("2026-07-01T00:00:00.000Z"),
   eventDataMap = new Map<string, { completed: boolean; expectedTrials: number | null }>(),
   scheduleItems = [eventItem({ uid: "event-a" })],
   options = defaultOptions,
   bandMode,
+  collectedSourceKeys = [],
 }: {
   initialResources?: PickupResources;
+  initialDate?: Date;
   eventDataMap?: Map<string, { completed: boolean; expectedTrials: number | null }>;
   scheduleItems?: PyroxeneScheduleItem[];
   options?: PyroxenePlannerOptions;
   bandMode?: PyroxeneTimelineBandMode;
+  collectedSourceKeys?: string[];
 } = {}) {
   return buildTimeline(
     initialResources,
-    new Date("2026-07-01T00:00:00.000Z"),
+    initialDate,
     eventDataMap,
     scheduleItems,
     options,
     bandMode,
+    collectedSourceKeys,
   );
 }
 
@@ -188,6 +219,127 @@ describe("normalizePyroxenePlannerOptions", () => {
         event: { pickupChance: "unexpected" as PyroxenePlannerOptions["event"]["pickupChance"] },
       }).event.pickupChance,
     ).toBe("average_pity");
+  });
+});
+
+describe("buildTimeline collected sources", () => {
+  it("keeps a zero-delta total assault row when the raid reward is already collected", () => {
+    const timeline = buildTestTimeline({
+      scheduleItems: [raidItem({ uid: "raid-total", type: "total_assault", name: "비나" })],
+      options: { ...defaultOptions, raid: { tier: "gold" } },
+      collectedSourceKeys: ["raid:raid-total"],
+    });
+
+    const raidEntry = timeline.find((entry) => entry.source.collectedSourceKey === "raid:raid-total");
+
+    expect(raidEntry).toEqual(
+      expect.objectContaining({
+        source: expect.objectContaining({
+          type: "raid",
+          uid: "raid-total",
+          description: "총력전 비나",
+          collectedSourceKey: "raid:raid-total",
+        }),
+        resourceDelta: { pyroxene: 0, oneTimeTicket: 0, tenTimeTicket: 0 },
+        accumulatedResources: { pyroxene: 100_000, oneTimeTicket: 0, tenTimeTicket: 0 },
+      }),
+    );
+  });
+
+  it("keeps a zero-delta elimination row and skips ticket grant and expiry when already collected", () => {
+    const timeline = buildTestTimeline({
+      scheduleItems: [raidItem({ uid: "raid-elimination", type: "elimination", name: "고즈" })],
+      collectedSourceKeys: ["raid:raid-elimination"],
+    });
+
+    const raidEntries = timeline.filter((entry) => entry.source.type === "raid");
+
+    expect(raidEntries).toHaveLength(1);
+    expect(raidEntries[0]).toEqual(
+      expect.objectContaining({
+        date: expect.objectContaining({}),
+        source: expect.objectContaining({
+          uid: "raid-elimination",
+          description: "대결전 고즈",
+          collectedSourceKey: "raid:raid-elimination",
+        }),
+        resourceDelta: { pyroxene: 0, oneTimeTicket: 0, tenTimeTicket: 0 },
+        accumulatedResources: { pyroxene: 100_000, oneTimeTicket: 0, tenTimeTicket: 0 },
+      }),
+    );
+    expect(raidEntries[0].date.format("YYYY-MM-DD")).toBe("2026-07-03");
+    expect(timeline.find((entry) => entry.source.uid === "raid-elimination::ten-time-ticket-expiry")).toBeUndefined();
+  });
+
+  it("keeps a zero-delta event reward row when the event reward is already collected", () => {
+    const timeline = buildTestTimeline({
+      initialResources: { pyroxene: 10_000, oneTimeTicket: 0, tenTimeTicket: 0 },
+      initialDate: new Date("2026-07-02T00:00:00.000Z"),
+      scheduleItems: [
+        eventItem({
+          uid: "reward-event",
+          earnablePyroxene: 1_200,
+          recruitments: [],
+          recruitmentPool: undefined,
+        }),
+      ],
+      collectedSourceKeys: ["event_reward:reward-event"],
+    });
+
+    const rewardEntry = timeline.find((entry) => entry.source.collectedSourceKey === "event_reward:reward-event");
+
+    expect(rewardEntry).toEqual(
+      expect.objectContaining({
+        source: expect.objectContaining({
+          type: "event_reward",
+          uid: "reward-event",
+          description: "reward-event",
+          collectedSourceKey: "event_reward:reward-event",
+        }),
+        resourceDelta: { pyroxene: 0, oneTimeTicket: 0, tenTimeTicket: 0 },
+        accumulatedResources: { pyroxene: 10_000, oneTimeTicket: 0, tenTimeTicket: 0 },
+      }),
+    );
+    expect(rewardEntry?.date.format("YYYY-MM-DD")).toBe("2026-07-03");
+  });
+
+  it("keeps existing raid and event reward behavior when sources are not collected", () => {
+    const timeline = buildTestTimeline({
+      initialResources: { pyroxene: 10_000, oneTimeTicket: 0, tenTimeTicket: 0 },
+      initialDate: new Date("2026-07-02T00:00:00.000Z"),
+      scheduleItems: [
+        raidItem({ uid: "raid-total", type: "total_assault", name: "비나" }),
+        raidItem({ uid: "raid-elimination", type: "elimination", name: "고즈" }),
+        eventItem({
+          uid: "reward-event",
+          earnablePyroxene: 1_200,
+          recruitments: [],
+          recruitmentPool: undefined,
+        }),
+      ],
+      options: { ...defaultOptions, raid: { tier: "gold" } },
+    });
+
+    expect(timeline.find((entry) => entry.source.uid === "raid-total")?.resourceDelta).toEqual({
+      pyroxene: 1_650,
+      oneTimeTicket: 0,
+      tenTimeTicket: 0,
+    });
+    expect(timeline.find((entry) => entry.source.uid === "raid-elimination")?.resourceDelta).toEqual({
+      pyroxene: 650,
+      oneTimeTicket: 0,
+      tenTimeTicket: 1,
+    });
+    expect(timeline.find((entry) => entry.source.uid === "raid-elimination::ten-time-ticket-expiry")).toEqual(
+      expect.objectContaining({
+        resourceDelta: { pyroxene: 0, oneTimeTicket: 0, tenTimeTicket: -1 },
+      }),
+    );
+    expect(timeline.find((entry) => entry.source.uid === "reward-event")?.resourceDelta).toEqual({
+      pyroxene: 1_200,
+      oneTimeTicket: 0,
+      tenTimeTicket: 0,
+    });
   });
 });
 

--- a/app/models/pyroxene-timeline.ts
+++ b/app/models/pyroxene-timeline.ts
@@ -15,6 +15,7 @@ export type TimelineSource = {
   event?: PyroxeneScheduleItem["event"];
   description?: string;
   uid?: string;
+  collectedSourceKey?: string;
 };
 
 export type TimelineDelta = {
@@ -832,7 +833,9 @@ export function buildTimeline(
   scheduleItems: PyroxeneScheduleItem[],
   options: PyroxeneCalculationOptions,
   bandMode: PyroxeneTimelineBandMode = "central_ticket_discount",
+  collectedSourceKeys: string[] = [],
 ): Timeline {
+  const collectedSources = new Set(collectedSourceKeys);
   const maxDate = scheduleItems.reduce((max, item) => {
     if (!item.event) {
       return max;
@@ -848,10 +851,13 @@ export function buildTimeline(
 
       // 이벤트 보상 청휘석은 픽업 완료 여부와 무관하게 이벤트 종료일에 수급됩니다.
       if (event.earnablePyroxene) {
+        const collectedSourceKey = `event_reward:${event.uid}`;
         timelineDeltas.push({
           date: dayjs(event.until),
-          source: { type: "event_reward", description: event.name },
-          resourceDelta: { pyroxene: event.earnablePyroxene, oneTimeTicket: 0, tenTimeTicket: 0 },
+          source: { type: "event_reward", uid: event.uid, description: event.name, collectedSourceKey },
+          resourceDelta: collectedSources.has(collectedSourceKey)
+            ? zeroResources()
+            : { pyroxene: event.earnablePyroxene, oneTimeTicket: 0, tenTimeTicket: 0 },
         });
       }
 
@@ -914,23 +920,40 @@ export function buildTimeline(
       });
     } else if (scheduleItem.raid) {
       const { raid } = scheduleItem;
+      const collectedSourceKey = `raid:${raid.uid}`;
+      const raidSource = {
+        type: "raid" as const,
+        uid: raid.uid,
+        collectedSourceKey,
+      };
+      const isCollected = collectedSources.has(collectedSourceKey);
       if (raid.type === "total_assault") {
         const tierReward = PYROXENE.RAID_TOTAL_ASSAULT_TIER[options.raid.tier];
         timelineDeltas.push({
           date: dayjs(raid.until),
-          source: { type: "raid", description: `총력전 ${raid.name}` },
-          resourceDelta: {
-            pyroxene: PYROXENE.RAID_TOTAL_ASSAULT_BASE + tierReward,
-            oneTimeTicket: 0,
-            tenTimeTicket: 0,
-          },
+          source: { ...raidSource, description: `총력전 ${raid.name}` },
+          resourceDelta: isCollected
+            ? zeroResources()
+            : {
+                pyroxene: PYROXENE.RAID_TOTAL_ASSAULT_BASE + tierReward,
+                oneTimeTicket: 0,
+                tenTimeTicket: 0,
+              },
         });
       } else if (raid.type === "elimination") {
+        if (isCollected) {
+          timelineDeltas.push({
+            date: dayjs(raid.until),
+            source: { ...raidSource, description: `대결전 ${raid.name}` },
+            resourceDelta: zeroResources(),
+          });
+          continue;
+        }
         const ticketLotId = `${raid.uid}::ten-time-ticket`;
         const ticketExpiresAt = getEliminationTicketExpiresAt(raid.until);
         timelineDeltas.push({
           date: dayjs(raid.until).add(1, "day"),
-          source: { type: "raid", description: `대결전 ${raid.name}` },
+          source: { ...raidSource, description: `대결전 ${raid.name}` },
           resourceDelta: { pyroxene: PYROXENE.RAID_ELIMINATION_BASE, oneTimeTicket: 0, tenTimeTicket: 1 },
           tenTimeTicketLotId: ticketLotId,
           tenTimeTicketExpiresAt: ticketExpiresAt,
@@ -940,6 +963,7 @@ export function buildTimeline(
           source: {
             type: "raid",
             uid: `${raid.uid}::ten-time-ticket-expiry`,
+            collectedSourceKey,
             description: "대결전 10회 모집 티켓 만료",
           },
           tenTimeTicketLotId: ticketLotId,

--- a/app/models/pyroxene-timeline.ts
+++ b/app/models/pyroxene-timeline.ts
@@ -1,5 +1,6 @@
 import dayjs from "dayjs";
 import type { PyroxeneScheduleItem } from "~/components/features/futures/types";
+import { collectedSourceKeyForEventReward, collectedSourceKeyForRaid } from "./pyroxene-collected-source";
 import type { PyroxeneCalculationOptions, TimelineSourceType } from "./pyroxene-planner";
 import { calculateDailyApChargePyroxene } from "./pyroxene-planner-source-config";
 import { DEFAULT_PICKUP_STUDENT_RATE_BY_TIER } from "./recruitment-simulator";
@@ -851,7 +852,7 @@ export function buildTimeline(
 
       // 이벤트 보상 청휘석은 픽업 완료 여부와 무관하게 이벤트 종료일에 수급됩니다.
       if (event.earnablePyroxene) {
-        const collectedSourceKey = `event_reward:${event.uid}`;
+        const collectedSourceKey = collectedSourceKeyForEventReward(event.uid);
         timelineDeltas.push({
           date: dayjs(event.until),
           source: { type: "event_reward", uid: event.uid, description: event.name, collectedSourceKey },
@@ -920,7 +921,7 @@ export function buildTimeline(
       });
     } else if (scheduleItem.raid) {
       const { raid } = scheduleItem;
-      const collectedSourceKey = `raid:${raid.uid}`;
+      const collectedSourceKey = collectedSourceKeyForRaid(raid.uid);
       const raidSource = {
         type: "raid" as const,
         uid: raid.uid,

--- a/app/routes/utils.pyroxene.tsx
+++ b/app/routes/utils.pyroxene.tsx
@@ -33,12 +33,15 @@ import {
   createPyroxeneMonthlyPackage,
   createPyroxeneOwnedResource,
   defaultPyroxenePlannerOptions,
+  deleteCollectedSource,
   deletePyroxeneTimelineItem,
   getAllPyroxeneEventData,
+  getCollectedSourceKeys,
   getLatestPyroxeneOwnedResource,
   getPyroxenePlannerContents,
   getPyroxenePlannerOptions,
   getPyroxeneTimelineItems,
+  upsertCollectedSources,
   upsertPyroxeneEventData,
   upsertPyroxenePlannerOptions,
 } from "~/models/pyroxene-planner";
@@ -79,6 +82,7 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
       calcOptions: defaultPyroxenePlannerOptions,
       eventData: [],
       recruitmentResultCompletions: [],
+      collectedSourceKeys: [],
     };
   }
 
@@ -87,7 +91,7 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
     content.kind === "event" && content.recruitmentGroupUid ? [content.recruitmentGroupUid] : [],
   );
 
-  const [favoritedStudents, latestResources, savedOptions, eventData, timelineItems, recruitmentResults] =
+  const [favoritedStudents, latestResources, savedOptions, eventData, timelineItems, recruitmentResults, collectedSources] =
     await Promise.all([
       getUserFavoritedStudents(env, currentUser.id),
       getLatestPyroxeneOwnedResource(env, currentUser.id),
@@ -95,6 +99,7 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
       getAllPyroxeneEventData(env, currentUser.id),
       getPyroxeneTimelineItems(env, currentUser.id),
       getRecruitmentResultsByRecruitmentGroupUids(env, currentUser.id, recruitmentGroupUids),
+      getCollectedSourceKeys(env, currentUser.id),
     ]);
 
   return {
@@ -123,6 +128,7 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
       );
       return content ? [{ eventUid: content.uid, recruitmentGroupUid: result.recruitmentGroupUid }] : [];
     }),
+    collectedSourceKeys: [...collectedSources],
   };
 };
 
@@ -171,6 +177,11 @@ export type ActionData = {
   };
 
   calcOptions?: PyroxenePlannerOptions;
+
+  collectedSource?: {
+    sourceKey?: string;
+    sourceKeys?: string[];
+  };
 };
 
 export const action = async ({ request, context }: ActionFunctionArgs) => {
@@ -180,7 +191,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
     return { success: false };
   }
 
-  const { createData, deleteData, eventData, calcOptions } = await request.json<ActionData>();
+  const { createData, deleteData, eventData, calcOptions, collectedSource } = await request.json<ActionData>();
   if (request.method === "POST") {
     if (createData) {
       if (createData.ownedResources !== undefined) {
@@ -265,7 +276,20 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
     if (calcOptions) {
       await upsertPyroxenePlannerOptions(env, currentUser.id, calcOptions);
     }
-  } else if (request.method === "DELETE" && deleteData) {
+    if (collectedSource) {
+      const sourceKeys = [
+        ...(collectedSource.sourceKey ? [collectedSource.sourceKey] : []),
+        ...(collectedSource.sourceKeys ?? []),
+      ];
+      await upsertCollectedSources(env, currentUser.id, sourceKeys);
+    }
+  } else if (request.method === "DELETE") {
+    if (collectedSource?.sourceKey) {
+      await deleteCollectedSource(env, currentUser.id, collectedSource.sourceKey);
+    }
+    if (!deleteData) {
+      return { success: true };
+    }
     let recruitmentGroupUid = deleteData.recruitmentGroupUid ?? null;
     if (!recruitmentGroupUid && deleteData.eventUid) {
       for (const content of await getPyroxenePlannerContents(env)) {
@@ -318,6 +342,9 @@ export default function PyroxenePlanner() {
   const [localRecruitmentResultCompletions, setLocalRecruitmentResultCompletions] = useState<
     { eventUid: string; recruitmentGroupUid: string }[]
   >(loaderData.recruitmentResultCompletions ?? []);
+  const [localCollectedSourceKeys, setLocalCollectedSourceKeys] = useState<string[]>(
+    loaderData.collectedSourceKeys ?? [],
+  );
 
   const fetcher = useFetcher<typeof action>();
   const timelineSaveInFlight = useRef(false);
@@ -341,6 +368,10 @@ export default function PyroxenePlanner() {
   }, [loaderData.recruitmentResultCompletions]);
 
   useEffect(() => {
+    setLocalCollectedSourceKeys(loaderData.collectedSourceKeys ?? []);
+  }, [loaderData.collectedSourceKeys]);
+
+  useEffect(() => {
     setOptions(loaderData.calcOptions);
   }, [loaderData.calcOptions]);
 
@@ -350,9 +381,16 @@ export default function PyroxenePlanner() {
     }
   }, [fetcher.state]);
 
-  const handleSaveOwnedResources = (eventUid: string | null, resources: PickupResources) => {
+  const handleSaveOwnedResources = (
+    eventUid: string | null,
+    resources: PickupResources,
+    collectedSourceKeys: string[] = [],
+  ) => {
     setInitialResources(resources);
     setInitialDate(new Date());
+    if (collectedSourceKeys.length > 0) {
+      setLocalCollectedSourceKeys((prev) => [...new Set([...prev, ...collectedSourceKeys])]);
+    }
     if (eventUid) {
       const content = contents.find((content) => content.kind === "event" && content.uid === eventUid);
       if (content?.kind === "event" && content.recruitmentGroupUid) {
@@ -366,8 +404,24 @@ export default function PyroxenePlanner() {
       }
     }
     fetcher.submit(
-      { createData: { ownedResources: { eventUid, ...resources } } },
+      {
+        createData: { ownedResources: { eventUid, ...resources } },
+        collectedSource: { sourceKeys: collectedSourceKeys },
+      },
       { method: "POST", encType: "application/json" },
+    );
+  };
+
+  const handleCollectedSourceChange = (sourceKey: string, collected: boolean) => {
+    setLocalCollectedSourceKeys((prev) => {
+      if (collected) {
+        return prev.includes(sourceKey) ? prev : [...prev, sourceKey];
+      }
+      return prev.filter((key) => key !== sourceKey);
+    });
+    fetcher.submit(
+      { collectedSource: { sourceKey } },
+      { method: collected ? "POST" : "DELETE", encType: "application/json" },
     );
   };
 
@@ -608,10 +662,14 @@ export default function PyroxenePlanner() {
             eventDataMap={eventDataMap}
             scheduleItems={scheduleItems}
             options={options}
-            onPickupComplete={(eventUid, resources) => handleSaveOwnedResources(eventUid, resources)}
+            collectedSourceKeys={localCollectedSourceKeys}
+            onPickupComplete={(eventUid, resources, collectedSourceKeys) =>
+              handleSaveOwnedResources(eventUid, resources, collectedSourceKeys)
+            }
             onDeletePickupComplete={(eventUid) => handleDeletePickupComplete(eventUid)}
             onDeleteItem={(itemUid) => handleDeleteItem(itemUid)}
             onUpdateEventData={handleUpdateEventData}
+            onCollectedSourceChange={handleCollectedSourceChange}
           />
         ) : (
           <ErrorPage Icon={LockClosedIcon} message="로그인 후 이용할 수 있어요" showButtons={false} />

--- a/db/migrations/20260621000100_create_pyroxene_collected_sources.sql
+++ b/db/migrations/20260621000100_create_pyroxene_collected_sources.sql
@@ -1,0 +1,11 @@
+create table pyroxene_collected_sources (
+  id integer primary key autoincrement,
+  uid text not null,
+  userId integer not null,
+  sourceKey text not null,
+  collectedAt text not null,
+  createdAt text not null default current_timestamp
+);
+
+create unique index if not exists pyroxene_collected_sources_uid on pyroxene_collected_sources (uid);
+create unique index if not exists pyroxene_collected_sources_userId_sourceKey on pyroxene_collected_sources (userId, sourceKey);

--- a/test/app/components/features/futures/pyroxene-timeline.test.ts
+++ b/test/app/components/features/futures/pyroxene-timeline.test.ts
@@ -783,7 +783,12 @@ describe("pyroxene-timeline", () => {
       expect.objectContaining({
         date: expect.objectContaining({}),
         resourceDelta: { pyroxene: 1200, oneTimeTicket: 0, tenTimeTicket: 0 },
-        source: { type: "event_reward", description: "보상 이벤트" },
+        source: expect.objectContaining({
+          type: "event_reward",
+          uid: "reward-event",
+          description: "보상 이벤트",
+          collectedSourceKey: "event_reward:reward-event",
+        }),
       }),
     );
     expect(rewardEntry?.date.format("YYYY-MM-DD")).toBe("2026-01-10");


### PR DESCRIPTION
## Summary

Prevents the Pyroxene Planner from counting raid, elimination raid, and event clear rewards again when those rewards have already been received and included in the user's current resource balance.

## Changes

- Added the `pyroxene_collected_sources` table and helpers to load, upsert, bulk upsert, and delete collected reward source keys.
- Updated `buildTimeline` to keep collected raid and event reward rows visible as zero-delta rows, so the UI can still show and undo the collected state without affecting the accumulated graph.
- Excluded both the elimination raid reward delta and the linked 10-recruitment ticket expiry delta when an elimination raid reward is marked as collected.
- Added per-row `Collected` / `Undo` controls and a bulk reconciliation checklist for ongoing rewards when saving current resources.
- Centralized collected source key generation so timeline calculation and UI candidate generation share the same key format.

## Validation

- [ ] Manually verified the related behavior.
- [x] Ran the necessary checks: `pnpm typecheck`, `pnpm exec biome check .`, and related tests.
- [ ] Human-reviewed AI-generated content sufficiently.

## Related Issues

None
