### PR TITLE
feat: allow provisional favorite recruitment students

### DIFF
--- a/app/components/features/contents/ContentTimelineItem.tsx
+++ b/app/components/features/contents/ContentTimelineItem.tsx
@@ -35,8 +35,8 @@ import {
 import { contentTypeLocale, recruitmentLabelLocale } from "~/locales/ko";
 import { SHOW_LINK_CONTENT_TYPES, SHOW_LINK_RAID_TYPES } from "~/models/content-rules";
 import type { EventType, RaidType, Role } from "~/models/content.d";
-import { canCompleteRecruitmentStudent } from "~/models/recruitment-result-completion";
 import type { RecruitmentCompletionMeta } from "~/models/recruitment-result";
+import { canCompleteRecruitmentStudent } from "~/models/recruitment-result-completion";
 import ContentCommentEditor from "./ContentCommentEditor";
 import ContentCommentView from "./ContentCommentView";
 import { TimelineItemBanner } from "./TimelineItemBanner";
@@ -109,6 +109,7 @@ export type ContentTimelineItemProps = {
       initialTier?: number;
     } | null;
     studentName: string;
+    favoriteKey: string;
     since: UtcIsoString;
     until: UtcIsoString | null;
   }[];
@@ -439,6 +440,7 @@ type RecruitmentsProps = {
       role?: Role;
       initialTier?: number;
     } | null;
+    favoriteKey: string;
     since: UtcIsoString;
     until: UtcIsoString | null;
   }[];
@@ -602,7 +604,8 @@ export function getRecruitmentStudentCards({
   return recruitments.map((recruitment) => {
     const student = recruitment.student;
     const studentUid = student?.uid;
-    const isFavorited = studentUid ? favoritedStudents.includes(studentUid) : false;
+    const favoriteKey = recruitment.favoriteKey;
+    const isFavorited = favoritedStudents.includes(favoriteKey);
     const recruitmentCompleted = studentUid ? completedStudentUids.includes(studentUid) : false;
     const showRecruitmentCompleteAction = Boolean(
       recruitmentCompleted ||
@@ -629,18 +632,17 @@ export function getRecruitmentStudentCards({
     return {
       ...student,
       uid: studentUid ?? null,
+      popupId: favoriteKey,
       name: recruitment.studentName,
       label: <span className={labelColorClass}>{recruitmentLabelLocale(recruitment)}</span>,
-      state: studentUid
-        ? {
-            favorited: isFavorited,
-            favoritedCount: favoritedCounts[studentUid],
-            completed: recruitmentCompleted,
-          }
-        : undefined,
-      popups: studentUid
+      state: {
+        favorited: isFavorited,
+        favoritedCount: favoritedCounts[favoriteKey],
+        completed: recruitmentCompleted,
+      },
+      popups: favoriteKey
         ? [
-            ...(onRecruitmentComplete && showRecruitmentCompleteAction
+            ...(onRecruitmentComplete && studentUid && showRecruitmentCompleteAction
               ? [
                   recruitmentCompleted
                     ? {
@@ -659,18 +661,22 @@ export function getRecruitmentStudentCards({
               ? {
                   Icon: FilledHeartIcon,
                   text: "관심 학생에서 해제",
-                  onClick: () => onFavorite?.(studentUid, false),
+                  onClick: () => onFavorite?.(favoriteKey, false),
                 }
               : {
                   Icon: EmptyHeartIcon,
                   text: "관심 학생에 등록",
-                  onClick: () => onFavorite?.(studentUid, true),
+                  onClick: () => onFavorite?.(favoriteKey, true),
                 },
-            {
-              Icon: IdentificationIcon,
-              text: detailedLinkText,
-              link: `/students/${studentUid}`,
-            },
+            ...(studentUid
+              ? [
+                  {
+                    Icon: IdentificationIcon,
+                    text: detailedLinkText,
+                    link: `/students/${studentUid}`,
+                  },
+                ]
+              : []),
           ]
         : undefined,
     };

--- a/app/components/features/events/Recruitments.tsx
+++ b/app/components/features/events/Recruitments.tsx
@@ -7,7 +7,7 @@ import { AttributeBadge, HorizontalScroll, SubTitle } from "~/components/primiti
 import { useSignIn } from "~/contexts/SignInProvider";
 import { useDisplayTimeZone } from "~/contexts/TimeZoneProvider";
 import type { Attack, Defense, RecruitmentTypeEnum } from "~/graphql/graphql";
-import { formatInstant, formatInstantDateKey, type UtcIsoString } from "~/lib/date-time";
+import { type UtcIsoString, formatInstant, formatInstantDateKey } from "~/lib/date-time";
 import {
   attackTypeColor,
   attackTypeLocale,
@@ -29,6 +29,7 @@ export type Recruitment = {
   since: UtcIsoString;
   until: UtcIsoString | null;
   studentName: string;
+  favoriteKey: string;
   student: {
     uid: string;
     attackType: Attack;
@@ -60,6 +61,7 @@ function getFavoriteButtonClassName(favorited: boolean) {
 
 function useRecruitmentFavorite(recruitment: Recruitment, favoriteAction?: string, favoriteContentUid?: string) {
   const studentUid = recruitment.student?.uid ?? null;
+  const favoriteKey = recruitment.favoriteKey;
   const fetcher = useFetcher();
   const [favorited, setFavorited] = useState(recruitment.favorited);
   const [favoritedCount, setFavoritedCount] = useState(recruitment.favoritedCount);
@@ -73,20 +75,17 @@ function useRecruitmentFavorite(recruitment: Recruitment, favoriteAction?: strin
   }, [recruitment.favoritedCount]);
 
   const toggleFavorite = () => {
-    if (!studentUid) {
-      return;
-    }
-
     const next = !favorited;
     setFavorited(next);
     setFavoritedCount((count) => count + (next ? 1 : -1));
 
-    const data: ActionData = { favorite: { studentUid, contentUid: favoriteContentUid, favorited: next } };
+    const data: ActionData = { favorite: { studentUid: favoriteKey, contentUid: favoriteContentUid, favorited: next } };
     fetcher.submit(data, { action: favoriteAction, method: "post", encType: "application/json" });
   };
 
   return {
     studentUid,
+    favoriteKey,
     favorited,
     favoritedCount,
     toggleFavorite,
@@ -196,7 +195,9 @@ export default function Recruitments({ recruitments, signedIn }: RecruitmentsPro
               {showDateLabels && (
                 <p className="mb-3 font-semibold text-sm text-neutral-600 dark:text-neutral-400">
                   {formatInstant(group.since, { timeZone: displayTimeZone, format: "M월 D일" })}
-                  {group.until ? ` ~ ${formatInstant(group.until, { timeZone: displayTimeZone, format: "M월 D일" })}` : ""}
+                  {group.until
+                    ? ` ~ ${formatInstant(group.until, { timeZone: displayTimeZone, format: "M월 D일" })}`
+                    : ""}
                 </p>
               )}
 
@@ -230,7 +231,7 @@ function RecruitmentCardList({
 }) {
   const recruitmentCards = recruitments.map((recruitment) => (
     <RecruitmentCard
-      key={recruitment.student?.uid ?? recruitment.studentName}
+      key={recruitment.favoriteKey}
       recruitment={recruitment}
       signedIn={signedIn}
       className="w-full md:w-28"
@@ -269,7 +270,7 @@ export function RecruitmentCard({
 }) {
   const { attackType, defenseType, role } = recruitment.student ?? {};
   const { showSignIn } = useSignIn();
-  const { studentUid, favorited, favoritedCount, toggleFavorite } = useRecruitmentFavorite(
+  const { studentUid, favoriteKey, favorited, favoritedCount, toggleFavorite } = useRecruitmentFavorite(
     recruitment,
     favoriteAction,
     favoriteContentUid,
@@ -326,7 +327,7 @@ export function RecruitmentCard({
           </Link>
         )}
 
-        {studentUid && (
+        {favoriteKey && (
           <RecruitmentFavoriteButton
             favorited={favorited}
             favoritedCount={favoritedCount}

--- a/app/components/features/students/StudentCard.tsx
+++ b/app/components/features/students/StudentCard.tsx
@@ -143,7 +143,7 @@ export default function StudentCard({
   const [canUsePopupPortal, setCanUsePopupPortal] = useState(false);
   const [usesMobilePopupLayout, setUsesMobilePopupLayout] = useState(false);
   const [popupPosition, setPopupPosition] = useState<PopupPosition | null>(null);
-  const interactive = Boolean((onSelect && uid) || (popups && popupId));
+  const interactive = Boolean(onSelect ? uid : popups && popupId);
   const handleCardClick = getStudentCardAction({
     uid,
     onSelect,

--- a/app/components/features/students/StudentCard.tsx
+++ b/app/components/features/students/StudentCard.tsx
@@ -76,13 +76,15 @@ function getStudentCardAction({
   activePopupId: string | null;
   setActivePopupId: (id: string | null) => void;
 }) {
-  if (!uid) {
+  if (!uid && (!popupId || onSelect)) {
     return undefined;
   }
 
   return () => {
     if (onSelect) {
-      onSelect(uid);
+      if (uid) {
+        onSelect(uid);
+      }
       return;
     }
 
@@ -141,7 +143,7 @@ export default function StudentCard({
   const [canUsePopupPortal, setCanUsePopupPortal] = useState(false);
   const [usesMobilePopupLayout, setUsesMobilePopupLayout] = useState(false);
   const [popupPosition, setPopupPosition] = useState<PopupPosition | null>(null);
-  const interactive = Boolean((onSelect || popups) && uid);
+  const interactive = Boolean((onSelect && uid) || (popups && popupId));
   const handleCardClick = getStudentCardAction({
     uid,
     onSelect,
@@ -221,7 +223,7 @@ export default function StudentCard({
         top: popupPosition?.top,
         maxHeight: "calc(100vh - 2rem)",
       };
-  const popup = uid && name && popups && popups.length > 0 && (
+  const popup = (uid || popupId) && name && popups && popups.length > 0 && (
     <Transition
       show={showPositionedPopup}
       as="div"
@@ -353,7 +355,7 @@ export default function StudentCard({
 
 type StudentCardPopupProps = {
   student: {
-    uid: string;
+    uid: string | null;
     name: string;
     attackType?: Attack;
     defenseType?: Defense;

--- a/app/models/content.ts
+++ b/app/models/content.ts
@@ -16,6 +16,7 @@ import { getFavoritedCounts } from "./favorite-students";
 import { hasUnreadAdminFeedbackReplies } from "./feedback";
 import { normalizeFutureContentDates } from "./future-content";
 import { getLatestPostTime } from "./post";
+import { getRecruitmentFavoriteKey } from "./recruitment-identity";
 import { getFutureRaidContents, getTimelineContents, getTimelineContentsByContentTypes } from "./timeline-content";
 import type { TimelineContent, TimelineContentType } from "./timeline-content";
 export { CONTENT_ORDER, SHOW_LINK_CONTENT_TYPES, SHOW_LINK_RAID_TYPES } from "./content-rules";
@@ -43,6 +44,7 @@ export type { NestedComment } from "./content-comment";
 
 export type IndexRecruitment = {
   student: { uid: string; name: string; attackType: Attack; defenseType: Defense; role: Role } | null;
+  favoriteKey: string;
   recruitmentType: RecruitmentTypeEnum;
   pickup: boolean;
   rerun: boolean;
@@ -121,7 +123,6 @@ export async function getIndexContents(env: Env, forceRefresh = false) {
       group.recruitments
         .filter(
           (recruitment) =>
-            recruitment.student !== null &&
             recruitment.recruitmentType !== "recollect" &&
             recruitment.recruitmentType !== "archive" &&
             recruitment.recruitmentType !== "encore",
@@ -138,6 +139,7 @@ export async function getIndexContents(env: Env, forceRefresh = false) {
                   role: recruitment.student.role,
                 }
               : null,
+            favoriteKey: getRecruitmentFavoriteKey(recruitment),
             recruitmentType: recruitment.recruitmentType,
             pickup: recruitment.pickup,
             rerun: recruitment.rerun,
@@ -152,9 +154,7 @@ export async function getIndexContents(env: Env, forceRefresh = false) {
         !isInstantAfter(recruitment.since, now) && recruitment.until !== null && isInstantAfter(recruitment.until, now),
     );
 
-  const allStudentUids = currentRecruitments
-    .map(({ recruitment }) => recruitment.student?.uid)
-    .filter((uid) => uid !== null) as string[];
+  const allStudentUids = currentRecruitments.map(({ recruitment }) => recruitment.favoriteKey);
   const favoritedCounts = (await getFavoritedCounts(env, allStudentUids)).filter((favorited) =>
     currentRecruitments.some((recruitment) => recruitment.eventUid === favorited.contentId),
   );
@@ -178,6 +178,7 @@ export type RecruitmentInfo = {
   since: UtcIsoString;
   until: UtcIsoString | null;
   studentName: string;
+  favoriteKey: string;
   student: {
     uid: string;
     attackType?: Attack;
@@ -294,6 +295,7 @@ function toRecruitmentInfos(group: Awaited<ReturnType<RecruitmentRepository["get
       since: toUtcIso(r.since),
       until: r.until ? toUtcIso(r.until) : null,
       studentName: r.studentName,
+      favoriteKey: getRecruitmentFavoriteKey(r),
       student: r.student
         ? {
             uid: r.student.uid,

--- a/app/models/recruitment-identity.ts
+++ b/app/models/recruitment-identity.ts
@@ -1,0 +1,29 @@
+const PROVISIONAL_STUDENT_KEY_PREFIX = "provisional:";
+
+export function normalizeRecruitmentStudentName(name: string): string {
+  return name.normalize("NFKC").trim().toLocaleLowerCase("ko-KR").replace(/\s+/g, " ");
+}
+
+function hashName(name: string): string {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < name.length; index += 1) {
+    hash ^= name.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+
+  return (hash >>> 0).toString(36);
+}
+
+export function getProvisionalRecruitmentStudentKey(studentName: string): string {
+  return `${PROVISIONAL_STUDENT_KEY_PREFIX}${hashName(normalizeRecruitmentStudentName(studentName))}`;
+}
+
+export function getRecruitmentFavoriteKey({
+  student,
+  studentName,
+}: {
+  student: { uid: string } | null;
+  studentName: string;
+}): string {
+  return student?.uid ?? getProvisionalRecruitmentStudentKey(studentName);
+}

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -6,14 +6,14 @@ import { getActiveSensei } from "~/auth/authenticator.server";
 import { EventHeader, RecruitmentCard } from "~/components/features/events";
 import { RaidCard } from "~/components/features/raids";
 import { HorizontalScroll, SubTitle, Title } from "~/components/primitives";
-import { type IndexRecruitment, getIndexContents } from "~/models/content";
-import { raidTypeToParam } from "~/models/raid";
-import { getUserFavoritedStudents } from "~/models/favorite-students";
+import { getLogger } from "~/lib/observability.server";
 import { getCommunityFeedPage } from "~/models/community";
 import { enrichCommunityFeedPosts } from "~/models/community-feed";
+import { type IndexRecruitment, getIndexContents } from "~/models/content";
+import { getUserFavoritedStudents } from "~/models/favorite-students";
+import { raidTypeToParam } from "~/models/raid";
 import type { TimelineContent } from "~/models/timeline-content";
 import { getHomeYoutubeSections } from "~/models/youtube";
-import { getLogger } from "~/lib/observability.server";
 import HomeRightRail from "./_index._components/HomeRightRail";
 
 export const meta: MetaFunction = () => {
@@ -31,23 +31,20 @@ export const loader = async ({ context, request }: LoaderFunctionArgs) => {
   const logger = getLogger(env, ctx, { route: "_index.loader" });
   const currentUser = await getActiveSensei(env, request);
 
-  const [
-    { mainEvent, currentRaids, currentRecruitments, favoritedCounts },
-    recentCommunityPage,
-    youtubeSections,
-  ] = await Promise.all([
-    getIndexContents(env),
-    getCommunityFeedPage(env, {
-      currentUserId: currentUser?.id,
-      postTypes: ["student_review", "event_opinion"],
-      pageSize: 4,
-      includeEngagement: false,
-    }),
-    getHomeYoutubeSections(env).catch((error) => {
-      logger.error("Failed to load home youtube sections", error);
-      return [];
-    }),
-  ]);
+  const [{ mainEvent, currentRaids, currentRecruitments, favoritedCounts }, recentCommunityPage, youtubeSections] =
+    await Promise.all([
+      getIndexContents(env),
+      getCommunityFeedPage(env, {
+        currentUserId: currentUser?.id,
+        postTypes: ["student_review", "event_opinion"],
+        pageSize: 4,
+        includeEngagement: false,
+      }),
+      getHomeYoutubeSections(env).catch((error) => {
+        logger.error("Failed to load home youtube sections", error);
+        return [];
+      }),
+    ]);
   const recentCommunityFeed = await enrichCommunityFeedPosts(env, recentCommunityPage.items);
   const favoritedStudentUids = currentUser
     ? (await getUserFavoritedStudents(env, currentUser.id))
@@ -56,7 +53,9 @@ export const loader = async ({ context, request }: LoaderFunctionArgs) => {
     : [];
 
   // ========== Raids ==========
-  const currentTotalAssualt = currentRaids.find((raid) => raid.raidType === "total_assault" || raid.raidType === "elimination");
+  const currentTotalAssualt = currentRaids.find(
+    (raid) => raid.raidType === "total_assault" || raid.raidType === "elimination",
+  );
   const currentUnlimit = currentRaids.find((raid) => raid.raidType === "unlimit");
   return {
     mainEvent,
@@ -111,12 +110,18 @@ export default function Index() {
 
         <div className="my-6 grid grid-cols-1 gap-2 md:grid-cols-2">
           {currentTotalAssualt && (
-            <Link to={`/raids/${raidTypeToParam(currentTotalAssualt.raidType)}/${currentTotalAssualt.seasonIndex}`} className="hover:opacity-75 transition-opacity">
+            <Link
+              to={`/raids/${raidTypeToParam(currentTotalAssualt.raidType)}/${currentTotalAssualt.seasonIndex}`}
+              className="hover:opacity-75 transition-opacity"
+            >
               <RaidCard raid={currentTotalAssualt} timeLocaleType="relative" />
             </Link>
           )}
           {currentUnlimit && (
-            <Link to={`/raids/${raidTypeToParam(currentUnlimit.raidType)}/${currentUnlimit.seasonIndex}`} className="hover:opacity-75 transition-opacity">
+            <Link
+              to={`/raids/${raidTypeToParam(currentUnlimit.raidType)}/${currentUnlimit.seasonIndex}`}
+              className="hover:opacity-75 transition-opacity"
+            >
               <RaidCard raid={currentUnlimit} timeLocaleType="relative" />
             </Link>
           )}
@@ -174,19 +179,15 @@ function CurrentRecruitments({
   signedIn,
 }: CurrentRecruitmentsProps) {
   const recruitmentCards = recruitments.map(({ eventUid, recruitment }) => {
-    const student = recruitment.student;
-    if (!student) {
-      return null;
-    }
-
-    const favorited = favoritedStudentUids.includes(student.uid);
-    const favoritedCount = favoritedCounts.find(
-      (favorited) => favorited.studentId === student.uid && favorited.contentId === eventUid,
-    )?.count ?? 0;
+    const favorited = favoritedStudentUids.includes(recruitment.favoriteKey);
+    const favoritedCount =
+      favoritedCounts.find(
+        (favorited) => favorited.studentId === recruitment.favoriteKey && favorited.contentId === eventUid,
+      )?.count ?? 0;
 
     return (
       <RecruitmentCard
-        key={`${eventUid}-${student.uid}`}
+        key={`${eventUid}-${recruitment.favoriteKey}`}
         recruitment={{
           ...recruitment,
           favorited,
@@ -213,9 +214,7 @@ function CurrentRecruitments({
           {recruitmentCards}
         </HorizontalScroll>
       </div>
-      <div className="hidden md:flex md:flex-wrap md:gap-3">
-        {recruitmentCards}
-      </div>
+      <div className="hidden md:flex md:flex-wrap md:gap-3">{recruitmentCards}</div>
     </div>
   );
 }

--- a/app/routes/events.$uid._index.tsx
+++ b/app/routes/events.$uid._index.tsx
@@ -1,11 +1,17 @@
 import { useLoaderData } from "react-router";
 import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from "react-router";
 import { redirect } from "react-router";
+import { getActiveSensei } from "~/auth/authenticator.server";
 import { EventHeader, Recruitments } from "~/components/features/events";
 import { toUtcIso } from "~/lib/date-time";
 import { getNestedContentComments } from "~/models/content";
-import { getActiveSensei } from "~/auth/authenticator.server";
-import { favoriteStudent, getFavoritedCounts, getUserFavoritedStudents, unfavoriteStudent } from "~/models/favorite-students";
+import {
+  favoriteStudent,
+  getFavoritedCounts,
+  getUserFavoritedStudents,
+  unfavoriteStudent,
+} from "~/models/favorite-students";
+import { getRecruitmentFavoriteKey } from "~/models/recruitment-identity";
 import { getTimelineContent } from "~/models/timeline-content";
 import { RecruitmentRepository } from "~/repositories";
 import EventComment from "./events.$uid._components/EventComment";
@@ -39,9 +45,7 @@ export const loader = async ({ params, context, request }: LoaderFunctionArgs) =
 
   const currentUser = await getActiveSensei(env, request);
 
-  const studentUids = eventContent.recruitments
-    .map((r) => r.student?.uid)
-    .filter((uid): uid is string => uid !== undefined);
+  const studentUids = eventContent.recruitments.map(getRecruitmentFavoriteKey);
 
   const [favoritedStudents, favoritedCounts, allComments] = await Promise.all([
     currentUser ? getUserFavoritedStudents(env, currentUser.id, timelineUid) : [],
@@ -53,11 +57,11 @@ export const loader = async ({ params, context, request }: LoaderFunctionArgs) =
     ...recruitment,
     since: toUtcIso(recruitment.since),
     until: recruitment.until ? toUtcIso(recruitment.until) : null,
-    favorited: favoritedStudents.some((f) => f.studentId === recruitment.student?.uid),
+    favoriteKey: getRecruitmentFavoriteKey(recruitment),
+    favorited: favoritedStudents.some((f) => f.studentId === getRecruitmentFavoriteKey(recruitment)),
     favoritedCount:
-      favoritedCounts.find(
-        (f) => f.studentId === recruitment.student?.uid && f.contentId === timelineUid,
-      )?.count ?? 0,
+      favoritedCounts.find((f) => f.studentId === getRecruitmentFavoriteKey(recruitment) && f.contentId === timelineUid)
+        ?.count ?? 0,
   }));
 
   return {
@@ -87,7 +91,7 @@ export const action = async ({ params, context, request }: ActionFunctionArgs) =
   if (!eventUid) {
     throw new Response("Not Found", { status: 404 });
   }
-  const actionData = await request.json() as ActionData;
+  const actionData = (await request.json()) as ActionData;
   if (actionData.favorite) {
     const { studentUid, favorited } = actionData.favorite;
     const run = favorited ? favoriteStudent : unfavoriteStudent;

--- a/app/routes/futures._components/FutureRecruitmentTable.tsx
+++ b/app/routes/futures._components/FutureRecruitmentTable.tsx
@@ -15,8 +15,8 @@ import { useDisplayTimeZone } from "~/contexts/TimeZoneProvider";
 import { formatInstant, isInstantAfter, isInstantBefore, nowUtcIso } from "~/lib/date-time";
 import { contentTypeLocale, recruitmentLabelLocale } from "~/locales/ko";
 import { bossImageUrl } from "~/models/assets";
-import { canCompleteRecruitmentStudent } from "~/models/recruitment-result-completion";
 import type { RecruitmentCompletionMeta } from "~/models/recruitment-result";
+import { canCompleteRecruitmentStudent } from "~/models/recruitment-result-completion";
 import {
   type FutureRecruitmentTableContent,
   type FutureRecruitmentTableRecruitmentGroup,
@@ -453,12 +453,13 @@ function getRecruitmentStudentGroup(
 ) {
   const recruitment = group.recruitment;
   const studentUid = recruitment.student?.uid ?? null;
-  const favorited = studentUid
-    ? favoritedStudents.some((item) => item.contentUid === group.content.uid && item.studentUid === studentUid)
-    : false;
-  const favoritedCount = studentUid
-    ? favoritedCounts.find((item) => item.contentUid === group.content.uid && item.studentUid === studentUid)?.count
-    : undefined;
+  const favoriteKey = recruitment.favoriteKey;
+  const favorited = favoritedStudents.some(
+    (item) => item.contentUid === group.content.uid && item.studentUid === favoriteKey,
+  );
+  const favoritedCount = favoritedCounts.find(
+    (item) => item.contentUid === group.content.uid && item.studentUid === favoriteKey,
+  )?.count;
   const label = recruitmentLabelLocale(recruitment);
   const completed = Boolean(
     group.content.recruitmentGroupUid &&
@@ -488,6 +489,7 @@ function getRecruitmentStudentGroup(
 
   return {
     uid: studentUid,
+    popupId: favoriteKey,
     name: recruitment.studentName,
     attackType: recruitment.student?.attackType,
     defenseType: recruitment.student?.defenseType,
@@ -498,9 +500,9 @@ function getRecruitmentStudentGroup(
     pickup: recruitment.pickup,
     favorited,
     favoritedCount: favoritedCount ?? 0,
-    popups: studentUid
+    popups: favoriteKey
       ? [
-          ...(onRecruitmentComplete && group.content.recruitmentGroupUid && showRecruitmentCompleteAction
+          ...(onRecruitmentComplete && group.content.recruitmentGroupUid && studentUid && showRecruitmentCompleteAction
             ? [
                 completed
                   ? {
@@ -533,12 +535,12 @@ function getRecruitmentStudentGroup(
             ? {
                 Icon: FilledHeartIcon,
                 text: "관심 학생에서 해제",
-                onClick: () => onFavorite?.(group.content.uid, studentUid, false),
+                onClick: () => onFavorite?.(group.content.uid, favoriteKey, false),
               }
             : {
                 Icon: EmptyHeartIcon,
                 text: "관심 학생에 등록",
-                onClick: () => onFavorite?.(group.content.uid, studentUid, true),
+                onClick: () => onFavorite?.(group.content.uid, favoriteKey, true),
               },
           ...(resultEditLink
             ? [
@@ -549,11 +551,15 @@ function getRecruitmentStudentGroup(
                 },
               ]
             : []),
-          {
-            Icon: IdentificationIcon,
-            text: "학생부 보기 (평가/통계)",
-            link: `/students/${studentUid}`,
-          },
+          ...(studentUid
+            ? [
+                {
+                  Icon: IdentificationIcon,
+                  text: "학생부 보기 (평가/통계)",
+                  link: `/students/${studentUid}`,
+                },
+              ]
+            : []),
         ]
       : undefined,
   };

--- a/app/routes/futures._components/future-recruitment-table-model.test.ts
+++ b/app/routes/futures._components/future-recruitment-table-model.test.ts
@@ -40,6 +40,7 @@ function recruitment(
     pickup: overrides.pickup ?? true,
     rerun: overrides.rerun ?? false,
     studentName: overrides.studentName,
+    favoriteKey: overrides.favoriteKey ?? overrides.student?.uid ?? `provisional:${overrides.studentName}`,
     since: overrides.since,
     until: overrides.until,
     student: overrides.student ?? null,

--- a/app/routes/futures._components/future-recruitment-table-model.ts
+++ b/app/routes/futures._components/future-recruitment-table-model.ts
@@ -18,6 +18,7 @@ export type FutureRecruitmentTableRecruitment = {
   since: UtcIsoString;
   until: UtcIsoString | null;
   studentName: string;
+  favoriteKey: string;
   student: {
     uid: string;
     attackType?: Attack;

--- a/app/routes/futures.tsx
+++ b/app/routes/futures.tsx
@@ -19,11 +19,11 @@ import {
 import type { EventType, RaidType } from "~/models/content.d";
 import { getFavoritedCounts, getUserFavoritedStudents } from "~/models/favorite-students";
 import { raidTypeToParam } from "~/models/raid";
-import { applyRecruitmentResultStudentCompletion } from "~/models/recruitment-result-completion";
 import {
-  getRecruitmentResultsByRecruitmentGroupUids,
   type RecruitmentCompletionMeta,
+  getRecruitmentResultsByRecruitmentGroupUids,
 } from "~/models/recruitment-result";
+import { applyRecruitmentResultStudentCompletion } from "~/models/recruitment-result-completion";
 import type { ActionData as ContentsActionData } from "./api.contents";
 import type { ActionData as CommentActionData } from "./api.contents.$uid.comments";
 import type { ActionData as RecruitmentResultActionData } from "./api.recruitment-results";
@@ -66,7 +66,7 @@ export const loader = async ({ request, context }: LoaderFunctionArgs): Promise<
 
   const allStudentUids = contents
     .flatMap((content: FutureContentsLoaderContent) =>
-      content.recruitments.map((recruitment: FutureRecruitment) => recruitment.student?.uid ?? null),
+      content.recruitments.map((recruitment: FutureRecruitment) => recruitment.favoriteKey),
     )
     .filter((uid): uid is string => uid !== null);
 

--- a/test/app/models/recruitment-identity.test.ts
+++ b/test/app/models/recruitment-identity.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  getProvisionalRecruitmentStudentKey,
+  getRecruitmentFavoriteKey,
+  normalizeRecruitmentStudentName,
+} from "../../../app/models/recruitment-identity";
+
+describe("recruitment identity", () => {
+  it("normalizes recruitment student names before deriving provisional keys", () => {
+    const compact = getProvisionalRecruitmentStudentKey("리오(무장)");
+    const spaced = getProvisionalRecruitmentStudentKey("  리오(무장)  ");
+
+    expect(normalizeRecruitmentStudentName("  리오(무장)  ")).toBe("리오(무장)");
+    expect(spaced).toBe(compact);
+    expect(compact).toMatch(/^provisional:[0-9a-z]+$/);
+  });
+
+  it("prefers the canonical student uid when student data exists", () => {
+    expect(getRecruitmentFavoriteKey({ student: { uid: "rio-armed" }, studentName: "리오(무장)" })).toBe("rio-armed");
+  });
+
+  it("falls back to a deterministic provisional key when student data is missing", () => {
+    expect(getRecruitmentFavoriteKey({ student: null, studentName: "리오(무장)" })).toBe(
+      getProvisionalRecruitmentStudentKey("리오(무장)"),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Allow users to favorite recruitment students before their full BAQL student data is registered.

## Changes

- Add a provisional favorite key derived from the recruitment student name when no student UID exists yet.
- Thread the favorite key through future/event recruitment data and favorite student controls.
- Keep existing student UID behavior unchanged for registered students.
- Add tests for provisional key generation and recruitment table favorite keys.

## Verification

- [x] Manually verified the relevant behavior through code paths.
- [x] Ran `mise exec -- pnpm run typecheck`.
- [x] Ran `mise exec -- pnpm test -- test/app/models/recruitment-identity.test.ts app/routes/futures._components/future-recruitment-table-model.test.ts test/app/models/favorite-students.test.ts --runInBand`.
- [x] Ran `mise exec -- pnpm run lint`.
- [x] Reviewed AI-generated content.

## Related Issues

None.