### PR TITLE
feat: improve coupon menu states

### DIFF
--- a/app/components/features/coupons/CouponCard.tsx
+++ b/app/components/features/coupons/CouponCard.tsx
@@ -26,7 +26,7 @@ export default function CouponCard({ coupon, registered, signedIn }: CouponCardP
   return (
     <div className="relative rounded-xl border border-neutral-200 dark:border-neutral-700 overflow-hidden bg-white dark:bg-neutral-800 shadow-sm">
       {/* 만료 오버레이 */}
-      {isExpired && !optimisticRegistered && (
+      {isExpired && (
         <div className="absolute inset-0 z-10 backdrop-blur-sm bg-white/60 dark:bg-neutral-800/60 flex flex-col items-center justify-center gap-2">
           <ClockIcon className="size-10 text-red-400" strokeWidth={1.5} />
           <span className="font-bold text-red-500 dark:text-red-400">만료됨</span>
@@ -34,7 +34,7 @@ export default function CouponCard({ coupon, registered, signedIn }: CouponCardP
       )}
 
       {/* 등록 완료 오버레이 */}
-      {optimisticRegistered && (
+      {!isExpired && optimisticRegistered && (
         <div className="absolute inset-0 z-10 backdrop-blur-sm bg-white/60 dark:bg-neutral-800/60 flex flex-col items-center justify-center gap-2">
           <CheckCircleIconSolid className="size-10 text-green-500" />
           <span className="font-bold text-green-600 dark:text-green-400">이미 등록한 쿠폰이에요</span>

--- a/app/components/features/coupons/CouponCard.tsx
+++ b/app/components/features/coupons/CouponCard.tsx
@@ -1,7 +1,7 @@
-import { useFetcher } from "react-router";
 import { ArrowTopRightOnSquareIcon, CheckCircleIcon, ClockIcon } from "@heroicons/react/24/outline";
 import { CheckCircleIcon as CheckCircleIconSolid } from "@heroicons/react/24/solid";
 import dayjs from "dayjs";
+import { useFetcher } from "react-router";
 import type { Coupon } from "~/models/coupon";
 import CopyField from "./CopyField";
 import CouponRewardList from "./CouponRewardList";
@@ -16,23 +16,18 @@ export default function CouponCard({ coupon, registered, signedIn }: CouponCardP
   const fetcher = useFetcher();
 
   const isExpired = coupon.expiresAt !== null && dayjs(coupon.expiresAt).isBefore(dayjs());
-  const optimisticRegistered = fetcher.state !== "idle"
-    ? fetcher.formMethod === "POST"
-    : registered;
+  const optimisticRegistered = fetcher.state !== "idle" ? fetcher.formMethod === "POST" : registered;
 
   const handleToggle = () => {
     if (fetcher.state !== "idle") return;
-    fetcher.submit(
-      { couponId: coupon.id },
-      { method: optimisticRegistered ? "DELETE" : "POST" },
-    );
+    fetcher.submit({ couponId: coupon.id }, { method: optimisticRegistered ? "DELETE" : "POST" });
   };
 
   return (
     <div className="relative rounded-xl border border-neutral-200 dark:border-neutral-700 overflow-hidden bg-white dark:bg-neutral-800 shadow-sm">
       {/* 만료 오버레이 */}
       {isExpired && !optimisticRegistered && (
-        <div className="absolute inset-0 z-10 backdrop-blur-sm bg-white/60 dark:bg-neutral-800/60 flex flex-col items-center justify-center gap-2 pointer-events-none">
+        <div className="absolute inset-0 z-10 backdrop-blur-sm bg-white/60 dark:bg-neutral-800/60 flex flex-col items-center justify-center gap-2">
           <ClockIcon className="size-10 text-red-400" strokeWidth={1.5} />
           <span className="font-bold text-red-500 dark:text-red-400">만료됨</span>
         </div>
@@ -40,7 +35,7 @@ export default function CouponCard({ coupon, registered, signedIn }: CouponCardP
 
       {/* 등록 완료 오버레이 */}
       {optimisticRegistered && (
-        <div className="absolute inset-0 z-10 backdrop-blur-sm bg-white/60 dark:bg-neutral-800/60 flex flex-col items-center justify-center gap-2 pointer-events-none">
+        <div className="absolute inset-0 z-10 backdrop-blur-sm bg-white/60 dark:bg-neutral-800/60 flex flex-col items-center justify-center gap-2">
           <CheckCircleIconSolid className="size-10 text-green-500" />
           <span className="font-bold text-green-600 dark:text-green-400">이미 등록한 쿠폰이에요</span>
           <button
@@ -57,12 +52,7 @@ export default function CouponCard({ coupon, registered, signedIn }: CouponCardP
       {/* 이미지 */}
       <div className="aspect-video bg-neutral-100 dark:bg-neutral-700 overflow-hidden">
         {coupon.imageUrl ? (
-          <img
-            src={coupon.imageUrl}
-            alt={coupon.name}
-            className="w-full h-full object-cover"
-            loading="lazy"
-          />
+          <img src={coupon.imageUrl} alt={coupon.name} className="w-full h-full object-cover" loading="lazy" />
         ) : (
           <div className="w-full h-full flex items-center justify-center text-neutral-300 dark:text-neutral-600 text-sm">
             이미지 없음

--- a/app/components/features/coupons/coupon-display.ts
+++ b/app/components/features/coupons/coupon-display.ts
@@ -1,0 +1,17 @@
+import type { Coupon } from "~/models/coupon";
+
+export type CouponDisplayStatus = "available" | "history";
+
+export function isCouponExpired(coupon: Pick<Coupon, "expiresAt">, now = new Date()): boolean {
+  if (coupon.expiresAt === null) return false;
+  return new Date(coupon.expiresAt).getTime() < now.getTime();
+}
+
+export function getCouponDisplayStatus(
+  coupon: Pick<Coupon, "expiresAt">,
+  registeredAtLoad: boolean,
+  now = new Date(),
+): CouponDisplayStatus {
+  if (registeredAtLoad || isCouponExpired(coupon, now)) return "history";
+  return "available";
+}

--- a/app/routes/coupons.tsx
+++ b/app/routes/coupons.tsx
@@ -1,15 +1,26 @@
-import { data, Link } from "react-router";
-import { ArrowTopRightOnSquareIcon } from "@heroicons/react/24/solid";
-import type { LoaderFunctionArgs, ActionFunctionArgs, MetaFunction } from "react-router";
-import { getActiveSensei } from "~/auth/authenticator.server";
-import Page from "~/components/features/layout/Page";
-import CouponCard from "~/components/features/coupons/CouponCard";
-import { getAllCoupons, getCouponRegistrations, registerCoupon, unregisterCoupon } from "~/models/coupon";
-import { useLoaderData } from "react-router";
-import { getSenseiPrivacyByUserId } from "~/models/sensei-privacy";
 import { IdentificationIcon } from "@heroicons/react/16/solid";
+import { ArrowTopRightOnSquareIcon } from "@heroicons/react/24/solid";
+import { useState } from "react";
+import { Link, data, useLoaderData } from "react-router";
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from "react-router";
+import { getActiveSensei } from "~/auth/authenticator.server";
 import CopyField from "~/components/features/coupons/CopyField";
+import CouponCard from "~/components/features/coupons/CouponCard";
+import { type CouponDisplayStatus, getCouponDisplayStatus } from "~/components/features/coupons/coupon-display";
+import Page from "~/components/features/layout/Page";
+import { FilterButtons } from "~/components/primitives";
 import { canonicalLink } from "~/lib/seo";
+import { getAllCoupons, getCouponRegistrations, registerCoupon, unregisterCoupon } from "~/models/coupon";
+import { getSenseiPrivacyByUserId } from "~/models/sensei-privacy";
+
+type CouponStatusFilter = CouponDisplayStatus;
+
+const AVAILABLE_EMPTY_IMAGE_URL = "https://assets.mollulog.net/assets/videos/site/dear-yongha-kim.gif";
+
+const COUPON_STATUS_FILTERS: { id: CouponStatusFilter; label: string }[] = [
+  { id: "available", label: "사용 가능" },
+  { id: "history", label: "사용완료/만료" },
+];
 
 export const meta: MetaFunction = ({ location }) => [
   { title: "블루 아카이브 쿠폰 목록 | 몰루로그" },
@@ -22,10 +33,12 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
   const coupons = await getAllCoupons(env);
 
   const sensei = await getActiveSensei(env, request);
-  const currentUserData = sensei ? {
-    registeredCouponIds: await getCouponRegistrations(env, sensei.id),
-    memberCode: (await getSenseiPrivacyByUserId(env, sensei.id))?.memberCode ?? null,
-  } : null;
+  const currentUserData = sensei
+    ? {
+        registeredCouponIds: await getCouponRegistrations(env, sensei.id),
+        memberCode: (await getSenseiPrivacyByUserId(env, sensei.id))?.memberCode ?? null,
+      }
+    : null;
 
   return {
     coupons,
@@ -57,6 +70,8 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
 
 export default function CouponsPage() {
   const { coupons, currentUserData } = useLoaderData<typeof loader>();
+  const [statusFilter, setStatusFilter] = useState<CouponStatusFilter>("available");
+  const [initialRegisteredCouponIds] = useState(() => currentUserData?.registeredCouponIds ?? []);
 
   const memberCodeSection = currentUserData?.memberCode ? (
     <div className="px-3 py-2.5 bg-neutral-50 dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-700 rounded-lg">
@@ -76,6 +91,11 @@ export default function CouponsPage() {
   ) : undefined;
 
   const registeredSet = new Set(currentUserData?.registeredCouponIds ?? []);
+  const initialRegisteredSet = new Set(initialRegisteredCouponIds);
+  const displayedCoupons = coupons.filter(
+    (coupon) => getCouponDisplayStatus(coupon, initialRegisteredSet.has(coupon.id)) === statusFilter,
+  );
+
   return (
     <Page
       title="쿠폰"
@@ -90,13 +110,26 @@ export default function CouponsPage() {
         },
       ]}
     >
-      {coupons.length === 0 ? (
-        <div className="py-16 text-center text-neutral-400 dark:text-neutral-500">
-          쿠폰이 없습니다.
-        </div>
+      <div className="mb-4">
+        <FilterButtons
+          exclusive
+          atLeastOne
+          size="sm"
+          buttonProps={COUPON_STATUS_FILTERS.map((filter) => ({
+            text: filter.label,
+            active: statusFilter === filter.id,
+            onToggle: (activated) => {
+              if (activated) setStatusFilter(filter.id);
+            },
+          }))}
+        />
+      </div>
+
+      {displayedCoupons.length === 0 ? (
+        <CouponEmptyView statusFilter={statusFilter} />
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          {coupons.map((coupon) => (
+          {displayedCoupons.map((coupon) => (
             <CouponCard
               key={coupon.uid}
               coupon={coupon}
@@ -108,4 +141,17 @@ export default function CouponsPage() {
       )}
     </Page>
   );
+}
+
+function CouponEmptyView({ statusFilter }: { statusFilter: CouponStatusFilter }) {
+  if (statusFilter === "available") {
+    return (
+      <div className="my-16 flex w-full flex-col items-center justify-center text-center">
+        <img src={AVAILABLE_EMPTY_IMAGE_URL} alt="" className="mb-4 size-36 object-contain" loading="lazy" />
+        <p className="text-sm font-medium text-neutral-700 dark:text-neutral-200">현재 사용 가능한 쿠폰이 없어요</p>
+      </div>
+    );
+  }
+
+  return <div className="py-16 text-center text-neutral-400 dark:text-neutral-500">사용완료/만료된 쿠폰이 없어요</div>;
 }

--- a/test/app/components/features/coupons/coupon-display.test.ts
+++ b/test/app/components/features/coupons/coupon-display.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "@jest/globals";
+import { getCouponDisplayStatus, isCouponExpired } from "~/components/features/coupons/coupon-display";
+
+const now = new Date("2026-07-02T00:00:00.000Z");
+
+describe("coupon display status", () => {
+  it("treats an active unregistered coupon as available", () => {
+    expect(getCouponDisplayStatus({ expiresAt: "2026-07-03T00:00:00.000Z" }, false, now)).toBe("available");
+  });
+
+  it("treats an active registered coupon as history", () => {
+    expect(getCouponDisplayStatus({ expiresAt: "2026-07-03T00:00:00.000Z" }, true, now)).toBe("history");
+  });
+
+  it("treats an expired unregistered coupon as history", () => {
+    expect(getCouponDisplayStatus({ expiresAt: "2026-07-01T23:59:59.999Z" }, false, now)).toBe("history");
+  });
+
+  it("treats a coupon without an expiry as active", () => {
+    expect(isCouponExpired({ expiresAt: null }, now)).toBe(false);
+    expect(getCouponDisplayStatus({ expiresAt: null }, false, now)).toBe("available");
+  });
+});


### PR DESCRIPTION
## Summary

Improves the coupon page state handling so users can focus on currently usable coupons while still reviewing completed or expired coupons separately. It also fixes the completed/expired overlay click-through issue and adds a branded empty state for the available coupon list.

## Changes

- Add a status filter for `사용 가능` and `사용완료/만료` coupon views using the existing filter button pattern.
- Keep newly completed coupons visible in the available view until the next page load by filtering from the initial loader registration state.
- Add a GIF empty view for the available coupon list when no usable coupons remain.
- Prevent completed and expired coupon overlays from passing clicks through to links or buttons behind them.
- Add focused tests for coupon display status classification.

## Verification

- [x] I verified the related behavior myself.
- [ ] I ran `pnpm typecheck`, `pnpm exec biome check .`, and relevant tests when needed.
  - Ran `mise exec -- pnpm test -- test/app/components/features/coupons/coupon-display.test.ts`
  - Ran scoped Biome check: `mise exec -- pnpm exec biome check app/routes/coupons.tsx app/components/features/coupons/CouponCard.tsx app/components/features/coupons/coupon-display.ts test/app/components/features/coupons/coupon-display.test.ts`
  - Ran `mise exec -- pnpm exec react-router typegen`
  - Ran `mise exec -- pnpm exec tsc`
  - Did not run full `pnpm exec biome check .`
- [ ] (If AI tools were used) The generated content was reviewed by a person.

## Related issues

None.
