### PR TITLE
perf: use D1 sessions for replica-eligible reads

### DIFF
--- a/app/lib/cache/index.ts
+++ b/app/lib/cache/index.ts
@@ -1,3 +1,4 @@
+import { mapWithConcurrencyLimit } from "~/lib/concurrency";
 import { getIoWatchdogContext, watchIo } from "~/lib/io-watchdog";
 import { RUNTIME_TIMEOUTS } from "~/lib/runtime-timeouts";
 import { isTimeoutError, withTimeout } from "~/lib/with-timeout";
@@ -36,6 +37,9 @@ export function cacheQuery(params: Record<string, string | number | boolean | nu
  */
 const KV_TIMEOUT_MS = RUNTIME_TIMEOUTS.kv.operation;
 const KV_COOLDOWN_AFTER_TIMEOUT_MS = RUNTIME_TIMEOUTS.kv.cooldownAfterTimeout;
+// Cron can request hundreds of source keys at once. Keep enough parallelism for
+// throughput without fanning every KV operation out in the same event-loop turn.
+const LAZY_SOURCE_KV_CONCURRENCY = 32;
 
 type KvCircuitState = {
   disabledUntil: number;
@@ -686,12 +690,10 @@ export async function fetchLazySourceCachedBatch<K extends string, T>(
   const staleValues = new Map<K, T>();
   const missingEntries: Array<LazySourceBatchEntry<K>> = [];
 
-  const cachedValues = await Promise.all(
-    uniqueEntries.map(async (entry) => ({
-      entry,
-      cached: await readKvCacheValue<T>(env, entry.dataKey),
-    })),
-  );
+  const cachedValues = await mapWithConcurrencyLimit(uniqueEntries, LAZY_SOURCE_KV_CONCURRENCY, async (entry) => ({
+    entry,
+    cached: await readKvCacheValue<T>(env, entry.dataKey),
+  }));
 
   for (const { entry, cached } of cachedValues) {
     if (!cached) {
@@ -741,16 +743,14 @@ export async function fetchLazySourceCachedBatch<K extends string, T>(
     );
   }
 
-  await Promise.all(
-    missingEntries.flatMap((entry) => {
-      if (!loadedValues.has(entry.key)) {
-        return [];
-      }
-
+  await mapWithConcurrencyLimit(
+    missingEntries.filter((entry) => loadedValues.has(entry.key)),
+    LAZY_SOURCE_KV_CONCURRENCY,
+    async (entry) => {
       const data = loadedValues.get(entry.key) as T;
       freshValues.set(entry.key, data);
-      return [writeKvCacheValue(env, entry.dataKey, data, cachedAt, SOURCE_CACHE_EXPIRATION_TTL)];
-    }),
+      await writeKvCacheValue(env, entry.dataKey, data, cachedAt, SOURCE_CACHE_EXPIRATION_TTL);
+    },
   );
 
   return new Map(uniqueEntries.map((entry) => [entry.key, resolveBatchValue(entry.key, freshValues, staleValues)]));

--- a/app/lib/d1-session.ts
+++ b/app/lib/d1-session.ts
@@ -1,0 +1,4 @@
+export function withD1Session(env: Env, constraint: D1SessionConstraint): Env {
+  // Drizzle's D1 driver only needs prepare/batch, which D1DatabaseSession provides.
+  return { ...env, DB: env.DB.withSession(constraint) as unknown as D1Database };
+}

--- a/app/models/community.ts
+++ b/app/models/community.ts
@@ -3,6 +3,7 @@ import { drizzle } from "drizzle-orm/d1";
 import { int, sqliteTable, text } from "drizzle-orm/sqlite-core";
 import { nanoid } from "nanoid/non-secure";
 import { type UtcIsoString, normalizeUtcTimestamp, nowUtcIso } from "~/lib/date-time";
+import { withD1Session } from "~/lib/d1-session";
 import { watchIo } from "~/lib/io-watchdog";
 import { cacheKey, cacheQuery, fetchCached } from "~/lib/cache";
 import { senseisTable } from "./sensei";
@@ -433,6 +434,7 @@ export async function getCommunityFeedPage(
     return loadCommunityFeedPage(env, options);
   }
 
+  const sessionEnv = withD1Session(env, "first-unconstrained");
   const { postType, postTypes, authorUserId, youtubeChannelKey, includeEngagement = true } = options;
   const types = postTypes && postTypes.length > 0 ? [...postTypes].sort() : postType ? [postType] : [];
   const feedCacheKey = cacheKey(
@@ -451,7 +453,7 @@ export async function getCommunityFeedPage(
   return fetchCached(
     env,
     feedCacheKey,
-    () => loadCommunityFeedPage(env, options),
+    () => loadCommunityFeedPage(sessionEnv, options),
     COMMUNITY_FEED_CACHE_FRESH_TTL,
     false,
     {

--- a/app/models/youtube.ts
+++ b/app/models/youtube.ts
@@ -1,4 +1,5 @@
 import { XMLParser } from "fast-xml-parser";
+import { mapWithConcurrencyLimit } from "~/lib/concurrency";
 import { fetchWithTimeout, readBodyWithTimeout } from "~/lib/fetch-timeout";
 import { RUNTIME_TIMEOUTS } from "~/lib/runtime-timeouts";
 import {
@@ -32,6 +33,9 @@ const xmlParser = new XMLParser({
 
 const YOUTUBE_FEED_FETCH_TIMEOUT_MS = RUNTIME_TIMEOUTS.external.youtubeFeedFetch;
 const YOUTUBE_FEED_BODY_TIMEOUT_MS = RUNTIME_TIMEOUTS.external.youtubeFeedBody;
+// Each upsert starts with a D1 existence check. Both staging and production cron
+// target the same database, so an unbounded fan-out can overload the primary.
+const YOUTUBE_SYNC_CONCURRENCY = 4;
 
 export type HomeYoutubeVideo = {
   id: string;
@@ -111,7 +115,9 @@ export async function fetchYoutubeFeedVideos(): Promise<YoutubeFeedVideo[]> {
 
 export async function syncYoutubeCommunityPosts(env: Env): Promise<{ synced: number }> {
   const videos = await fetchYoutubeFeedVideos();
-  await Promise.all(videos.map((video) => upsertYoutubeVideoCommunityPost(env, video)));
+  await mapWithConcurrencyLimit(videos, YOUTUBE_SYNC_CONCURRENCY, (video) =>
+    upsertYoutubeVideoCommunityPost(env, video),
+  );
   return { synced: videos.length };
 }
 

--- a/app/routes/api.contents.$uid.comments.tsx
+++ b/app/routes/api.contents.$uid.comments.tsx
@@ -1,6 +1,17 @@
 import { redirect, type ActionFunctionArgs, type LoaderFunctionArgs } from "react-router";
 import { getActiveSensei } from "~/auth/authenticator.server";
-import { createComment, createSubcomment, updateComment, deleteComment, getNestedContentComments, nestComments, getContentComments, pinComment, unpinComment } from "~/models/content";
+import { withD1Session } from "~/lib/d1-session";
+import {
+  createComment,
+  createSubcomment,
+  deleteComment,
+  getContentComments,
+  getNestedContentComments,
+  nestComments,
+  pinComment,
+  unpinComment,
+  updateComment,
+} from "~/models/content";
 
 export const loader = async ({ request, params, context }: LoaderFunctionArgs) => {
   const contentUid = params.uid;
@@ -10,7 +21,8 @@ export const loader = async ({ request, params, context }: LoaderFunctionArgs) =
 
   const env = context.cloudflare.env;
   const currentUser = await getActiveSensei(env, request);
-  return nestComments(await getContentComments(env, contentUid, currentUser?.id), currentUser);
+  const sessionEnv = withD1Session(env, currentUser ? "first-primary" : "first-unconstrained");
+  return nestComments(await getContentComments(sessionEnv, contentUid, currentUser?.id), currentUser);
 };
 
 export type ActionData = {
@@ -43,12 +55,25 @@ export const action = async ({ request, params, context }: ActionFunctionArgs) =
     if (!actionData.body || !actionData.parentCommentUid) {
       throw new Response("Body and parentCommentUid are required", { status: 400 });
     }
-    await createSubcomment(env, currentUser.id, contentUid, actionData.parentCommentUid, actionData.body, actionData.visibility ?? "private");
+    await createSubcomment(
+      env,
+      currentUser.id,
+      contentUid,
+      actionData.parentCommentUid,
+      actionData.body,
+      actionData.visibility ?? "private",
+    );
   } else if (actionData.action === "update") {
     if (!actionData.commentUid || !actionData.body) {
       throw new Response("CommentUid and body are required", { status: 400 });
     }
-    await updateComment(env, currentUser.id, actionData.commentUid, actionData.body, actionData.visibility ?? "private");
+    await updateComment(
+      env,
+      currentUser.id,
+      actionData.commentUid,
+      actionData.body,
+      actionData.visibility ?? "private",
+    );
   } else if (actionData.action === "delete") {
     if (!actionData.commentUid) {
       throw new Response("CommentUid is required", { status: 400 });

--- a/test/app/lib/cache.test.ts
+++ b/test/app/lib/cache.test.ts
@@ -894,6 +894,51 @@ describe("fetchLazySourceCachedBatch", () => {
     expect(kv.put).not.toHaveBeenCalled();
   });
 
+  it("limits concurrent KV reads to 32 entries", async () => {
+    const now = 1_800_000_000_000;
+    jest.spyOn(Date, "now").mockReturnValue(now);
+
+    const manyEntries = Array.from({ length: 40 }, (_, index) => ({
+      key: `key-${index}`,
+      dataKey: `source::thing::v1::uid=key-${index}`,
+    }));
+    let activeReads = 0;
+    let maxActiveReads = 0;
+    const pendingReads: Array<() => void> = [];
+    const kv = {
+      get: jest.fn(
+        (key: string) =>
+          new Promise<string>((resolve) => {
+            activeReads += 1;
+            maxActiveReads = Math.max(maxActiveReads, activeReads);
+            pendingReads.push(() => {
+              activeReads -= 1;
+              resolve(JSON.stringify({ _ver: 2, data: key, cachedAt: now }));
+            });
+          }),
+      ),
+      put: jest.fn(async () => undefined),
+      delete: jest.fn(async () => undefined),
+      list: jest.fn(async () => ({ keys: [], list_complete: true })),
+    };
+    const env = { KV_CACHE: kv } as unknown as CacheEnv;
+    const loadMissing = jest.fn(async () => new Map<string, string>());
+
+    const result = fetchLazySourceCachedBatch(env, manyEntries, loadMissing, 60);
+    await flushPromises();
+
+    expect(maxActiveReads).toBe(32);
+    while (pendingReads.length > 0) {
+      pendingReads.splice(0).forEach((resolve) => {
+        resolve();
+      });
+      await flushPromises();
+    }
+
+    expect((await result).size).toBe(40);
+    expect(loadMissing).not.toHaveBeenCalled();
+  });
+
   it("loads and writes only missing batch keys", async () => {
     const now = 1_800_000_000_000;
     jest.spyOn(Date, "now").mockReturnValue(now);

--- a/test/app/models/community.test.ts
+++ b/test/app/models/community.test.ts
@@ -71,6 +71,12 @@ class FakeCommunityD1Database {
 
   readonly preparedSql: string[] = [];
   readonly executedStatements: PreparedStatement[] = [];
+  readonly sessionConstraints: D1SessionConstraint[] = [];
+
+  withSession(constraint: D1SessionConstraint): FakeCommunityD1Database {
+    this.sessionConstraints.push(constraint);
+    return this;
+  }
 
   prepare(sql: string): FakeD1Statement {
     this.preparedSql.push(sql);
@@ -399,6 +405,7 @@ describe("community model feed queries", () => {
     });
 
     expect(page.items).toHaveLength(1);
+    expect(db.sessionConstraints).toEqual(["first-unconstrained"]);
     expect(page.items[0]).toMatchObject({
       uid: "post-user-review",
       postType: "student_review",

--- a/test/app/models/youtube.test.ts
+++ b/test/app/models/youtube.test.ts
@@ -12,6 +12,10 @@ const mockedUpsertYoutubeVideoCommunityPost = upsertYoutubeVideoCommunityPost as
 >;
 const mockedGetCommunityFeedPage = getCommunityFeedPage as jest.MockedFunction<typeof getCommunityFeedPage>;
 
+function flushPromises() {
+  return new Promise<void>((resolve) => setImmediate(resolve));
+}
+
 function createFeedXml(videoId: string, title: string) {
   return `<?xml version="1.0" encoding="UTF-8"?>
 <feed xmlns:yt="http://www.youtube.com/xml/schemas/2015" xmlns:media="http://search.yahoo.com/mrss/">
@@ -24,6 +28,25 @@ function createFeedXml(videoId: string, title: string) {
       <media:thumbnail url="https://i.ytimg.com/vi/${videoId}/hqdefault.jpg" />
     </media:group>
   </entry>
+</feed>`;
+}
+
+function createFeedXmlWithVideos(videoIds: string[]) {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns:yt="http://www.youtube.com/xml/schemas/2015" xmlns:media="http://search.yahoo.com/mrss/">
+  ${videoIds
+    .map(
+      (videoId) => `<entry>
+    <yt:videoId>${videoId}</yt:videoId>
+    <title>${videoId}</title>
+    <link href="https://www.youtube.com/watch?v=${videoId}" />
+    <published>2026-03-28T00:00:00+00:00</published>
+    <media:group>
+      <media:thumbnail url="https://i.ytimg.com/vi/${videoId}/hqdefault.jpg" />
+    </media:group>
+  </entry>`,
+    )
+    .join("\n")}
 </feed>`;
 }
 
@@ -107,6 +130,45 @@ describe("syncYoutubeCommunityPosts", () => {
         channelKey: "kr",
       }),
     );
+  });
+
+  it("limits concurrent D1-backed upserts to four videos", async () => {
+    jest.spyOn(global, "fetch").mockImplementation(
+      async () =>
+        ({
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          text: async () => createFeedXmlWithVideos(["video-1", "video-2", "video-3", "video-4", "video-5"]),
+        }) as Response,
+    );
+    let activeUpserts = 0;
+    let maxActiveUpserts = 0;
+    const pendingUpserts: Array<() => void> = [];
+    mockedUpsertYoutubeVideoCommunityPost.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          activeUpserts += 1;
+          maxActiveUpserts = Math.max(maxActiveUpserts, activeUpserts);
+          pendingUpserts.push(() => {
+            activeUpserts -= 1;
+            resolve();
+          });
+        }),
+    );
+
+    const result = syncYoutubeCommunityPosts({} as Env);
+    await flushPromises();
+
+    expect(maxActiveUpserts).toBe(4);
+    while (pendingUpserts.length > 0) {
+      pendingUpserts.splice(0).forEach((resolve) => {
+        resolve();
+      });
+      await Promise.resolve();
+    }
+
+    await expect(result).resolves.toEqual({ synced: 10 });
   });
 });
 

--- a/test/workers/d1-timeout.test.ts
+++ b/test/workers/d1-timeout.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { D1TimeoutError, withD1Timeout } from "../../workers/d1-timeout";
+
+type FakeStatement = D1PreparedStatement & { query: string };
+
+function createStatement(query: string, result: Promise<unknown> = Promise.resolve({ success: true })) {
+  const statement = {
+    query,
+    bind: jest.fn(() => statement),
+    first: jest.fn(() => result),
+    run: jest.fn(() => result),
+    all: jest.fn(() => result),
+    raw: jest.fn(() => result),
+  } as unknown as FakeStatement;
+  return statement;
+}
+
+describe("withD1Timeout sessions", () => {
+  it("forwards the session constraint and preserves session methods", () => {
+    const session = {
+      prepare: jest.fn((query: string) => createStatement(query)),
+      batch: jest.fn(async () => []),
+      getBookmark: jest.fn(() => "bookmark-1"),
+    } as unknown as D1DatabaseSession;
+    const db = {
+      withSession: jest.fn(() => session),
+    } as unknown as D1Database;
+
+    const wrappedSession = withD1Timeout(db).withSession("first-unconstrained");
+
+    expect(db.withSession).toHaveBeenCalledWith("first-unconstrained");
+    expect(wrappedSession.getBookmark()).toBe("bookmark-1");
+  });
+
+  it("applies the D1 deadline to session statements", async () => {
+    jest.useFakeTimers();
+    jest.spyOn(console, "error").mockImplementation(() => undefined);
+    const statement = createStatement("select 1", new Promise(() => undefined));
+    const session = {
+      prepare: jest.fn(() => statement),
+      batch: jest.fn(async () => []),
+      getBookmark: jest.fn(() => null),
+    } as unknown as D1DatabaseSession;
+    const db = {
+      withSession: jest.fn(() => session),
+    } as unknown as D1Database;
+    const query = withD1Timeout(db, 100).withSession("first-unconstrained").prepare("select 1").all();
+    query.catch(() => undefined);
+
+    await jest.advanceTimersByTimeAsync(100);
+
+    await expect(query).rejects.toBeInstanceOf(D1TimeoutError);
+    expect(console.error).toHaveBeenCalledWith(
+      "[io-watchdog] timeout",
+      expect.objectContaining({ label: "d1", operation: "statement.all", timeoutMs: 100 }),
+    );
+  });
+
+  it("unwraps proxied statements before a session batch", async () => {
+    const first = createStatement("select 1");
+    const second = createStatement("select 2");
+    const batch = jest.fn(async (_statements: D1PreparedStatement[]) => []);
+    const session = {
+      prepare: jest.fn((query: string) => (query === "select 1" ? first : second)),
+      batch,
+      getBookmark: jest.fn(() => null),
+    } as unknown as D1DatabaseSession;
+    const db = {
+      withSession: jest.fn(() => session),
+    } as unknown as D1Database;
+    const wrappedSession = withD1Timeout(db).withSession("first-unconstrained");
+    const wrappedFirst = wrappedSession.prepare("select 1");
+    const wrappedSecond = wrappedSession.prepare("select 2");
+
+    await wrappedSession.batch([wrappedFirst, wrappedSecond]);
+
+    expect(batch).toHaveBeenCalledWith([first, second]);
+  });
+});

--- a/workers/d1-timeout.ts
+++ b/workers/d1-timeout.ts
@@ -143,6 +143,37 @@ function unwrapStatement(statement: D1PreparedStatement): D1PreparedStatement {
   return (statement as { [UNWRAP]?: D1PreparedStatement })[UNWRAP] ?? statement;
 }
 
+function wrapSession(session: D1DatabaseSession, timeoutMs: number): D1DatabaseSession {
+  return new Proxy(session, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver);
+      if (typeof value !== "function") {
+        return value;
+      }
+
+      if (prop === "prepare") {
+        return (query: string) =>
+          wrapStatement(
+            (value as (q: string) => D1PreparedStatement).call(target, query),
+            timeoutMs,
+            createQueryContext("session.prepare", query),
+          );
+      }
+
+      if (prop === "batch") {
+        return (statements: D1PreparedStatement[]) =>
+          withDeadline(
+            (value as (s: D1PreparedStatement[]) => Promise<unknown>).call(target, statements.map(unwrapStatement)),
+            timeoutMs,
+            { operation: "session.batch", batchSize: statements.length },
+          );
+      }
+
+      return (value as (...a: unknown[]) => unknown).bind(target);
+    },
+  });
+}
+
 /**
  * Wraps a D1 binding so every query rejects after `timeoutMs` instead of hanging.
  */
@@ -180,6 +211,17 @@ export function withD1Timeout(db: D1Database, timeoutMs: number = DEFAULT_D1_TIM
             (value as (q: string) => Promise<unknown>).call(target, query),
             timeoutMs,
             createQueryContext("exec", query),
+          );
+      }
+
+      if (prop === "withSession") {
+        return (constraintOrBookmark?: D1SessionBookmark | D1SessionConstraint) =>
+          wrapSession(
+            (value as (c?: D1SessionBookmark | D1SessionConstraint) => D1DatabaseSession).call(
+              target,
+              constraintOrBookmark,
+            ),
+            timeoutMs,
           );
       }
 

--- a/wrangler.cron.jsonc
+++ b/wrangler.cron.jsonc
@@ -45,6 +45,11 @@
   // - SERVER_BETTER_STACK_SENTRY_DSN
   "env": {
     "staging": {
+      // Staging shares the production D1 database. Do not duplicate the
+      // production cache warm and YouTube sync load on the same schedule.
+      "triggers": {
+        "crons": []
+      },
       "vars": {
         "STAGE": "staging"
       },


### PR DESCRIPTION
## Summary

Improve D1 resilience and reduce scheduled workload fan-out during recurring database overload incidents.

This adds D1 Sessions API support for replica-eligible reads while preserving the existing query timeout behavior. It also limits concurrent KV and D1 operations in scheduled jobs and disables the staging cron trigger because staging and production currently share the same D1 database.

D1 read replication is currently disabled at the database level and should be enabled separately after deployment and monitoring.

## Changes

- Add a request-scoped D1 session adapter for Drizzle-backed queries.
- Preserve D1 query timeouts for session `prepare`, `batch`, and statement operations.
- Use `first-unconstrained` sessions for anonymous community feed and comment reads.
- Use `first-primary` for signed-in comment reads that require the latest database state.
- Preserve the latest community feed stale-while-revalidate behavior after rebasing onto `main`.
- Limit lazy source-cache KV reads and writes to 32 concurrent operations.
- Limit YouTube community-post upserts to 4 concurrent D1-backed operations.
- Disable the staging cron trigger because it duplicates scheduled work against the production D1 database.
- Add coverage for session constraints, timeout handling, statement unwrapping, and concurrency limits.

## Verification

- [x] I verified the related behavior.
- [x] I ran TypeScript type generation and typecheck, Biome checks on the changed files, and the full Jest suite.
- [ ] (If AI tools were used) The generated content was reviewed by a person.

Additional verification:

- 86 test suites passed.
- 572 tests passed.
- Staging and production cron Wrangler dry-runs passed.
- `git diff --check` passed.

## Related issues

None.