### PR TITLE
feat: link recruitment groups to timeline contents

### DIFF
--- a/app/components/features/events/EventInfoCard.tsx
+++ b/app/components/features/events/EventInfoCard.tsx
@@ -26,14 +26,14 @@ export default function EventInfoCard({ Icon, title, description, color, onClick
   return (
     <ClickableSurface
       onClick={onClick}
-      className={`my-4 flex items-center gap-3 p-3 md:p-4 rounded-lg border ${bgColorClass} ${onClick ? "cursor-pointer hover:opacity-50 transition-opacity" : ""}`}
+      className={`my-3 flex w-full items-center gap-3 rounded-lg border px-3 py-2.5 md:px-4 md:py-3 ${bgColorClass} ${onClick ? "cursor-pointer hover:opacity-50 transition-opacity" : ""}`}
     >
       <div className={`flex-shrink-0 p-2 rounded-lg ${iconBgColorClass}`}>
         <Icon className={`size-4 md:size-5 ${textColorClass}`} />
       </div>
       <div className="grow">
-        <h4 className={`font-semibold ${titleColorClass} mb-1`}>{title}</h4>
-        <p className={`text-sm ${textColorClass}`}>{description}</p>
+        <h4 className={`mb-0.5 text-sm font-semibold ${titleColorClass}`}>{title}</h4>
+        <p className={`text-xs ${textColorClass}`}>{description}</p>
       </div>
       {showArrow && (
         <ArrowRightIcon className="shrink-0 size-4 text-neutral-600 dark:text-neutral-300" />

--- a/app/components/features/events/EventSelector.tsx
+++ b/app/components/features/events/EventSelector.tsx
@@ -171,7 +171,7 @@ export default function EventSelector({
         <div className="sticky top-0 z-10 mb-1 rounded-md border border-input bg-background p-1">
           <input
             type="text"
-            className="min-h-10 w-full rounded-sm bg-background px-3 py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground"
+            className="min-h-10 w-full rounded-sm bg-background px-3 py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground/50"
             placeholder={searchPlaceholder ?? "이벤트 이름으로 찾기"}
             value={searchQuery}
             onChange={(event) => setSearchQuery(event.target.value)}
@@ -303,8 +303,8 @@ function EventSelectorItem({
           {event.until ? formatInstant(event.until, { timeZone: displayTimeZone, format: "MM.DD" }) : "미정"}
         </p>
         {pickupStudents && pickupStudents.length > 0 && (
-          <div className="mt-1.5 max-w-72">
-            <StudentCards students={pickupStudents.slice(0, 8)} pcGrid={6} mobileGrid={6} gap="tight" />
+          <div className="mt-1.5 w-full">
+            <StudentCards students={pickupStudents.slice(0, 8)} layout="wrap" cardSize="xs" gap="tight" />
           </div>
         )}
       </div>

--- a/app/components/features/forms/StudentSelectForm.tsx
+++ b/app/components/features/forms/StudentSelectForm.tsx
@@ -35,7 +35,7 @@ function SearchInput({ searchQuery, setSearchQuery, searchPlaceholder, inputRef 
       <input
         ref={inputRef}
         type="text"
-        className="min-h-10 w-full rounded-sm border border-input bg-background px-3 py-2 text-sm text-foreground outline-none transition placeholder:text-muted-foreground focus:border-ring focus:ring-2 focus:ring-ring/20"
+        className="min-h-10 w-full rounded-sm border border-input bg-background px-3 py-2 text-sm text-foreground outline-none transition placeholder:text-muted-foreground/50 focus:border-ring focus:ring-2 focus:ring-ring/20"
         placeholder={searchPlaceholder ?? "검색해서 찾기..."}
         value={searchQuery}
         onChange={(event) => {

--- a/app/components/primitives/FormContainer.tsx
+++ b/app/components/primitives/FormContainer.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from "react";
+
+type FormContainerProps = {
+  title: string;
+  description?: string;
+  children: ReactNode;
+};
+
+export default function FormContainer({ title, description, children }: FormContainerProps) {
+  return (
+    <section className="space-y-4 rounded-xl bg-neutral-50 p-4 text-card-foreground dark:bg-card md:p-5">
+      <div className="space-y-1">
+        <h2 className="text-base font-semibold">{title}</h2>
+        {description ? <p className="text-sm text-muted-foreground">{description}</p> : null}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+export type { FormContainerProps };

--- a/app/components/primitives/Input.tsx
+++ b/app/components/primitives/Input.tsx
@@ -43,7 +43,7 @@ export default function Input({
         type={type ?? "text"}
         name={name}
         className={cn(
-          "w-full max-w-96 rounded-md border border-input bg-background px-3 text-sm text-foreground placeholder:text-muted-foreground transition-colors outline-none focus:border-ring focus:ring-2 focus:ring-ring/20 disabled:cursor-not-allowed disabled:opacity-50",
+          "w-full max-w-96 rounded-md border border-input bg-background px-3 text-sm text-foreground placeholder:text-muted-foreground/50 transition-colors outline-none focus:border-ring focus:ring-2 focus:ring-ring/20 disabled:cursor-not-allowed disabled:opacity-50",
           size === "sm" ? "min-h-9 py-1.5" : "min-h-10 py-2",
           type === "number" &&
             "[appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none",

--- a/app/components/primitives/Textarea.tsx
+++ b/app/components/primitives/Textarea.tsx
@@ -38,7 +38,7 @@ export default function Textarea({
         name={name}
         rows={rows}
         className={cn(
-          "min-h-24 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground transition-colors outline-none focus:border-ring focus:ring-2 focus:ring-ring/20 disabled:cursor-not-allowed disabled:opacity-50",
+          "min-h-24 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/50 transition-colors outline-none focus:border-ring focus:ring-2 focus:ring-ring/20 disabled:cursor-not-allowed disabled:opacity-50",
           error && "border-destructive focus:border-destructive focus:ring-destructive/20",
           className,
         )}

--- a/app/components/primitives/index.ts
+++ b/app/components/primitives/index.ts
@@ -14,6 +14,8 @@ export type { DropdownOption, DropdownProps } from "./Dropdown";
 export { default as EmptyView } from "./EmptyView";
 export { default as Field } from "./Field";
 export { default as FilterButtons } from "./FilterButtons";
+export { default as FormContainer } from "./FormContainer";
+export type { FormContainerProps } from "./FormContainer";
 export { default as HorizontalScroll } from "./HorizontalScroll";
 export { default as HoverTooltip } from "./HoverTooltip";
 export { default as Input } from "./Input";

--- a/app/domain/pyroxene-schedule.ts
+++ b/app/domain/pyroxene-schedule.ts
@@ -20,6 +20,10 @@ export type PyroxeneScheduleContent =
         rerun: boolean;
         until: UtcIsoString | null;
         student: { uid: string; name: string; initialTier: number } | null;
+        // Set when this content merges recruitments from multiple events sharing one
+        // recruitment group; identifies which event this particular recruitment belongs to,
+        // since favorites are stored per-event rather than per-group.
+        sourceContentUid?: string;
       }[];
       recruitmentPool?: {
         tier2Count: number;
@@ -56,6 +60,7 @@ export type PyroxeneScheduleItem = {
       until: UtcIsoString | null;
       student: { uid: string; name: string; initialTier: number } | null;
       favorited: boolean;
+      sourceContentUid?: string;
     }[];
     recruitmentPool?: {
       tier2Count: number;
@@ -124,7 +129,8 @@ export function buildPyroxeneScheduleItems(
           recruitments: content.recruitments.map((recruitment) => ({
             ...recruitment,
             favorited:
-              recruitment.student !== null && favoritedStudentKeys.has(`${content.uid}:${recruitment.student.uid}`),
+              recruitment.student !== null &&
+              favoritedStudentKeys.has(`${recruitment.sourceContentUid ?? content.uid}:${recruitment.student.uid}`),
           })),
         },
       };

--- a/app/domain/recruitment-identity.ts
+++ b/app/domain/recruitment-identity.ts
@@ -27,3 +27,20 @@ export function getRecruitmentFavoriteKey({
 }): string {
   return student?.uid ?? getProvisionalRecruitmentStudentKey(studentName);
 }
+
+/**
+ * Restricts a recruitment group's recruitments to the students an event's page is allowed
+ * to show. `studentUids: null` means "no restriction" (show every recruitment in the group),
+ * which is the default for events that don't share their recruitment group with another event.
+ */
+export function filterRecruitmentsByStudentUids<T extends { student: { uid: string } | null }>(
+  recruitments: T[],
+  studentUids: string[] | null,
+): T[] {
+  if (studentUids === null) {
+    return recruitments;
+  }
+
+  const allowedUids = new Set(studentUids);
+  return recruitments.filter((recruitment) => recruitment.student !== null && allowedUids.has(recruitment.student.uid));
+}

--- a/app/models/community-feed.ts
+++ b/app/models/community-feed.ts
@@ -28,6 +28,7 @@ export type CommunityFeedStatsTimelineContent = {
   uid: string;
   name: string;
   recruitmentGroupUid: string | null;
+  recruitmentStudentUids: string[] | null;
 };
 
 function parseRecruitmentResultStudents(value: string): RecruitmentResultStudent[] {

--- a/app/models/timeline-content.ts
+++ b/app/models/timeline-content.ts
@@ -1,13 +1,13 @@
 import { and, eq, gte, inArray, isNotNull, isNull, or, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { int, sqliteTable, text } from "drizzle-orm/sqlite-core";
-import { type UtcIsoString, normalizeInstant, nowUtcIso, toUtcIso } from "~/lib/date-time";
-import { cacheKey, fetchSourceCached } from "~/lib/cache";
 import {
-  type TimelineContentNameI18n,
   parseTimelineContentNames,
   selectTimelineContentName,
+  type TimelineContentNameI18n,
 } from "~/domain/timeline-content-name-i18n";
+import { cacheKey, fetchSourceCached } from "~/lib/cache";
+import { normalizeInstant, nowUtcIso, toUtcIso, type UtcIsoString } from "~/lib/date-time";
 
 const ALL_TIMELINE_CONTENTS_META_CACHE_KEY = cacheKey("source", "timeline-content", 1, "all");
 
@@ -47,6 +47,7 @@ export const timelineContentsTable = sqliteTable("timeline_contents", {
   contentUid: text("content_uid"),
   shopContentUid: text("shop_content_uid"),
   recruitmentGroupUid: text("recruitment_group_uid"),
+  recruitmentStudentUids: text("recruitment_student_uids"),
   confirmed: int().notNull().default(0),
   isSpoiler: int("is_spoiler").notNull().default(0),
   tags: text().notNull().default("[]"),
@@ -71,6 +72,8 @@ export type TimelineContent = {
   contentUid: string | null;
   shopContentUid: string | null;
   recruitmentGroupUid: string | null;
+  // null = 그룹의 모든 학생 노출(하위호환 기본값). 값이 있으면 이 이벤트 페이지엔 해당 uid의 학생만 필터링해서 보여줌.
+  recruitmentStudentUids: string[] | null;
   confirmed: boolean;
   isSpoiler: boolean;
   tags: string[];
@@ -106,6 +109,7 @@ function toRaw(row: typeof timelineContentsTable.$inferSelect): RawTimelineConte
     contentUid: row.contentUid ?? null,
     shopContentUid: row.shopContentUid ?? null,
     recruitmentGroupUid: row.recruitmentGroupUid ?? null,
+    recruitmentStudentUids: row.recruitmentStudentUids ? (JSON.parse(row.recruitmentStudentUids) as string[]) : null,
     confirmed: row.confirmed === 1,
     isSpoiler: row.isSpoiler === 1,
     tags: JSON.parse(row.tags) as string[],
@@ -289,6 +293,49 @@ export async function getTimelineContentsByRecruitmentGroupUids(
   return rows.map(toRaw).map(toTimelineContent);
 }
 
+/**
+ * Groups timeline contents by their recruitmentGroupUid without dropping entries when
+ * multiple events share the same group (unlike `new Map(contents.map(...))`, which keeps
+ * only the last event per key).
+ */
+export function groupTimelineContentsByRecruitmentGroupUid(
+  contents: TimelineContent[],
+): Map<string, TimelineContent[]> {
+  const map = new Map<string, TimelineContent[]>();
+  for (const content of contents) {
+    if (!content.recruitmentGroupUid) continue;
+
+    const existing = map.get(content.recruitmentGroupUid);
+    if (existing) {
+      existing.push(content);
+    } else {
+      map.set(content.recruitmentGroupUid, [content]);
+    }
+  }
+  return map;
+}
+
+/**
+ * Picks which of a shared recruitment group's events a given student "belongs to", based on
+ * each event's recruitmentStudentUids allowlist. Events with no allowlist (null) match every
+ * student, which keeps the common one-event-per-group case working unchanged. Falls back to
+ * every candidate event when nothing matches, since a student is expected to always be listed
+ * under at least one event.
+ */
+export function findEventsForRecruitmentStudent(
+  events: TimelineContent[],
+  studentUid: string | null,
+): TimelineContent[] {
+  if (events.length === 0) return [];
+
+  const matches = events.filter(
+    (event) =>
+      event.recruitmentStudentUids === null ||
+      (studentUid !== null && event.recruitmentStudentUids.includes(studentUid)),
+  );
+  return matches.length > 0 ? matches : events;
+}
+
 export async function getContentUidsByRecruitmentGroup(
   env: Env,
 ): Promise<Map<string, { contentType: string; contentUid: string | null }>> {
@@ -312,7 +359,12 @@ async function fetchAllTimelineContentsMetaFromDb(env: Env): Promise<TimelineCon
 }
 
 export async function syncAllTimelineContentsMeta(env: Env, forceRefresh = true): Promise<TimelineContent[]> {
-  return fetchSourceCached(env, ALL_TIMELINE_CONTENTS_META_CACHE_KEY, () => fetchAllTimelineContentsMetaFromDb(env), forceRefresh);
+  return fetchSourceCached(
+    env,
+    ALL_TIMELINE_CONTENTS_META_CACHE_KEY,
+    () => fetchAllTimelineContentsMetaFromDb(env),
+    forceRefresh,
+  );
 }
 
 export async function getAllTimelineContentsMeta(env: Env): Promise<TimelineContent[]> {
@@ -365,6 +417,7 @@ export async function upsertTimelineContent(
     contentUid: input.contentUid,
     shopContentUid: input.shopContentUid,
     recruitmentGroupUid: input.recruitmentGroupUid,
+    recruitmentStudentUids: input.recruitmentStudentUids ? JSON.stringify(input.recruitmentStudentUids) : null,
     confirmed: input.confirmed ? 1 : 0,
     tags: JSON.stringify(input.tags),
   };

--- a/app/routes/$username.pickups._components/PickupHistoryView.tsx
+++ b/app/routes/$username.pickups._components/PickupHistoryView.tsx
@@ -4,14 +4,13 @@ import ContentCommentView from "~/components/features/contents/ContentCommentVie
 import { StudentCards } from "~/components/features/students";
 import { Button } from "~/components/primitives";
 import { useDisplayTimeZone } from "~/contexts/TimeZoneProvider";
-import { type UtcIsoString, formatInstant } from "~/lib/date-time";
+import { formatInstant, type UtcIsoString } from "~/lib/date-time";
 import { pickupGroupTypeLocale } from "~/locales/ko";
 
 type PickupHistoryViewProps = {
   uid: string;
   event: {
-    uid: string;
-    name: string;
+    events: { uid: string; name: string }[];
     type: string;
     since: UtcIsoString;
   };
@@ -118,12 +117,17 @@ function PickupHeader({ event }: { event: PickupHistoryViewProps["event"] }) {
 
   return (
     <div>
-      <Link to={`/events/${event.uid}`} className="inline-block max-w-full hover:underline">
-        <h2 className="whitespace-pre-line font-bold text-base leading-tight md:text-lg">
-          {event.name}
-          <ChevronRightIcon className="ml-1 inline-block size-4 align-[-0.125em]" />
-        </h2>
-      </Link>
+      <h2 className="whitespace-pre-line font-bold text-base leading-tight md:text-lg">
+        {event.events.map((eventItem, index) => (
+          <span key={eventItem.uid}>
+            {index > 0 && " / "}
+            <Link to={`/events/${eventItem.uid}`} className="hover:underline">
+              {eventItem.name}
+            </Link>
+          </span>
+        ))}
+        <ChevronRightIcon className="ml-1 inline-block size-4 align-[-0.125em]" />
+      </h2>
       <p className="mt-1 text-sm text-neutral-500 dark:text-neutral-400">
         {pickupGroupTypeLocale[event.type] ?? "픽업 모집"} |{" "}
         {formatInstant(event.since, { timeZone: displayTimeZone, format: "YYYY-MM-DD" })}

--- a/app/routes/$username.pickups._index.tsx
+++ b/app/routes/$username.pickups._index.tsx
@@ -3,20 +3,20 @@ import { data, redirect, useLoaderData } from "react-router";
 import { getActiveSensei } from "~/auth/authenticator.server";
 import { AddContentButton } from "~/components/features/editor";
 import { SubTitle } from "~/components/primitives";
-import { compareInstantDesc } from "~/lib/date-time";
+import { getRecruitmentResultCountStats, resolveRecruitmentResultStudents } from "~/domain/recruitment-result";
+import { compareInstantAsc, compareInstantDesc } from "~/lib/date-time";
 import { routeError } from "~/lib/http-errors";
+import { getRecruitmentGroupsByUids, getRecruitmentPoolStudents } from "~/models/recruitment";
 import {
   deleteRecruitmentResult,
   getRecruitmentResultComments,
   getRecruitmentResults,
 } from "~/models/recruitment-result";
-import {
-  getRecruitmentResultCountStats,
-  resolveRecruitmentResultStudents,
-} from "~/domain/recruitment-result";
-import { getRecruitmentGroupsByUids, getRecruitmentPoolStudents } from "~/models/recruitment";
 import { getAllStudentsMap } from "~/models/student";
-import { getTimelineContentsByRecruitmentGroupUids } from "~/models/timeline-content";
+import {
+  getTimelineContentsByRecruitmentGroupUids,
+  groupTimelineContentsByRecruitmentGroupUid,
+} from "~/models/timeline-content";
 import { getRouteSensei } from "./$username";
 import PickupHistoryView from "./$username.pickups._components/PickupHistoryView";
 
@@ -74,11 +74,7 @@ export const loader = async ({ context, request, params }: LoaderFunctionArgs) =
 
   const groupMap = new Map(groups.map((group) => [group.uid, group] as const));
   const poolStudentsMap = new Map(poolStudents.map((student) => [student.uid, student] as const));
-  const timelineContentMap = new Map(
-    timelineContents.flatMap((content) =>
-      content.recruitmentGroupUid ? [[content.recruitmentGroupUid, content] as const] : [],
-    ),
-  );
+  const timelineContentsByGroupUid = groupTimelineContentsByRecruitmentGroupUid(timelineContents);
 
   let tier3Count = 0;
   let tier3DrawCount = 0;
@@ -96,8 +92,11 @@ export const loader = async ({ context, request, params }: LoaderFunctionArgs) =
     )
     .map((result) => {
       const group = groupMap.get(result.recruitmentGroupUid);
-      const timelineContent = timelineContentMap.get(result.recruitmentGroupUid);
-      if (!timelineContent) {
+      const timelineContents = [...(timelineContentsByGroupUid.get(result.recruitmentGroupUid) ?? [])].sort((a, b) =>
+        compareInstantAsc(a.startAt, b.startAt),
+      );
+      const firstTimelineContent = timelineContents[0];
+      if (!firstTimelineContent) {
         throw routeError(500, "pickup_history.timeline_content_missing", "모집 이력 정보를 불러오지 못했어요", {
           eventId: result.recruitmentGroupUid,
         });
@@ -135,10 +134,9 @@ export const loader = async ({ context, request, params }: LoaderFunctionArgs) =
       return {
         uid: result.uid,
         event: {
-          uid: timelineContent.uid,
-          name: timelineContent.name,
+          events: timelineContents.map((content) => ({ uid: content.uid, name: content.name })),
           type: group?.recruitmentType ?? "pickup",
-          since: timelineContent.startAt,
+          since: firstTimelineContent.startAt,
         },
         trial: result.trial,
         recruitedStudents: students,

--- a/app/routes/$username.pickups.edit.$id.tsx
+++ b/app/routes/$username.pickups.edit.$id.tsx
@@ -1,7 +1,14 @@
 import { DocumentArrowDownIcon } from "@heroicons/react/24/outline";
 import { useState } from "react";
-import { type ActionFunctionArgs, type LoaderFunctionArgs, type MetaFunction, redirect } from "react-router";
-import { useLoaderData, useSearchParams, useSubmit } from "react-router";
+import {
+  type ActionFunctionArgs,
+  type LoaderFunctionArgs,
+  type MetaFunction,
+  redirect,
+  useLoaderData,
+  useSearchParams,
+  useSubmit,
+} from "react-router";
 import { getActiveSensei } from "~/auth/authenticator.server";
 import { EventSelector } from "~/components/features/events";
 import { Button, SubTitle, Textarea, Title } from "~/components/primitives";
@@ -13,9 +20,16 @@ import {
   mergeEditableRecruitmentResultStudents,
   resolveRecruitmentResultStudents,
 } from "~/domain/recruitment-result";
-import { compareInstantDesc, formatInstant, isInstantBefore, nowUtcIso, toUtcIso } from "~/lib/date-time";
+import {
+  compareInstantAsc,
+  compareInstantDesc,
+  formatInstant,
+  isInstantBefore,
+  nowUtcIso,
+  toUtcIso,
+} from "~/lib/date-time";
 import { routeError } from "~/lib/http-errors";
-import { type PickupHistory, getPickupHistory } from "~/models/pickup-history";
+import { getPickupHistory, type PickupHistory } from "~/models/pickup-history";
 import { getAllHistoricalRecruitmentGroups, getRecruitmentGroupByUid } from "~/models/recruitment";
 import {
   getRecruitmentResult,
@@ -23,7 +37,10 @@ import {
   upsertRecruitmentResult,
 } from "~/models/recruitment-result";
 import { getAllStudents } from "~/models/student";
-import { getTimelineContentsByRecruitmentGroupUids } from "~/models/timeline-content";
+import {
+  getTimelineContentsByRecruitmentGroupUids,
+  groupTimelineContentsByRecruitmentGroupUid,
+} from "~/models/timeline-content";
 import PickupHistoryEditor from "./$username.pickups._components/PickupHistoryEditor";
 import PickupHistoryImporter from "./$username.pickups._components/PickupHistoryImporter";
 
@@ -154,13 +171,11 @@ export const loader = async ({ context, request, params }: LoaderFunctionArgs) =
     env,
     pickupGroups.map((group) => group.uid),
   );
-  const timelineContentMap = new Map(
-    timelineContents.map((content) => [content.recruitmentGroupUid, content] as const),
-  );
+  const timelineContentsByGroupUid = groupTimelineContentsByRecruitmentGroupUid(timelineContents);
   const allStudentsMap = Object.fromEntries(allStudentsList.map((student) => [student.uid, student] as const));
 
   const missingTimelineGroupUids = pickupGroups
-    .filter((group) => !timelineContentMap.has(group.uid))
+    .filter((group) => !timelineContentsByGroupUid.has(group.uid))
     .map((group) => group.uid);
   if (missingTimelineGroupUids.length > 0) {
     throw routeError(500, "pickup_history.timeline_content_missing", "모집 이력 정보를 불러오지 못했어요", {
@@ -169,17 +184,22 @@ export const loader = async ({ context, request, params }: LoaderFunctionArgs) =
   }
 
   const events = pickupGroups.map((group) => {
-    const timelineContent = timelineContentMap.get(group.uid);
-    if (!timelineContent) {
+    // A group can be shared by more than one event (e.g. a rerun and its permanent
+    // counterpart); this screen treats the whole group as one option, labeled with every
+    // event's name joined by "/".
+    const groupTimelineContents = [...(timelineContentsByGroupUid.get(group.uid) ?? [])].sort((a, b) =>
+      compareInstantAsc(a.startAt, b.startAt),
+    );
+    if (groupTimelineContents.length === 0) {
       throw new Error(`timeline content is missing for recruitment group: ${group.uid}`);
     }
 
     return {
       uid: group.uid,
-      name: timelineContent.name,
+      name: groupTimelineContents.map((content) => content.name).join(" / "),
       since: toUtcIso(group.startAt),
       until: group.endAt ? toUtcIso(group.endAt) : null,
-      isSpoiler: timelineContent.isSpoiler,
+      isSpoiler: groupTimelineContents.some((content) => content.isSpoiler),
       recruitments: group.recruitments
         .filter((r) => r.pickup && r.student)
         .map((r) => ({
@@ -256,7 +276,13 @@ export const action = async ({ context, request, params }: ActionFunctionArgs) =
       recruitmentGroupUid: data.eventUid,
     });
   }
-  const timelineContent = (await getTimelineContentsByRecruitmentGroupUids(env, [data.eventUid]))[0];
+  // When the group is shared by multiple events, default to the earliest one as the
+  // representative content (e.g. for community post linking). See TODO in project notes:
+  // this policy isn't user-facing yet.
+  const groupTimelineContents = (await getTimelineContentsByRecruitmentGroupUids(env, [data.eventUid])).sort((a, b) =>
+    compareInstantAsc(a.startAt, b.startAt),
+  );
+  const timelineContent = groupTimelineContents[0];
   const exchangeableStudentMap = new Map(
     recruitmentGroup.recruitments.flatMap((recruitment) => {
       if (!canExchangeRecruitmentStudent(recruitment)) {
@@ -353,9 +379,9 @@ export default function EditPickup() {
     }
   }
 
-  let initialTotalCount: number | undefined = undefined;
-  let initialTier3Count: number | undefined = undefined;
-  let initialTier3StudentUids: string[] | undefined = undefined;
+  let initialTotalCount: number | undefined;
+  let initialTier3Count: number | undefined;
+  let initialTier3StudentUids: string[] | undefined;
   if (currentPickupHistory?.result) {
     const recordedTrials = currentPickupHistory.result
       .map((trial) => trial.trial)

--- a/app/routes/$username.pickups.edit.$id.tsx
+++ b/app/routes/$username.pickups.edit.$id.tsx
@@ -11,7 +11,7 @@ import {
 } from "react-router";
 import { getActiveSensei } from "~/auth/authenticator.server";
 import { EventSelector } from "~/components/features/events";
-import { Button, SubTitle, Textarea, Title } from "~/components/primitives";
+import { Button, FormContainer, Textarea, Title } from "~/components/primitives";
 import { useDisplayTimeZone } from "~/contexts/TimeZoneProvider";
 import {
   createRecruitmentResultStudentsFromPickupHistory,
@@ -449,87 +449,91 @@ export default function EditPickup() {
   };
 
   return (
-    <>
+    <div className="space-y-8">
       <Title text="모집 이력 관리" />
 
-      <SubTitle text="모집 이벤트" />
-      {isEditing ? (
-        initialEvent && (
-          <div className="rounded-lg border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-900">
-            <p className="whitespace-pre-line font-semibold text-neutral-950 dark:text-neutral-50">
-              {initialEvent.name}
-            </p>
-            <p className="mt-1 text-sm text-neutral-500 dark:text-neutral-400">
-              {formatInstant(initialEvent.since, { timeZone: displayTimeZone, format: "YYYY-MM-DD" })}
-            </p>
-          </div>
-        )
-      ) : (
-        <EventSelector
-          label="이벤트"
-          description="모집을 진행한 이벤트를 선택해주세요."
-          name="eventUid"
-          events={events}
-          currentEventUid={eventUid}
-          maxVisibleEvents={PICKUP_EVENT_SELECTOR_LIMIT}
-          placeholder="이벤트 선택"
-          searchPlaceholder="이벤트 또는 모집 학생 이름으로 찾기"
-          onSelect={(uid) => {
-            setEventUid(uid);
-            setExchangedStudentUids([]);
-          }}
-        />
-      )}
-
-      <SubTitle text="모집 결과" />
-      <div className="mb-4">
-        <Button
-          text={showImporter ? "외부 데이터 닫기" : "외부 데이터 가져오기"}
-          icon={DocumentArrowDownIcon}
-          variant="tint"
-          onClick={() => setShowImporter((prev) => !prev)}
-        />
-      </div>
-      {showImporter && (
-        <div className="mb-6 rounded-lg border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-900">
-          <PickupHistoryImporter
-            tier3Students={tier3Students}
-            onImport={({ totalCount, tier3Count, tier3StudentIds }) => {
-              setTotalCount(totalCount);
-              setTier3Count(tier3Count);
-              setTier3StudentUids(tier3StudentIds);
+      <FormContainer title="모집 이벤트">
+        {isEditing ? (
+          initialEvent && (
+            <div className="rounded-lg border border-border bg-background p-4">
+              <p className="whitespace-pre-line font-semibold text-foreground">{initialEvent.name}</p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {formatInstant(initialEvent.since, { timeZone: displayTimeZone, format: "YYYY-MM-DD" })}
+              </p>
+            </div>
+          )
+        ) : (
+          <EventSelector
+            label="이벤트"
+            description="모집을 진행한 이벤트를 선택해주세요."
+            name="eventUid"
+            events={events}
+            currentEventUid={eventUid}
+            maxVisibleEvents={PICKUP_EVENT_SELECTOR_LIMIT}
+            placeholder="이벤트 선택"
+            searchPlaceholder="이벤트 또는 모집 학생 이름으로 찾기"
+            onSelect={(uid) => {
+              setEventUid(uid);
+              setExchangedStudentUids([]);
             }}
           />
-        </div>
-      )}
-      <PickupHistoryEditor
-        tier3Students={tier3Students}
-        totalCount={totalCount}
-        tier3Count={tier3Count}
-        tier3StudentIds={visibleTier3StudentUids}
-        skipTier3StudentList={skipTier3StudentList}
-        exchangedStudentIds={exchangedStudentUids}
-        exchangeableStudents={
-          selectedEvent?.recruitments.flatMap((recruitment) =>
-            canExchangeRecruitmentStudent(recruitment) && recruitment.student ? [recruitment.student] : [],
-          ) ?? []
-        }
-        onTotalCountChange={handleTotalCountChange}
-        onTier3CountChange={handleTier3CountChange}
-        onTier3StudentIdsChange={setTier3StudentUids}
-        onSkipTier3StudentListChange={setSkipTier3StudentList}
-        onExchangedStudentIdsChange={setExchangedStudentUids}
-      />
+        )}
+      </FormContainer>
 
-      <SubTitle text="모집 결과 의견 (선택)" />
-      <Textarea
-        value={comment}
-        rows={4}
-        description="입력하지 않아도 저장할 수 있어요."
-        placeholder="남긴 의견은 다른 사람에게 공개돼요."
-        onChange={setComment}
-      />
-      <div className="mt-8 flex flex-col items-start gap-2">
+      <FormContainer
+        title="모집 결과"
+        description="총 모집 횟수와 획득한 ★3 학생, 모집 포인트 교환 학생을 입력해주세요."
+      >
+        <div>
+          <Button
+            text={showImporter ? "외부 데이터 닫기" : "외부 데이터 가져오기"}
+            icon={DocumentArrowDownIcon}
+            variant="tint"
+            onClick={() => setShowImporter((prev) => !prev)}
+          />
+        </div>
+        {showImporter && (
+          <div className="rounded-lg border border-border bg-background p-4">
+            <PickupHistoryImporter
+              tier3Students={tier3Students}
+              onImport={({ totalCount, tier3Count, tier3StudentIds }) => {
+                setTotalCount(totalCount);
+                setTier3Count(tier3Count);
+                setTier3StudentUids(tier3StudentIds);
+              }}
+            />
+          </div>
+        )}
+        <PickupHistoryEditor
+          tier3Students={tier3Students}
+          totalCount={totalCount}
+          tier3Count={tier3Count}
+          tier3StudentIds={visibleTier3StudentUids}
+          skipTier3StudentList={skipTier3StudentList}
+          exchangedStudentIds={exchangedStudentUids}
+          exchangeableStudents={
+            selectedEvent?.recruitments.flatMap((recruitment) =>
+              canExchangeRecruitmentStudent(recruitment) && recruitment.student ? [recruitment.student] : [],
+            ) ?? []
+          }
+          onTotalCountChange={handleTotalCountChange}
+          onTier3CountChange={handleTier3CountChange}
+          onTier3StudentIdsChange={setTier3StudentUids}
+          onSkipTier3StudentListChange={setSkipTier3StudentList}
+          onExchangedStudentIdsChange={setExchangedStudentUids}
+        />
+        <Textarea
+          label="모집 결과 의견"
+          value={comment}
+          rows={4}
+          description="입력하지 않아도 저장할 수 있어요."
+          placeholder="남긴 의견은 다른 사람에게 공개돼요."
+          onChange={setComment}
+          containerClassName="mt-0 mb-0"
+        />
+      </FormContainer>
+
+      <div className="flex flex-col items-start gap-2">
         <Button
           text="모집 결과 저장"
           variant="primary"
@@ -540,6 +544,6 @@ export default function EditPickup() {
           <p className="text-sm text-neutral-500 dark:text-neutral-400">{saveUnavailableReason}</p>
         )}
       </div>
-    </>
+    </div>
   );
 }

--- a/app/routes/edit._index.tsx
+++ b/app/routes/edit._index.tsx
@@ -5,12 +5,12 @@ import {
   KeyIcon,
   LinkIcon,
 } from "@heroicons/react/24/outline";
-import { type ElementType, type ReactNode, useEffect, useState } from "react";
+import { type ElementType, useEffect, useState } from "react";
 import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from "react-router";
 import { Form, Link, data, redirect, useActionData, useLoaderData, useNavigation } from "react-router";
 import { getActiveSensei, getAuthenticator, sessionStorage } from "~/auth/authenticator.server";
 import { ProfileEditor } from "~/components/features/profile";
-import { Button, Input, Title } from "~/components/primitives";
+import { Button, FormContainer, Input, Title } from "~/components/primitives";
 import { nowUtcIso } from "~/lib/date-time";
 import { cn } from "~/lib/utils";
 import { type AuthProvider, getAuthIdentityStatuses } from "~/models/auth-identity";
@@ -156,26 +156,6 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
   return data<ActionData>({ intent, success: true, savedAt: nowUtcIso() });
 };
 
-function EditSection({
-  title,
-  description,
-  children,
-}: {
-  title: string;
-  description?: string;
-  children: ReactNode;
-}) {
-  return (
-    <section className="space-y-5 rounded-xl border border-border bg-card p-5 text-card-foreground">
-      <div className="space-y-1">
-        <h2 className="text-lg font-semibold">{title}</h2>
-        {description ? <p className="text-sm text-muted-foreground">{description}</p> : null}
-      </div>
-      {children}
-    </section>
-  );
-}
-
 function SaveSubmitButton({
   idleLabel,
   isSubmitting,
@@ -308,7 +288,7 @@ export default function EditProfile() {
     <div className="space-y-8">
       <Title text="프로필 관리" />
 
-      <EditSection title="프로필 정보" description="프로필 정보는 다른 사람에게 표시돼요">
+      <FormContainer title="프로필 정보" description="프로필 정보는 다른 사람에게 표시돼요">
         <Form
           method="put"
           className="space-y-6"
@@ -327,9 +307,9 @@ export default function EditProfile() {
             />
           </div>
         </Form>
-      </EditSection>
+      </FormContainer>
 
-      <EditSection title="블루 아카이브 계정 정보" description="계정 정보는 다른 사람이 확인할 수 없어요">
+      <FormContainer title="블루 아카이브 계정 정보" description="계정 정보는 다른 사람이 확인할 수 없어요">
         <Form
           method="put"
           className="space-y-6"
@@ -358,9 +338,9 @@ export default function EditProfile() {
             />
           </div>
         </Form>
-      </EditSection>
+      </FormContainer>
 
-      <EditSection title="인증 및 보안">
+      <FormContainer title="인증 및 보안">
         <div className="space-y-3">
           {authMessage ? (
             <p
@@ -384,7 +364,7 @@ export default function EditProfile() {
           />
           <SettingsLink to="/signout" title="로그아웃" Icon={ArrowRightStartOnRectangleIcon} tone="destructive" />
         </div>
-      </EditSection>
+      </FormContainer>
     </div>
   );
 }

--- a/app/routes/events.$uid._index.tsx
+++ b/app/routes/events.$uid._index.tsx
@@ -1,8 +1,10 @@
-import { useLoaderData } from "react-router";
+import { SparklesIcon } from "@heroicons/react/24/outline";
 import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from "react-router";
-import { redirect } from "react-router";
+import { redirect, useLoaderData } from "react-router";
 import { getActiveSensei } from "~/auth/authenticator.server";
 import { EventHeader, Recruitments } from "~/components/features/events";
+import { PageLink } from "~/components/primitives";
+import { filterRecruitmentsByStudentUids, getRecruitmentFavoriteKey } from "~/domain/recruitment-identity";
 import { toUtcIso } from "~/lib/date-time";
 import { canonicalLink } from "~/lib/seo";
 import { getNestedContentComments } from "~/models/content";
@@ -13,8 +15,7 @@ import {
   unfavoriteStudent,
 } from "~/models/favorite-students";
 import { getRecruitmentGroupByUid } from "~/models/recruitment";
-import { getRecruitmentFavoriteKey } from "~/domain/recruitment-identity";
-import { getTimelineContent } from "~/models/timeline-content";
+import { getTimelineContent, getTimelineContentsByRecruitmentGroupUids } from "~/models/timeline-content";
 import EventComment from "./events.$uid._components/EventComment";
 
 export const loader = async ({ params, context, request }: LoaderFunctionArgs) => {
@@ -28,8 +29,17 @@ export const loader = async ({ params, context, request }: LoaderFunctionArgs) =
     throw new Response("Not Found", { status: 404 });
   }
 
-  const recruitments = content.recruitmentGroupUid
-    ? ((await getRecruitmentGroupByUid(env, content.recruitmentGroupUid))?.recruitments ?? [])
+  const recruitmentGroup = content.recruitmentGroupUid
+    ? await getRecruitmentGroupByUid(env, content.recruitmentGroupUid)
+    : null;
+  const recruitments = filterRecruitmentsByStudentUids(
+    recruitmentGroup?.recruitments ?? [],
+    content.recruitmentStudentUids,
+  );
+  const siblingEvents = content.recruitmentGroupUid
+    ? (await getTimelineContentsByRecruitmentGroupUids(env, [content.recruitmentGroupUid])).filter(
+        (sibling) => sibling.uid !== content.uid,
+      )
     : [];
   const eventContent = {
     name: content.name,
@@ -70,6 +80,7 @@ export const loader = async ({ params, context, request }: LoaderFunctionArgs) =
     allComments,
     me: currentUser ? { username: currentUser.username } : null,
     eventUid: timelineUid,
+    siblingEvents: siblingEvents.map((sibling) => ({ uid: sibling.uid, name: sibling.name })),
   };
 };
 
@@ -126,7 +137,7 @@ export const meta: MetaFunction<typeof loader> = ({ loaderData, params, location
 };
 
 export default function EventIndex() {
-  const { eventContent, signedIn, allComments, me, eventUid } = useLoaderData<typeof loader>();
+  const { eventContent, signedIn, allComments, me, eventUid, siblingEvents } = useLoaderData<typeof loader>();
   return (
     <div className="w-full">
       <div className="my-2 lg:my-8">
@@ -141,6 +152,16 @@ export default function EventIndex() {
           videos={eventContent.videos}
         />
       </div>
+
+      {siblingEvents.map((sibling) => (
+        <PageLink
+          key={sibling.uid}
+          Icon={SparklesIcon}
+          title="동시 개최 픽업 이벤트"
+          description={`"${sibling.name}"에서도 같은 모집이 진행돼요`}
+          to={`/events/${sibling.uid}`}
+        />
+      ))}
 
       {eventContent.recruitments.length > 0 && (
         <Recruitments recruitments={eventContent.recruitments} signedIn={signedIn} />

--- a/app/routes/events.$uid._index.tsx
+++ b/app/routes/events.$uid._index.tsx
@@ -1,9 +1,8 @@
 import { SparklesIcon } from "@heroicons/react/24/outline";
 import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from "react-router";
-import { redirect, useLoaderData } from "react-router";
+import { redirect, useLoaderData, useNavigate } from "react-router";
 import { getActiveSensei } from "~/auth/authenticator.server";
-import { EventHeader, Recruitments } from "~/components/features/events";
-import { PageLink } from "~/components/primitives";
+import { EventHeader, EventInfoCard, Recruitments } from "~/components/features/events";
 import { filterRecruitmentsByStudentUids, getRecruitmentFavoriteKey } from "~/domain/recruitment-identity";
 import { toUtcIso } from "~/lib/date-time";
 import { canonicalLink } from "~/lib/seo";
@@ -138,6 +137,8 @@ export const meta: MetaFunction<typeof loader> = ({ loaderData, params, location
 
 export default function EventIndex() {
   const { eventContent, signedIn, allComments, me, eventUid, siblingEvents } = useLoaderData<typeof loader>();
+  const navigate = useNavigate();
+
   return (
     <div className="w-full">
       <div className="my-2 lg:my-8">
@@ -154,12 +155,13 @@ export default function EventIndex() {
       </div>
 
       {siblingEvents.map((sibling) => (
-        <PageLink
+        <EventInfoCard
           key={sibling.uid}
           Icon={SparklesIcon}
-          title="동시 개최 픽업 이벤트"
-          description={`"${sibling.name}"에서도 같은 모집이 진행돼요`}
-          to={`/events/${sibling.uid}`}
+          title="모집 동시 개최"
+          description={`"${sibling.name}" 이벤트 모집과 동시에 개최되어 모집 포인트(천장)을 공유해요.`}
+          onClick={() => navigate(`/events/${sibling.uid}`)}
+          showArrow
         />
       ))}
 

--- a/app/routes/futures._components/FutureRecruitmentTable.tsx
+++ b/app/routes/futures._components/FutureRecruitmentTable.tsx
@@ -12,7 +12,7 @@ import { Link } from "react-router";
 import { StudentCard } from "~/components/features/students";
 import { EmptyView } from "~/components/primitives";
 import { useDisplayTimeZone } from "~/contexts/TimeZoneProvider";
-import { formatInstant, isInstantAfter, isInstantBefore, nowUtcIso } from "~/lib/date-time";
+import { formatInstant, getInstantTime, isInstantAfter, isInstantBefore, nowUtcIso } from "~/lib/date-time";
 import { contentTypeLocale, recruitmentLabelLocale } from "~/locales/ko";
 import { bossImageUrl } from "~/models/assets";
 import type { RecruitmentCompletionMeta } from "~/models/recruitment-result";
@@ -128,6 +128,7 @@ function DesktopRecruitmentTable({
                 <TableCell rowSpan={row.recruitmentRowSpan}>
                   <RecruitmentStudents
                     groups={row.recruitments}
+                    rowUntil={row.until}
                     favoritedStudents={favoritedStudents}
                     favoritedCounts={favoritedCounts}
                     completedRecruitmentStudents={completedRecruitmentStudents}
@@ -184,6 +185,7 @@ function PeriodLabel({ since, until }: { since: string; until: string }) {
 
 function RecruitmentStudents({
   groups,
+  rowUntil,
   favoritedStudents,
   favoritedCounts,
   completedRecruitmentStudents,
@@ -192,6 +194,7 @@ function RecruitmentStudents({
   onRecruitmentComplete,
 }: {
   groups: FutureRecruitmentTableRecruitmentGroup[];
+  rowUntil: string;
   favoritedStudents: { contentUid: string; studentUid: string }[];
   favoritedCounts: { contentUid: string; studentUid: string; count: number }[];
   completedRecruitmentStudents: { recruitmentGroupUid: string; studentUid: string }[];
@@ -221,7 +224,9 @@ function RecruitmentStudents({
   }
 
   if (groupedStudents.length === 1) {
-    return <RecruitmentContentStudentGroup group={groupedStudents[0]} now={now} showContentName={false} />;
+    return (
+      <RecruitmentContentStudentGroup group={groupedStudents[0]} rowUntil={rowUntil} now={now} showContentName={false} />
+    );
   }
 
   return (
@@ -230,6 +235,7 @@ function RecruitmentStudents({
         <RecruitmentContentStudentGroup
           key={group.content.uid}
           group={group}
+          rowUntil={rowUntil}
           now={now}
           showContentName
           className={index > 0 ? "border-t border-neutral-100 pt-2 dark:border-neutral-800" : undefined}
@@ -241,17 +247,24 @@ function RecruitmentStudents({
 
 function RecruitmentContentStudentGroup({
   group,
+  rowUntil,
   now,
   showContentName,
   className,
 }: {
   group: FutureRecruitmentTableContentStudentGroup;
+  rowUntil: string;
   now: string;
   showContentName: boolean;
   className?: string;
 }) {
   const tags = getRecruitmentContentTags(group.content, now);
-  const showHeader = showContentName || tags.length > 0;
+  const timeZone = useDisplayTimeZone();
+  const groupUntilDateKey = formatInstant(group.until, { timeZone, format: "YYYY-MM-DD" });
+  const rowUntilDateKey = formatInstant(rowUntil, { timeZone, format: "YYYY-MM-DD" });
+  const earlyEndLabel =
+    groupUntilDateKey < rowUntilDateKey ? `${formatInstant(group.until, { timeZone, format: "MM/DD" })} 종료` : null;
+  const showHeader = showContentName || earlyEndLabel !== null || tags.length > 0;
 
   return (
     <div className={className ? `space-y-1 ${className}` : "space-y-1"}>
@@ -262,6 +275,7 @@ function RecruitmentContentStudentGroup({
               {group.content.name}
             </p>
           )}
+          {earlyEndLabel && <RecruitmentContentTag text={earlyEndLabel} color="neutral" />}
           {tags.map((tag) => (
             <RecruitmentContentTag key={tag.text} {...tag} />
           ))}
@@ -279,7 +293,7 @@ function RecruitmentContentTag({
 }: {
   Icon?: React.ElementType;
   text: string;
-  color: "current" | "green" | "yellow";
+  color: "current" | "green" | "yellow" | "neutral";
 }) {
   if (color === "current") {
     return (
@@ -293,6 +307,9 @@ function RecruitmentContentTag({
   let className = "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200";
   if (color === "green") {
     className = "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200";
+  }
+  if (color === "neutral") {
+    className = "bg-neutral-100 text-neutral-600 dark:bg-neutral-800 dark:text-neutral-300";
   }
 
   return (
@@ -387,6 +404,7 @@ type FutureRecruitmentTableStudent = ReturnType<typeof getRecruitmentStudentGrou
 
 type FutureRecruitmentTableContentStudentGroup = {
   content: FutureRecruitmentTableContent;
+  until: string;
   students: FutureRecruitmentTableStudent[];
 };
 
@@ -413,9 +431,12 @@ function getRecruitmentContentStudentGroups(
     if (!contentGroup) {
       contentGroup = {
         content: group.content,
+        until: group.until,
         students: [],
       };
       contentGroups.push(contentGroup);
+    } else if (getInstantTime(group.until) > getInstantTime(contentGroup.until)) {
+      contentGroup.until = group.until;
     }
 
     contentGroup.students.push(

--- a/app/routes/futures._components/future-recruitment-table-model.ts
+++ b/app/routes/futures._components/future-recruitment-table-model.ts
@@ -149,34 +149,24 @@ function getContentPeriod(content: FutureRecruitmentTableContent): { since: UtcI
   return { since: content.startAt, until: content.endAt };
 }
 
+function getRecruitmentPeriod(
+  content: FutureRecruitmentTableContent,
+  recruitment: FutureRecruitmentTableRecruitment,
+): { since: UtcIsoString; until: UtcIsoString } | null {
+  const until = recruitment.until ?? content.endAt;
+  if (!until || getInstantTime(recruitment.since) >= getInstantTime(until)) {
+    return null;
+  }
+
+  return { since: recruitment.since, until };
+}
+
 function getDateKey(instant: UtcIsoString, timeZone: string): DateKey {
   return formatInstantDateKey(instant, timeZone);
 }
 
 function compareDateKeys(a: DateKey, b: DateKey): number {
   return a < b ? -1 : a > b ? 1 : 0;
-}
-
-function addDaysToDateKey(dateKey: DateKey, days: number, timeZone: string): DateKey {
-  return dayjs.tz(dateKey, normalizeTimeZone(timeZone)).add(days, "day").format("YYYY-MM-DD");
-}
-
-function addWeeklyBoundaryKeys(
-  boundaryKeys: Set<DateKey>,
-  sinceKey: DateKey,
-  untilKey: DateKey,
-  timeZone: string,
-): void {
-  boundaryKeys.add(sinceKey);
-  boundaryKeys.add(untilKey);
-
-  for (
-    let currentKey = addDaysToDateKey(sinceKey, 7, timeZone);
-    currentKey < untilKey;
-    currentKey = addDaysToDateKey(currentKey, 7, timeZone)
-  ) {
-    boundaryKeys.add(currentKey);
-  }
 }
 
 function toBoundaryInstant(dateKey: DateKey, timeZone: string): UtcIsoString {
@@ -226,7 +216,7 @@ export function buildFutureRecruitmentTableRows(
 ): FutureRecruitmentTableRow[] {
   const recruitmentGroups: InternalRecruitmentGroup[] = contents.flatMap((content, contentIndex) =>
     content.recruitments.flatMap((recruitment, recruitmentIndex) => {
-      const period = getContentPeriod(content);
+      const period = getRecruitmentPeriod(content, recruitment);
       if (!period) {
         return [];
       }
@@ -234,38 +224,40 @@ export function buildFutureRecruitmentTableRows(
     }),
   );
 
-  const boundaryKeys = new Set<DateKey>();
+  const rowRecruitmentsBySince = new Map<string, InternalRecruitmentGroup[]>();
   for (const group of recruitmentGroups) {
-    addWeeklyBoundaryKeys(boundaryKeys, getDateKey(group.since, timeZone), getDateKey(group.until, timeZone), timeZone);
+    const sinceKey = getDateKey(group.since, timeZone);
+    rowRecruitmentsBySince.set(sinceKey, [...(rowRecruitmentsBySince.get(sinceKey) ?? []), group]);
   }
-  const boundaries = [...boundaryKeys].sort(compareDateKeys);
 
-  const rowPeriods = boundaries.slice(0, -1).flatMap((sinceKey, index) => {
-    const untilKey = boundaries[index + 1];
-    const rowRecruitments = recruitmentGroups
-      .filter((group) => getDateKey(group.since, timeZone) < untilKey && getDateKey(group.until, timeZone) > sinceKey)
-      .sort(
+  const rowPeriods = [...rowRecruitmentsBySince.entries()]
+    .map(([sinceKey, rowRecruitments]) => {
+      const untilKey = rowRecruitments
+        .map((group) => getDateKey(group.until, timeZone))
+        .sort(compareDateKeys)
+        .at(-1) as DateKey;
+      const sortedRecruitments = rowRecruitments.sort(
         (a, b) =>
           compareContentsByTimelineOrder(a, b) ||
-          compareInstantAsc(a.since, b.since) ||
+          compareDateKeys(getDateKey(a.until, timeZone), getDateKey(b.until, timeZone)) ||
           a.recruitmentIndex - b.recruitmentIndex,
       );
 
-    if (rowRecruitments.length === 0) {
-      return [];
-    }
-
-    return [
-      {
+      return {
         since: toBoundaryInstant(sinceKey, timeZone),
         until: toBoundaryInstant(untilKey, timeZone),
         sinceKey,
         untilKey,
-        recruitments: rowRecruitments,
-        recruitmentCellKey: getRecruitmentCellKey(rowRecruitments),
-      },
-    ];
-  });
+        recruitments: sortedRecruitments,
+        recruitmentCellKey: getRecruitmentCellKey(sortedRecruitments),
+      };
+    })
+    .sort(
+      (a, b) =>
+        compareDateKeys(a.sinceKey, b.sinceKey) ||
+        compareInstantAsc(a.recruitments[0].since, b.recruitments[0].since) ||
+        a.recruitments[0].contentIndex - b.recruitments[0].contentIndex,
+    );
 
   const auxiliaryContentsByRow = new Map<number, { content: FutureRecruitmentTableContent; contentIndex: number }[]>();
   for (const [contentIndex, content] of contents.entries()) {

--- a/app/routes/students.$id.tsx
+++ b/app/routes/students.$id.tsx
@@ -2,7 +2,7 @@ import { ArrowTopRightOnSquareIcon, ChatBubbleLeftRightIcon, InformationCircleIc
 import type { LoaderFunctionArgs, MetaFunction } from "react-router";
 import { Outlet, useLoaderData, useLocation } from "react-router";
 import { getActiveSensei } from "~/auth/authenticator.server";
-import { Page, createPageErrorBoundary } from "~/components/features/layout";
+import { createPageErrorBoundary, Page } from "~/components/features/layout";
 import { StudentInfo } from "~/components/features/students";
 import { isStudentNotFoundError } from "~/lib/baql/errors";
 import { toUtcIso } from "~/lib/date-time";
@@ -14,7 +14,36 @@ import { getRecruitedStudentTiers } from "~/models/recruited-student";
 import { formatStudentFullName, getAllStudentsMap, getStudentDetail } from "~/models/student";
 import { getStudentGradingsByStudentWithUsers } from "~/models/student-grading";
 import { getTagCountsByStudent } from "~/models/student-grading-tag";
-import { getTimelineContentsByRecruitmentGroupUids } from "~/models/timeline-content";
+import {
+  findEventsForRecruitmentStudent,
+  getTimelineContentsByRecruitmentGroupUids,
+  groupTimelineContentsByRecruitmentGroupUid,
+} from "~/models/timeline-content";
+
+/**
+ * Restricts the events shown on a student's page to the ones actually listing that student,
+ * since a recruitment group can be shared by multiple events (e.g. a rerun and its permanent
+ * counterpart) that each only feature a subset of the group's students.
+ */
+export function getStudentRelevantTimelineContents(
+  timelineContents: Awaited<ReturnType<typeof getTimelineContentsByRecruitmentGroupUids>>,
+  recruitmentGroupUids: string[],
+  studentUid: string,
+) {
+  const timelineContentsByGroupUid = groupTimelineContentsByRecruitmentGroupUid(timelineContents);
+  const relevantContents = recruitmentGroupUids.flatMap((groupUid) =>
+    findEventsForRecruitmentStudent(timelineContentsByGroupUid.get(groupUid) ?? [], studentUid),
+  );
+
+  const seenUids = new Set<string>();
+  return relevantContents.filter((content) => {
+    if (seenUids.has(content.uid)) {
+      return false;
+    }
+    seenUids.add(content.uid);
+    return true;
+  });
+}
 
 export const loader = async ({ params, context, request }: LoaderFunctionArgs) => {
   const uid = params.id;
@@ -106,13 +135,15 @@ export const loader = async ({ params, context, request }: LoaderFunctionArgs) =
       schaleDbId: student.schaleDbId,
       releaseAt: student.releaseAt ? toUtcIso(student.releaseAt) : null,
     },
-    recruitments: timelineContents.map((content) => ({
-      uid: content.uid,
-      name: content.name,
-      since: content.startAt,
-      until: content.endAt,
-      imageUrl: content.imageUrl ?? null,
-    })),
+    recruitments: getStudentRelevantTimelineContents(timelineContents, recruitmentGroupUids, student.uid).map(
+      (content) => ({
+        uid: content.uid,
+        name: content.name,
+        since: content.startAt,
+        until: content.endAt,
+        imageUrl: content.imageUrl ?? null,
+      }),
+    ),
     tagCounts,
     allGradings: sortedGradings.map((grading) => ({
       ...grading,

--- a/app/views/community.ts
+++ b/app/views/community.ts
@@ -1,13 +1,14 @@
+import { filterRecruitmentsByStudentUids } from "~/domain/recruitment-identity";
 import type { CommunityFeedPost } from "~/models/community";
 import {
   type CommunityFeedStatsRecruitmentGroup,
   type CommunityFeedStatsTimelineContent,
-  type RecruitmentFeedStats,
   getRecruitmentFeedStatsByPostUid,
+  type RecruitmentFeedStats,
 } from "~/models/community-feed";
 import { getRecruitmentGroupsByUids } from "~/models/recruitment";
 import { getAllStudentsMap } from "~/models/student";
-import { type StudentGradingTagValue, getGradingTagsByGradingUids } from "~/models/student-grading-tag";
+import { getGradingTagsByGradingUids, type StudentGradingTagValue } from "~/models/student-grading-tag";
 import { getTimelineContentsByUids } from "~/models/timeline-content";
 
 export const COMMUNITY_FEED_PAGE_SIZE = 20;
@@ -79,15 +80,21 @@ export async function enrichCommunityFeedPosts(
         : null,
       recruitmentStats: recruitmentStatsByPostUid.get(post.uid) ?? null,
       pickupStudents: post.subjectContentUid
-        ? (recruitmentGroupMap
-            .get(timelineContentMap.get(post.subjectContentUid)?.recruitmentGroupUid ?? "")
-            ?.recruitments.filter(
-              (recruitment) => recruitment.pickup && recruitment.recruitmentType !== "given" && recruitment.student,
+        ? (() => {
+            const subjectContent = timelineContentMap.get(post.subjectContentUid);
+            const group = recruitmentGroupMap.get(subjectContent?.recruitmentGroupUid ?? "");
+            return filterRecruitmentsByStudentUids(
+              group?.recruitments ?? [],
+              subjectContent?.recruitmentStudentUids ?? null,
             )
-            .map((recruitment) => ({
-              uid: recruitment.student?.uid ?? "",
-              name: recruitment.student?.name ?? recruitment.studentName,
-            })) ?? [])
+              .filter(
+                (recruitment) => recruitment.pickup && recruitment.recruitmentType !== "given" && recruitment.student,
+              )
+              .map((recruitment) => ({
+                uid: recruitment.student?.uid ?? "",
+                name: recruitment.student?.name ?? recruitment.studentName,
+              }));
+          })()
         : [],
     })),
   };

--- a/app/views/futures.ts
+++ b/app/views/futures.ts
@@ -1,14 +1,11 @@
+import { filterRecruitmentsByStudentUids, getRecruitmentFavoriteKey } from "~/domain/recruitment-identity";
 import type { Attack, Defense, RecruitmentTypeEnum } from "~/graphql/graphql";
-import { normalizeInstant, type UtcIsoString, isInstantAfter, nowUtcIso, toUtcIso } from "~/lib/date-time";
 import { cacheKey, fetchRouteCached } from "~/lib/cache";
-import {
-  type getRecruitmentGroupByUid,
-  getRecruitmentGroupsByUids,
-} from "~/models/recruitment";
-import { getRecruitmentFavoriteKey } from "~/domain/recruitment-identity";
-import { getTimelineContents } from "~/models/timeline-content";
-import type { TimelineContent } from "~/models/timeline-content";
+import { isInstantAfter, normalizeInstant, nowUtcIso, toUtcIso, type UtcIsoString } from "~/lib/date-time";
 import type { Role } from "~/models/content.d";
+import { type getRecruitmentGroupByUid, getRecruitmentGroupsByUids } from "~/models/recruitment";
+import type { TimelineContent } from "~/models/timeline-content";
+import { getTimelineContents } from "~/models/timeline-content";
 import { getUpcomingRaidContents, type RaidInfo } from "./raid-content";
 
 const FUTURE_CONTENTS_CACHE_KEY = cacheKey("route", "futures", 1, "all");
@@ -57,8 +54,11 @@ export function normalizeFutureContentDates(content: FutureContent): FutureConte
   };
 }
 
-export function toRecruitmentInfos(group: Awaited<ReturnType<typeof getRecruitmentGroupByUid>>): RecruitmentInfo[] {
-  return (group?.recruitments ?? [])
+export function toRecruitmentInfos(
+  group: Awaited<ReturnType<typeof getRecruitmentGroupByUid>>,
+  studentUids: string[] | null = null,
+): RecruitmentInfo[] {
+  return filterRecruitmentsByStudentUids(group?.recruitments ?? [], studentUids)
     .sort((a, b) => Number(a.rerun) - Number(b.rerun))
     .map((r) => ({
       recruitmentType: r.recruitmentType,
@@ -109,7 +109,7 @@ export async function getFutureContents(
 
           if (content.recruitmentGroupUid) {
             const group = recruitmentGroupMap.get(content.recruitmentGroupUid) ?? null;
-            return { ...content, recruitments: toRecruitmentInfos(group) };
+            return { ...content, recruitments: toRecruitmentInfos(group, content.recruitmentStudentUids) };
           }
 
           return { ...content, recruitments: [] };

--- a/app/views/home.ts
+++ b/app/views/home.ts
@@ -1,13 +1,17 @@
 import { getRecruitmentFavoriteKey } from "~/domain/recruitment-identity";
 import type { Attack, Defense, RecruitmentTypeEnum } from "~/graphql/graphql";
 import { cacheKey, fetchRouteCached } from "~/lib/cache";
-import { type UtcIsoString, isInstantAfter, nowUtcIso, toUtcIso } from "~/lib/date-time";
+import { isInstantAfter, nowUtcIso, toUtcIso, type UtcIsoString } from "~/lib/date-time";
 import type { Role } from "~/models/content.d";
 import { getFavoritedCounts } from "~/models/favorite-students";
 import { getAllRecruitmentGroups } from "~/models/recruitment";
-import { getTimelineContentsByContentTypes } from "~/models/timeline-content";
 import type { TimelineContent, TimelineContentType } from "~/models/timeline-content";
-import { type RaidScheduleMeta, getUpcomingRaidContents } from "./raid-content";
+import {
+  findEventsForRecruitmentStudent,
+  getTimelineContentsByContentTypes,
+  groupTimelineContentsByRecruitmentGroupUid,
+} from "~/models/timeline-content";
+import { getUpcomingRaidContents, type RaidScheduleMeta } from "./raid-content";
 
 const INDEX_CONTENTS_CACHE_KEY = cacheKey("route", "index", 1, "all");
 
@@ -69,11 +73,7 @@ export async function getIndexContents(env: Env, forceRefresh = false, ctx?: Exe
         const nowTime = nowDate.getTime();
         return startAt <= nowTime && (endAt === null || endAt >= nowTime);
       });
-      const timelineUidByRecruitmentGroupUid = new Map(
-        allEvents
-          .filter((event) => event.recruitmentGroupUid)
-          .map((event) => [event.recruitmentGroupUid as string, event.uid]),
-      );
+      const eventsByRecruitmentGroupUid = groupTimelineContentsByRecruitmentGroupUid(allEvents);
       const currentRecruitments: { eventUid: string; recruitment: IndexRecruitment }[] = recruitmentGroups
         .flatMap((group) =>
           group.recruitments
@@ -84,7 +84,11 @@ export async function getIndexContents(env: Env, forceRefresh = false, ctx?: Exe
                 recruitment.recruitmentType !== "encore",
             )
             .map((recruitment) => ({
-              eventUid: timelineUidByRecruitmentGroupUid.get(group.uid) ?? group.uid,
+              eventUid:
+                findEventsForRecruitmentStudent(
+                  eventsByRecruitmentGroupUid.get(group.uid) ?? [],
+                  recruitment.student?.uid ?? null,
+                )[0]?.uid ?? group.uid,
               recruitment: {
                 student: recruitment.student
                   ? {

--- a/app/views/more.ts
+++ b/app/views/more.ts
@@ -1,16 +1,16 @@
 import { buildPyroxeneScheduleItems } from "~/domain/pyroxene-schedule";
-import { type PickupResources, buildTimeline } from "~/domain/pyroxene-timeline";
+import { buildTimeline, type PickupResources } from "~/domain/pyroxene-timeline";
 import { getInstantTime, isInstantAfter, nowUtcIso } from "~/lib/date-time";
 import { countUnregisteredActiveCoupons } from "~/models/coupon";
 import { getUserFavoritedStudents } from "~/models/favorite-students";
 import { getPickupHistories } from "~/models/pickup-history";
 import {
-  type PyroxeneEventData,
   getAllPyroxeneEventData,
   getCollectedSourceKeys,
   getLatestPyroxeneOwnedResource,
   getPyroxenePlannerOptions,
   getPyroxeneTimelineItems,
+  type PyroxeneEventData,
 } from "~/models/pyroxene-planner";
 import { getRecruitedStudents } from "~/models/recruited-student";
 import { getRecruitmentResultsByRecruitmentGroupUids } from "~/models/recruitment-result";
@@ -227,8 +227,11 @@ function getFavoritedRecruitments(
       }
 
       const favoritedRecruitments = content.recruitments.filter(
-        ({ pickup, recruitmentType, student }) =>
-          pickup && recruitmentType !== "given" && student && favoritedStudentKeys.has(`${content.uid}:${student.uid}`),
+        ({ pickup, recruitmentType, student, sourceContentUid }) =>
+          pickup &&
+          recruitmentType !== "given" &&
+          student &&
+          favoritedStudentKeys.has(`${sourceContentUid ?? content.uid}:${student.uid}`),
       );
       if (favoritedRecruitments.length === 0) {
         return [];
@@ -284,11 +287,20 @@ function buildPyroxeneEventDataMap(
     });
   }
 
-  const contentByRecruitmentGroupUid = new Map(
-    contents.flatMap((content) =>
-      content.kind === "event" && content.recruitmentGroupUid ? [[content.recruitmentGroupUid, content]] : [],
-    ),
-  );
+  // A recruitment group can be split into a recruitments-empty "reward only" entry per event
+  // plus one merged entry carrying the actual recruitments (see getPyroxenePlannerContents).
+  // Prefer the merged entry here so "completed" status lands on the content that actually
+  // renders the pickup students, regardless of which entry appears last in `contents`.
+  const contentByRecruitmentGroupUid = new Map<string, MorePyroxeneContent>();
+  for (const content of contents) {
+    if (content.kind !== "event" || !content.recruitmentGroupUid) {
+      continue;
+    }
+    const existing = contentByRecruitmentGroupUid.get(content.recruitmentGroupUid);
+    if (!existing || content.recruitments.length > 0) {
+      contentByRecruitmentGroupUid.set(content.recruitmentGroupUid, content);
+    }
+  }
   for (const result of recruitmentResults) {
     if (!result.completedAt) {
       continue;

--- a/app/views/pyroxene.ts
+++ b/app/views/pyroxene.ts
@@ -1,3 +1,4 @@
+import { filterRecruitmentsByStudentUids } from "~/domain/recruitment-identity";
 import { buildRecruitmentPoolSnapshot } from "~/domain/recruitment-simulator";
 import type { RecruitmentTypeEnum } from "~/graphql/graphql";
 import { compareInstantAsc, compareInstantDesc, toUtcIso, type UtcIsoString } from "~/lib/date-time";
@@ -9,10 +10,15 @@ import {
   type MainStoryVolume,
 } from "~/models/main-story";
 import { getRaidSchedule } from "~/models/raid";
-import { getRecruitmentGroupsByUids, getRecruitmentPoolStudents } from "~/models/recruitment";
+import { getRecruitmentGroupsByUids, getRecruitmentPoolStudents, type RecruitmentGroup } from "~/models/recruitment";
 import { getAllStudentsMap } from "~/models/student";
 import type { TimelineContent, TimelineContentType } from "~/models/timeline-content";
-import { getFutureRaidContents, getTimelineContents } from "~/models/timeline-content";
+import {
+  findEventsForRecruitmentStudent,
+  getFutureRaidContents,
+  getTimelineContents,
+  groupTimelineContentsByRecruitmentGroupUid,
+} from "~/models/timeline-content";
 
 const EVENT_CONTENT_TYPES: TimelineContentType[] = ["event", "main_story", "pickup"];
 const MAIN_STORY_REWARD_REGION = "gl";
@@ -36,6 +42,10 @@ export type PyroxenePlannerContent =
         rerun: boolean;
         until: UtcIsoString | null;
         student: { uid: string; name: string; initialTier: number } | null;
+        // Which event this recruitment "belongs to" when its group is shared by multiple
+        // events. Only set on the merged recruitment entry (see buildGroupRecruitmentContent);
+        // absent elsewhere, where recruitment.uid === content.uid already disambiguates.
+        sourceContentUid?: string;
       }[];
       recruitmentPool?: {
         tier2Count: number;
@@ -113,6 +123,41 @@ function getContentRecruitmentGroupUid(content: TimelineContent | PyroxenePlanne
   return content.recruitmentGroupUid;
 }
 
+type PyroxeneEventVariant = Extract<PyroxenePlannerContent, { kind: "event" }>;
+type PyroxeneRecruitmentDetail = PyroxeneEventVariant["recruitments"][number];
+
+function toRecruitmentDetail(
+  recruitment: RecruitmentGroup["recruitments"][number],
+  studentsMap: Awaited<ReturnType<typeof getAllStudentsMap>>,
+  sourceContentUid?: string,
+): PyroxeneRecruitmentDetail {
+  return {
+    recruitmentType: recruitment.recruitmentType,
+    pickup: recruitment.pickup,
+    rerun: recruitment.rerun,
+    until: recruitment.until ? toUtcIso(recruitment.until) : null,
+    student: recruitment.student
+      ? {
+          uid: recruitment.student.uid,
+          name: recruitment.student.name,
+          initialTier: studentsMap[recruitment.student.uid]?.initialTier ?? 0,
+        }
+      : null,
+    ...(sourceContentUid ? { sourceContentUid } : {}),
+  };
+}
+
+function buildRecruitmentPoolInfo(
+  group: RecruitmentGroup,
+  recruitmentPoolStudents: Awaited<ReturnType<typeof getRecruitmentPoolStudents>>,
+): PyroxeneEventVariant["recruitmentPool"] {
+  const snapshot = buildRecruitmentPoolSnapshot({ recruitmentGroup: group, students: recruitmentPoolStudents });
+  return {
+    tier2Count: snapshot.nonPickupStudentsByTier.tier2.length,
+    tier3Count: snapshot.nonPickupStudentsByTier.tier3.length,
+  };
+}
+
 export async function getPyroxenePlannerContents(env: Env, forceRefresh = false): Promise<PyroxenePlannerContent[]> {
   // Events require syncedAt (confirmed by BAQL); raids are fetched regardless of syncedAt
   const [eventContents, raidContents, mainStories] = await Promise.all([
@@ -136,39 +181,21 @@ export async function getPyroxenePlannerContents(env: Env, forceRefresh = false)
   ]);
 
   const recruitmentGroupMap = new Map(recruitmentGroups.map((g) => [g.uid, g]));
+  const eventsByRecruitmentGroupUid = groupTimelineContentsByRecruitmentGroupUid(eventContents);
+  // Multiple events can share one BAQL recruitment group (e.g. a rerun and its permanent
+  // counterpart). Each event still gets its own reward-only entry (earnablePyroxene is tied
+  // to that specific event, not the recruitment), but the group's recruitments are only
+  // surfaced once, as a separate merged entry, so pickup cost isn't double-counted.
+  const emittedGroupRecruitmentUids = new Set<string>();
+
   const results = await Promise.all(
-    allContents.map(async (content) => {
+    allContents.map(async (content): Promise<PyroxenePlannerContent[]> => {
       if ("kind" in content) {
-        return content;
+        return [content];
       }
 
       if (EVENT_CONTENT_TYPES.includes(content.contentType)) {
         const group = content.recruitmentGroupUid ? recruitmentGroupMap.get(content.recruitmentGroupUid) : undefined;
-        const recruitments = (group?.recruitments ?? []).map((r) => ({
-          recruitmentType: r.recruitmentType,
-          pickup: r.pickup,
-          rerun: r.rerun,
-          until: r.until ? toUtcIso(r.until) : null,
-          student: r.student
-            ? {
-                uid: r.student.uid,
-                name: r.student.name,
-                initialTier: studentsMap[r.student.uid]?.initialTier ?? 0,
-              }
-            : null,
-        }));
-        const recruitmentPool = group
-          ? (() => {
-              const snapshot = buildRecruitmentPoolSnapshot({
-                recruitmentGroup: group,
-                students: recruitmentPoolStudents,
-              });
-              return {
-                tier2Count: snapshot.nonPickupStudentsByTier.tier2.length,
-                tier3Count: snapshot.nonPickupStudentsByTier.tier3.length,
-              };
-            })()
-          : undefined;
 
         // Use the latest recruitment until date when endAt is missing.
         const until =
@@ -177,20 +204,77 @@ export async function getPyroxenePlannerContents(env: Env, forceRefresh = false)
             (max, r) => (r.until ? (max && compareInstantDesc(max, r.until) < 0 ? max : toUtcIso(r.until)) : max),
             null,
           );
-        if (!until) return null;
+        if (!until) return [];
 
-        return {
+        const earnablePyroxene = content.contentType === "main_story" ? null : (content.earnablePyroxene ?? null);
+        const siblingEvents = content.recruitmentGroupUid
+          ? (eventsByRecruitmentGroupUid.get(content.recruitmentGroupUid) ?? [])
+          : [];
+
+        if (siblingEvents.length <= 1) {
+          const recruitments = filterRecruitmentsByStudentUids(
+            group?.recruitments ?? [],
+            content.recruitmentStudentUids,
+          ).map((r) => toRecruitmentDetail(r, studentsMap));
+
+          return [
+            {
+              kind: "event" as const,
+              uid: content.uid,
+              recruitmentGroupUid: content.recruitmentGroupUid,
+              name: content.name,
+              since: content.startAt,
+              until,
+              earnablePyroxene,
+              tags: content.tags,
+              recruitments,
+              recruitmentPool: group ? buildRecruitmentPoolInfo(group, recruitmentPoolStudents) : undefined,
+            },
+          ];
+        }
+
+        const rewardOnlyEntry: PyroxenePlannerContent = {
           kind: "event" as const,
           uid: content.uid,
           recruitmentGroupUid: content.recruitmentGroupUid,
           name: content.name,
           since: content.startAt,
           until,
-          earnablePyroxene: content.contentType === "main_story" ? null : (content.earnablePyroxene ?? null),
+          earnablePyroxene,
           tags: content.tags,
-          recruitments,
-          recruitmentPool,
+          recruitments: [],
         };
+
+        const recruitmentGroupUid = content.recruitmentGroupUid as string;
+        if (emittedGroupRecruitmentUids.has(recruitmentGroupUid)) {
+          return [rewardOnlyEntry];
+        }
+        emittedGroupRecruitmentUids.add(recruitmentGroupUid);
+
+        const sortedSiblings = [...siblingEvents].sort((a, b) => compareInstantAsc(a.startAt, b.startAt));
+        const mergedRecruitments = (group?.recruitments ?? []).map((r) =>
+          toRecruitmentDetail(
+            r,
+            studentsMap,
+            findEventsForRecruitmentStudent(siblingEvents, r.student?.uid ?? null)[0]?.uid,
+          ),
+        );
+
+        return [
+          rewardOnlyEntry,
+          {
+            kind: "event" as const,
+            uid: `group:${recruitmentGroupUid}`,
+            recruitmentGroupUid,
+            name: sortedSiblings.map((sibling) => sibling.name).join(" / "),
+            since: group?.startAt ? toUtcIso(group.startAt) : content.startAt,
+            until: group?.endAt ? toUtcIso(group.endAt) : until,
+            earnablePyroxene: null,
+            tags: [...new Set(sortedSiblings.flatMap((sibling) => sibling.tags))],
+            recruitments: mergedRecruitments,
+            recruitmentPool: group ? buildRecruitmentPoolInfo(group, recruitmentPoolStudents) : undefined,
+          },
+        ];
       }
       if (content.contentType === "raid") {
         let raidName = content.name;
@@ -206,20 +290,22 @@ export async function getPyroxenePlannerContents(env: Env, forceRefresh = false)
           }
         }
 
-        if (!until) return null;
+        if (!until) return [];
 
-        return {
-          kind: "raid" as const,
-          uid: content.uid,
-          name: raidName,
-          type: raidType,
-          since: content.startAt,
-          until,
-        };
+        return [
+          {
+            kind: "raid" as const,
+            uid: content.uid,
+            name: raidName,
+            type: raidType,
+            since: content.startAt,
+            until,
+          },
+        ];
       }
-      return null;
+      return [];
     }),
   );
 
-  return results.filter((r) => r !== null);
+  return results.flat();
 }

--- a/db/migrations/20260706000100_add_recruitment_student_uids_to_timeline_contents.sql
+++ b/db/migrations/20260706000100_add_recruitment_student_uids_to_timeline_contents.sql
@@ -1,0 +1,1 @@
+alter table timeline_contents add column recruitment_student_uids text;

--- a/test/app/domain/pyroxene-schedule.test.ts
+++ b/test/app/domain/pyroxene-schedule.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "@jest/globals";
+import { buildPyroxeneScheduleItems, type PyroxeneScheduleContent } from "~/domain/pyroxene-schedule";
+import { RecruitmentTypeEnum } from "~/graphql/graphql";
+
+function recruitment(
+  studentUid: string,
+  sourceContentUid?: string,
+): NonNullable<PyroxeneScheduleContent & { kind: "event" }>["recruitments"][number] {
+  return {
+    recruitmentType: RecruitmentTypeEnum.Usual,
+    pickup: true,
+    rerun: false,
+    until: null,
+    student: { uid: studentUid, name: studentUid, initialTier: 3 },
+    ...(sourceContentUid ? { sourceContentUid } : {}),
+  };
+}
+
+describe("buildPyroxeneScheduleItems favorited resolution", () => {
+  it("resolves favorited using the content uid when recruitments carry no sourceContentUid", () => {
+    const contents: PyroxeneScheduleContent[] = [
+      {
+        kind: "event",
+        uid: "event-a",
+        name: "이벤트A",
+        since: "2026-11-10T02:00:00.000Z",
+        until: "2026-11-24T02:00:00.000Z",
+        earnablePyroxene: null,
+        tags: [],
+        recruitments: [recruitment("a")],
+      },
+    ];
+
+    const items = buildPyroxeneScheduleItems(contents, [{ contentUid: "event-a", studentUid: "a" }], []);
+
+    expect(items[0].event?.recruitments[0].favorited).toBe(true);
+  });
+
+  it("resolves favorited per-student using sourceContentUid when recruitments are merged from multiple events", () => {
+    // Simulates the getPyroxenePlannerContents merged entry: students A/B belong to event-a,
+    // students C/D belong to event-b, all surfaced under one synthetic "group:*" content.
+    const contents: PyroxeneScheduleContent[] = [
+      {
+        kind: "event",
+        uid: "group:shared-group",
+        name: "이벤트A / 이벤트B",
+        since: "2026-11-10T02:00:00.000Z",
+        until: "2026-11-24T02:00:00.000Z",
+        earnablePyroxene: null,
+        tags: [],
+        recruitments: [
+          recruitment("a", "event-a"),
+          recruitment("b", "event-a"),
+          recruitment("c", "event-b"),
+          recruitment("d", "event-b"),
+        ],
+      },
+    ];
+    const favoritedStudents = [
+      { contentUid: "event-a", studentUid: "a" },
+      { contentUid: "event-b", studentUid: "c" },
+    ];
+
+    const items = buildPyroxeneScheduleItems(contents, favoritedStudents, []);
+    const favoritedByStudentUid = Object.fromEntries(
+      (items[0].event?.recruitments ?? []).map((r) => [r.student?.uid, r.favorited]),
+    );
+
+    expect(favoritedByStudentUid).toEqual({ a: true, b: false, c: true, d: false });
+  });
+});

--- a/test/app/models/content.test.ts
+++ b/test/app/models/content.test.ts
@@ -82,6 +82,7 @@ function event(uid: string, startAt: string, endAt: string | null, runType: "fir
     contentUid: null,
     shopContentUid: null,
     recruitmentGroupUid: null,
+    recruitmentStudentUids: null,
     confirmed: true,
     isSpoiler: false,
     tags: [],

--- a/test/app/models/future-content.test.ts
+++ b/test/app/models/future-content.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, jest } from "@jest/globals";
-import { type FutureContent, normalizeFutureContentDates } from "../../../app/views/futures";
+import { type FutureContent, normalizeFutureContentDates, toRecruitmentInfos } from "../../../app/views/futures";
 
 jest.mock("~/models/recruitment", () => ({
   getRecruitmentGroupByUid: jest.fn(),
@@ -8,6 +8,9 @@ jest.mock("~/models/recruitment", () => ({
 
 jest.mock("~/domain/recruitment-identity", () => ({
   getRecruitmentFavoriteKey: jest.fn(),
+  filterRecruitmentsByStudentUids: jest.requireActual<typeof import("~/domain/recruitment-identity")>(
+    "~/domain/recruitment-identity",
+  ).filterRecruitmentsByStudentUids,
 }));
 
 jest.mock("~/models/timeline-content", () => ({
@@ -93,5 +96,52 @@ describe("normalizeFutureContentDates", () => {
     } as unknown as FutureContent);
 
     expect(normalized.endAt ? normalized.endAt > now : normalized.startAt > now).toBe(true);
+  });
+});
+
+describe("toRecruitmentInfos", () => {
+  const group = {
+    uid: "shared-group",
+    recruitments: [
+      {
+        recruitmentType: "usual",
+        pickup: true,
+        rerun: false,
+        since: "2026-11-10T02:00:00.000Z",
+        until: null,
+        studentName: "학생A",
+        student: { uid: "a" },
+      },
+      {
+        recruitmentType: "usual",
+        pickup: true,
+        rerun: false,
+        since: "2026-11-10T02:00:00.000Z",
+        until: null,
+        studentName: "학생B",
+        student: { uid: "b" },
+      },
+      {
+        recruitmentType: "usual",
+        pickup: true,
+        rerun: true,
+        since: "2026-11-10T02:00:00.000Z",
+        until: null,
+        studentName: "학생C",
+        student: { uid: "c" },
+      },
+    ],
+  } as unknown as Parameters<typeof toRecruitmentInfos>[0];
+
+  it("returns every recruitment when no student filter is given", () => {
+    expect(toRecruitmentInfos(group).map((r) => r.student?.uid)).toEqual(["a", "b", "c"]);
+  });
+
+  it("keeps only the recruitments whose student uid is in the filter", () => {
+    expect(toRecruitmentInfos(group, ["a", "b"]).map((r) => r.student?.uid)).toEqual(["a", "b"]);
+  });
+
+  it("returns an empty list when the group is missing", () => {
+    expect(toRecruitmentInfos(null, ["a"])).toEqual([]);
   });
 });

--- a/test/app/models/recruitment-identity.test.ts
+++ b/test/app/models/recruitment-identity.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "@jest/globals";
 import {
+  filterRecruitmentsByStudentUids,
   getProvisionalRecruitmentStudentKey,
   getRecruitmentFavoriteKey,
   normalizeRecruitmentStudentName,
@@ -23,5 +24,29 @@ describe("recruitment identity", () => {
     expect(getRecruitmentFavoriteKey({ student: null, studentName: "리오(무장)" })).toBe(
       getProvisionalRecruitmentStudentKey("리오(무장)"),
     );
+  });
+});
+
+describe("filterRecruitmentsByStudentUids", () => {
+  const recruitmentA = { student: { uid: "a" } };
+  const recruitmentB = { student: { uid: "b" } };
+  const recruitmentNoStudent = { student: null };
+
+  it("returns every recruitment unchanged when studentUids is null", () => {
+    const recruitments = [recruitmentA, recruitmentB, recruitmentNoStudent];
+    expect(filterRecruitmentsByStudentUids(recruitments, null)).toBe(recruitments);
+  });
+
+  it("keeps only recruitments whose student uid is listed", () => {
+    const recruitments = [recruitmentA, recruitmentB, recruitmentNoStudent];
+    expect(filterRecruitmentsByStudentUids(recruitments, ["a"])).toEqual([recruitmentA]);
+  });
+
+  it("drops student-less recruitments once a filter is active", () => {
+    expect(filterRecruitmentsByStudentUids([recruitmentNoStudent], ["a"])).toEqual([]);
+  });
+
+  it("returns an empty array when no recruitment matches the filter", () => {
+    expect(filterRecruitmentsByStudentUids([recruitmentA], ["c"])).toEqual([]);
   });
 });

--- a/test/app/models/timeline-content.test.ts
+++ b/test/app/models/timeline-content.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it, jest } from "@jest/globals";
 import {
+  findEventsForRecruitmentStudent,
   getTimelineContentDatesByContentUid,
   getTimelineContentDatesByContentUids,
   getTimelineContents,
   getTimelineContentsByContentTypes,
   getUpcomingEvent,
+  groupTimelineContentsByRecruitmentGroupUid,
+  type TimelineContent,
 } from "~/models/timeline-content";
 
 type TimelineContentRow = {
@@ -22,6 +25,7 @@ type TimelineContentRow = {
   content_uid: string | null;
   shop_content_uid: string | null;
   recruitment_group_uid: string | null;
+  recruitment_student_uids: string | null;
   confirmed: number;
   is_spoiler: number;
   tags: string;
@@ -116,6 +120,7 @@ function row(overrides: Partial<TimelineContentRow>): TimelineContentRow {
     content_uid: "future-unsynced-event",
     shop_content_uid: null,
     recruitment_group_uid: "future-unsynced-event",
+    recruitment_student_uids: null,
     confirmed: 1,
     is_spoiler: 0,
     tags: "[]",
@@ -143,6 +148,7 @@ function rowToArray(row: TimelineContentRow): unknown[] {
     row.content_uid,
     row.shop_content_uid,
     row.recruitment_group_uid,
+    row.recruitment_student_uids,
     row.confirmed,
     row.is_spoiler,
     row.tags,
@@ -252,5 +258,82 @@ describe("timeline content dates by content_uid", () => {
       startAt: "2026-05-01T02:00:00.000Z",
       endAt: null,
     });
+  });
+});
+
+function timelineContent(overrides: Partial<TimelineContent> & { uid: string }): TimelineContent {
+  return {
+    name: overrides.uid,
+    nameI18n: {},
+    startAt: "2026-11-10T02:00:00.000Z",
+    endAt: "2026-11-24T02:00:00.000Z",
+    endless: false,
+    imageUrl: null,
+    videos: [],
+    contentType: "event",
+    runType: "first",
+    occurrence: null,
+    contentUid: null,
+    shopContentUid: null,
+    recruitmentGroupUid: null,
+    recruitmentStudentUids: null,
+    confirmed: true,
+    isSpoiler: false,
+    tags: [],
+    earnablePyroxene: null,
+    syncedAt: null,
+    ...overrides,
+  };
+}
+
+describe("groupTimelineContentsByRecruitmentGroupUid", () => {
+  it("keeps every event sharing a recruitment group, not just the last one", () => {
+    const eventA = timelineContent({ uid: "event-a", recruitmentGroupUid: "shared-group" });
+    const eventB = timelineContent({ uid: "event-b", recruitmentGroupUid: "shared-group" });
+    const eventC = timelineContent({ uid: "event-c", recruitmentGroupUid: "other-group" });
+
+    const map = groupTimelineContentsByRecruitmentGroupUid([eventA, eventB, eventC]);
+
+    expect(map.get("shared-group")?.map((content) => content.uid)).toEqual(["event-a", "event-b"]);
+    expect(map.get("other-group")?.map((content) => content.uid)).toEqual(["event-c"]);
+  });
+
+  it("skips events with no recruitment group", () => {
+    const map = groupTimelineContentsByRecruitmentGroupUid([timelineContent({ uid: "no-group" })]);
+    expect(map.size).toBe(0);
+  });
+});
+
+describe("findEventsForRecruitmentStudent", () => {
+  const eventA = timelineContent({
+    uid: "event-a",
+    recruitmentGroupUid: "shared-group",
+    recruitmentStudentUids: ["a", "b"],
+  });
+  const eventB = timelineContent({
+    uid: "event-b",
+    recruitmentGroupUid: "shared-group",
+    recruitmentStudentUids: ["c", "d"],
+  });
+
+  it("returns the event whose allowlist includes the student", () => {
+    expect(findEventsForRecruitmentStudent([eventA, eventB], "a").map((e) => e.uid)).toEqual(["event-a"]);
+    expect(findEventsForRecruitmentStudent([eventA, eventB], "c").map((e) => e.uid)).toEqual(["event-b"]);
+  });
+
+  it("matches every event with no allowlist, since null means show-all", () => {
+    const unfiltered = timelineContent({ uid: "event-c", recruitmentGroupUid: "shared-group" });
+    expect(findEventsForRecruitmentStudent([unfiltered], "anyone").map((e) => e.uid)).toEqual(["event-c"]);
+  });
+
+  it("falls back to every candidate event when no allowlist matches", () => {
+    expect(findEventsForRecruitmentStudent([eventA, eventB], "unlisted").map((e) => e.uid)).toEqual([
+      "event-a",
+      "event-b",
+    ]);
+  });
+
+  it("returns an empty list when there are no candidate events", () => {
+    expect(findEventsForRecruitmentStudent([], "a")).toEqual([]);
   });
 });

--- a/test/app/routes/futures._components/future-recruitment-table-model.test.ts
+++ b/test/app/routes/futures._components/future-recruitment-table-model.test.ts
@@ -48,7 +48,7 @@ function recruitment(
 }
 
 describe("buildFutureRecruitmentTableRows", () => {
-  it("splits overlapping recruitments by every start and end boundary", () => {
+  it("groups overlapping recruitments by their own recruitment periods", () => {
     const rows = buildFutureRecruitmentTableRows([
       content({
         uid: "content-a",
@@ -80,13 +80,11 @@ describe("buildFutureRecruitmentTableRows", () => {
     ]);
 
     expect(rows.map((row) => [row.since, row.until])).toEqual([
-      ["2026-05-12T00:00:00.000Z", "2026-05-19T00:00:00.000Z"],
-      ["2026-05-19T00:00:00.000Z", "2026-05-26T00:00:00.000Z"],
-      ["2026-05-26T00:00:00.000Z", "2026-06-02T00:00:00.000Z"],
+      ["2026-05-12T00:00:00.000Z", "2026-05-26T00:00:00.000Z"],
+      ["2026-05-19T00:00:00.000Z", "2026-06-02T00:00:00.000Z"],
     ]);
     expect(rows.map((row) => row.recruitments.map((group) => group.recruitment.studentName))).toEqual([
       ["학생 A"],
-      ["학생 A", "학생 B"],
       ["학생 B"],
     ]);
   });
@@ -116,7 +114,7 @@ describe("buildFutureRecruitmentTableRows", () => {
     expect(rows[0].recruitments[0].recruitment.studentName).toBe("아카이브 학생");
   });
 
-  it("uses timeline content dates for archive recruitments when the content is not endless", () => {
+  it("uses recruitment dates for archive recruitments when the content is not endless", () => {
     const rows = buildFutureRecruitmentTableRows([
       content({
         uid: "archive-but-limited",
@@ -136,11 +134,11 @@ describe("buildFutureRecruitmentTableRows", () => {
     ]);
 
     expect(rows).toHaveLength(1);
-    expect(rows[0].since).toBe("2026-08-01T00:00:00.000Z");
-    expect(rows[0].until).toBe("2026-08-08T00:00:00.000Z");
+    expect(rows[0].since).toBe("2026-08-03T00:00:00.000Z");
+    expect(rows[0].until).toBe("2026-08-10T00:00:00.000Z");
   });
 
-  it("ignores recruitment dates and uses the timeline content period", () => {
+  it("uses recruitment dates when they differ from the timeline content period", () => {
     const rows = buildFutureRecruitmentTableRows([
       content({
         uid: "fes-content",
@@ -159,9 +157,76 @@ describe("buildFutureRecruitmentTableRows", () => {
       }),
     ]);
 
-    expect(rows).toHaveLength(1);
-    expect(rows[0].since).toBe("2026-06-09T00:00:00.000Z");
-    expect(rows[0].until).toBe("2026-06-16T00:00:00.000Z");
+    expect(rows.map((row) => [row.since, row.until])).toEqual([
+      ["2026-06-02T00:00:00.000Z", "2026-06-16T00:00:00.000Z"],
+    ]);
+    expect(rows[0].events.map((item) => item.name)).toEqual(["페스 모집"]);
+  });
+
+  it("does not keep showing an event recruitment after the recruitment ends", () => {
+    const rows = buildFutureRecruitmentTableRows([
+      content({
+        uid: "event-with-shorter-recruitment",
+        name: "이벤트보다 짧은 모집",
+        startAt: "2026-10-13T02:00:00.000Z",
+        endAt: "2026-10-27T02:00:00.000Z",
+        contentType: "event",
+        recruitments: [
+          recruitment({
+            studentName: "나구사",
+            since: "2026-10-13T02:00:00.000Z",
+            until: "2026-10-20T02:00:00.000Z",
+          }),
+        ],
+      }),
+    ]);
+
+    expect(rows.map((row) => [row.since, row.until])).toEqual([
+      ["2026-10-13T00:00:00.000Z", "2026-10-20T00:00:00.000Z"],
+    ]);
+    expect(rows[0].recruitments.map((group) => group.recruitment.studentName)).toEqual(["나구사"]);
+  });
+
+  it("groups simultaneous recruitments by their shared start date even when they have different end dates", () => {
+    const rows = buildFutureRecruitmentTableRows([
+      content({
+        uid: "long-recruitment",
+        name: "2주 모집",
+        startAt: "2026-11-10T02:00:00.000Z",
+        endAt: "2026-11-24T02:00:00.000Z",
+        contentType: "event",
+        recruitments: [
+          recruitment({
+            studentName: "히카리",
+            since: "2026-11-10T02:00:00.000Z",
+            until: "2026-11-24T02:00:00.000Z",
+          }),
+        ],
+      }),
+      content({
+        uid: "short-recruitment",
+        name: "1주 모집",
+        startAt: "2026-11-10T02:00:00.000Z",
+        endAt: "2026-11-24T02:00:00.000Z",
+        contentType: "event",
+        recruitments: [
+          recruitment({
+            studentName: "사오리",
+            since: "2026-11-10T02:00:00.000Z",
+            until: "2026-11-17T02:00:00.000Z",
+          }),
+        ],
+      }),
+    ]);
+
+    expect(rows.map((row) => [row.since, row.until])).toEqual([
+      ["2026-11-10T00:00:00.000Z", "2026-11-24T00:00:00.000Z"],
+    ]);
+    expect(rows[0].recruitments.map((group) => group.recruitment.studentName)).toEqual(["히카리", "사오리"]);
+    expect(rows[0].recruitments.map((group) => group.until)).toEqual([
+      "2026-11-24T02:00:00.000Z",
+      "2026-11-17T02:00:00.000Z",
+    ]);
   });
 
   it("uses the display timezone midnight for row boundary instants", () => {
@@ -189,7 +254,7 @@ describe("buildFutureRecruitmentTableRows", () => {
     ]);
   });
 
-  it("splits recruitment content into weekly rows when a later week has auxiliary contents", () => {
+  it("keeps long recruitment content in one row when a later week has auxiliary contents", () => {
     const rows = buildFutureRecruitmentTableRows([
       content({
         uid: "two-week-pickup",
@@ -215,9 +280,9 @@ describe("buildFutureRecruitmentTableRows", () => {
     ]);
 
     expect(rows.map((row) => [row.since, row.until])).toEqual([
-      ["2026-05-26T00:00:00.000Z", "2026-06-02T00:00:00.000Z"],
-      ["2026-06-02T00:00:00.000Z", "2026-06-09T00:00:00.000Z"],
+      ["2026-05-26T00:00:00.000Z", "2026-06-09T00:00:00.000Z"],
     ]);
+    expect(rows[0].events.map((item) => item.name)).toEqual(["2주 모집", "2주차 컨텐츠"]);
   });
 
   it("folds empty continuation rows into the previous visible row period", () => {
@@ -269,10 +334,7 @@ describe("buildFutureRecruitmentTableRows", () => {
       }),
     ]);
 
-    expect(rows.map((row) => [row.hideRecruitmentCell, row.recruitmentRowSpan])).toEqual([
-      [false, 2],
-      [true, 1],
-    ]);
+    expect(rows.map((row) => [row.hideRecruitmentCell, row.recruitmentRowSpan])).toEqual([[false, 1]]);
   });
 
   it("does not create rows from auxiliary-only contents", () => {

--- a/test/app/routes/pickup-history-edit.test.ts
+++ b/test/app/routes/pickup-history-edit.test.ts
@@ -82,6 +82,7 @@ jest.mock("~/models/student", () => ({
 }));
 
 jest.mock("~/models/timeline-content", () => ({
+  ...jest.requireActual<typeof import("~/models/timeline-content")>("~/models/timeline-content"),
   getTimelineContentsByRecruitmentGroupUids: jest.fn(),
 }));
 
@@ -210,6 +211,52 @@ describe("pickup history editor loader", () => {
       "gojinraigou-rerun",
       "magical-heavy-caliber",
     ]);
+  });
+
+  it("collapses a group shared by two events into one option with joined names", async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-11-25T00:00:00.000Z").getTime());
+
+    const sharedGroup = createGroup("shared-group", "2026-11-10T02:00:00Z");
+    mockedGetAllHistoricalRecruitmentGroups.mockResolvedValue([sharedGroup]);
+    mockedGetActiveSensei.mockResolvedValue({
+      id: 1,
+      uid: "sensei-1",
+      username: "sensei",
+    } as Awaited<ReturnType<typeof getActiveSensei>>);
+    mockedGetRecruitmentResult.mockResolvedValue(null);
+    mockedGetRecruitmentResultComment.mockResolvedValue(null);
+    mockedGetPickupHistory.mockResolvedValue(null);
+    mockedGetAllStudents.mockResolvedValue([]);
+    mockedGetTimelineContentsByRecruitmentGroupUids.mockResolvedValue([
+      {
+        uid: "event-b",
+        name: "이벤트B",
+        recruitmentGroupUid: "shared-group",
+        startAt: "2026-11-12T02:00:00.000Z",
+        isSpoiler: false,
+      },
+      {
+        uid: "event-a",
+        name: "이벤트A",
+        recruitmentGroupUid: "shared-group",
+        startAt: "2026-11-10T02:00:00.000Z",
+        isSpoiler: false,
+      },
+    ] as Awaited<ReturnType<typeof getTimelineContentsByRecruitmentGroupUids>>);
+
+    const result = await loader({
+      context: { cloudflare: { env } },
+      request: new Request("https://mollulog.net/@sensei/pickups/edit/new"),
+      params: { username: "@sensei", id: "new" },
+    } as never);
+    if (result instanceof Response) {
+      throw new Error(`Expected pickup history editor data, got redirect to ${result.headers.get("Location")}`);
+    }
+
+    expect(result.events.map((event: { uid: string; name: string }) => ({ uid: event.uid, name: event.name }))).toEqual(
+      [{ uid: "shared-group", name: "이벤트A / 이벤트B" }],
+    );
   });
 
   it("keeps given students out of exchangeable pickup candidates", async () => {

--- a/test/app/routes/pickup-history-index.test.ts
+++ b/test/app/routes/pickup-history-index.test.ts
@@ -36,6 +36,7 @@ jest.mock("~/models/student", () => ({
 }));
 
 jest.mock("~/models/timeline-content", () => ({
+  ...jest.requireActual<typeof import("~/models/timeline-content")>("~/models/timeline-content"),
   getTimelineContentsByRecruitmentGroupUids: jest.fn(),
 }));
 
@@ -142,7 +143,69 @@ describe("pickup history index loader", () => {
     const result = await loader(createLoaderArgs() as never);
 
     expect(mockedGetRecruitmentGroupsByUids).toHaveBeenCalledWith(env, ["hidden-heritage-rerun"]);
-    expect(result.recruitmentHistories[0].event.name).toBe("숨겨진 유산을 찾아서 ~트리니티 과외 활동~");
+    expect(result.recruitmentHistories[0].event.events).toEqual([
+      { uid: "content-hidden-heritage-rerun", name: "숨겨진 유산을 찾아서 ~트리니티 과외 활동~" },
+    ]);
+  });
+
+  it("lists every event sharing a recruitment group instead of dropping all but one", async () => {
+    mockedGetSenseiByUsername.mockResolvedValue({
+      id: 1,
+      uid: "sensei-1",
+      username: "sensei",
+    } as Awaited<ReturnType<typeof getSenseiByUsername>>);
+    mockedGetActiveSensei.mockResolvedValue({
+      id: 1,
+      uid: "sensei-1",
+      username: "sensei",
+    } as Awaited<ReturnType<typeof getActiveSensei>>);
+    mockedGetRecruitmentResults.mockResolvedValue([
+      {
+        uid: "history-shared",
+        userId: 1,
+        recruitmentGroupUid: "shared-group",
+        contentUid: null,
+        completedAt: "2026-11-10T02:00:00.000Z",
+        recruitedStudents: [{ studentUid: "a", tier: 3, pickup: true }],
+        exchangedStudents: [],
+        trial: 10,
+        rawResult: null,
+        commentPostUid: null,
+        createdAt: "2026-11-10T02:00:00.000Z",
+        updatedAt: "2026-11-10T02:00:00.000Z",
+      },
+    ]);
+    mockedGetAllStudentsMap.mockResolvedValue({
+      a: { uid: "a", name: "학생A", initialTier: 3 },
+    } as unknown as Awaited<ReturnType<typeof getAllStudentsMap>>);
+    mockedGetRecruitmentGroupsByUids.mockResolvedValue([
+      {
+        uid: "shared-group",
+        recruitmentType: "usual",
+        recruitments: [{ pickup: true, student: { uid: "a" } }],
+      },
+    ]);
+    mockedGetTimelineContentsByRecruitmentGroupUids.mockResolvedValue([
+      {
+        uid: "event-b",
+        name: "이벤트B",
+        recruitmentGroupUid: "shared-group",
+        startAt: "2026-11-12T02:00:00.000Z",
+      },
+      {
+        uid: "event-a",
+        name: "이벤트A",
+        recruitmentGroupUid: "shared-group",
+        startAt: "2026-11-10T02:00:00.000Z",
+      },
+    ] as Awaited<ReturnType<typeof getTimelineContentsByRecruitmentGroupUids>>);
+
+    const result = await loader(createLoaderArgs() as never);
+
+    expect(result.recruitmentHistories[0].event.events).toEqual([
+      { uid: "event-a", name: "이벤트A" },
+      { uid: "event-b", name: "이벤트B" },
+    ]);
   });
 
   it("uses the student's initial tier for pickup history display", async () => {

--- a/test/app/routes/students-id-relevant-timeline-contents.test.ts
+++ b/test/app/routes/students-id-relevant-timeline-contents.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import type { TimelineContent } from "~/models/timeline-content";
+
+jest.mock("~/auth/authenticator.server", () => ({ getActiveSensei: jest.fn() }));
+jest.mock("~/components/features/layout", () => ({
+  Page: jest.fn(() => null),
+  createPageErrorBoundary: jest.fn(() => null),
+}));
+jest.mock("~/components/features/students", () => ({ StudentInfo: jest.fn(() => null) }));
+jest.mock("~/lib/observability.server", () => ({ getLogger: jest.fn(() => ({ error: jest.fn() })) }));
+jest.mock("~/models/raid", () => ({ getAllRaidSchedules: jest.fn() }));
+jest.mock("~/models/recruited-student", () => ({ getRecruitedStudentTiers: jest.fn() }));
+jest.mock("~/models/student", () => ({
+  formatStudentFullName: jest.fn(),
+  getAllStudentsMap: jest.fn(),
+  getStudentDetail: jest.fn(),
+}));
+jest.mock("~/models/student-grading", () => ({ getStudentGradingsByStudentWithUsers: jest.fn() }));
+jest.mock("~/models/student-grading-tag", () => ({ getTagCountsByStudent: jest.fn() }));
+
+import { getStudentRelevantTimelineContents } from "../../../app/routes/students.$id";
+
+function timelineContent(overrides: Partial<TimelineContent> & { uid: string }): TimelineContent {
+  return {
+    name: overrides.uid,
+    nameI18n: {},
+    startAt: "2026-11-10T02:00:00.000Z",
+    endAt: "2026-11-24T02:00:00.000Z",
+    endless: false,
+    imageUrl: null,
+    videos: [],
+    contentType: "event",
+    runType: "first",
+    occurrence: null,
+    contentUid: null,
+    shopContentUid: null,
+    recruitmentGroupUid: null,
+    recruitmentStudentUids: null,
+    confirmed: true,
+    isSpoiler: false,
+    tags: [],
+    earnablePyroxene: null,
+    syncedAt: null,
+    ...overrides,
+  };
+}
+
+describe("getStudentRelevantTimelineContents", () => {
+  it("only keeps the event listing the student when a group is shared by two events", () => {
+    const eventA = timelineContent({
+      uid: "event-a",
+      recruitmentGroupUid: "shared-group",
+      recruitmentStudentUids: ["a", "b"],
+    });
+    const eventB = timelineContent({
+      uid: "event-b",
+      recruitmentGroupUid: "shared-group",
+      recruitmentStudentUids: ["c", "d"],
+    });
+
+    const resultForA = getStudentRelevantTimelineContents([eventA, eventB], ["shared-group"], "a");
+    const resultForC = getStudentRelevantTimelineContents([eventA, eventB], ["shared-group"], "c");
+
+    expect(resultForA.map((content) => content.uid)).toEqual(["event-a"]);
+    expect(resultForC.map((content) => content.uid)).toEqual(["event-b"]);
+  });
+
+  it("keeps every event across the student's distinct recruitment groups", () => {
+    const originalEvent = timelineContent({ uid: "event-original", recruitmentGroupUid: "group-1" });
+    const rerunEvent = timelineContent({ uid: "event-rerun", recruitmentGroupUid: "group-2" });
+
+    const result = getStudentRelevantTimelineContents(
+      [originalEvent, rerunEvent],
+      ["group-1", "group-2"],
+      "any-student",
+    );
+
+    expect(result.map((content) => content.uid)).toEqual(["event-original", "event-rerun"]);
+  });
+
+  it("does not duplicate an event that would otherwise match twice", () => {
+    const event = timelineContent({ uid: "event-a", recruitmentGroupUid: "group-1" });
+
+    const result = getStudentRelevantTimelineContents([event], ["group-1", "group-1"], "a");
+
+    expect(result.map((content) => content.uid)).toEqual(["event-a"]);
+  });
+});

--- a/test/app/views/community.test.ts
+++ b/test/app/views/community.test.ts
@@ -273,4 +273,31 @@ describe("enrichCommunityFeedPosts", () => {
     });
     expect(enriched.posts[0].pickupStudents.map((student) => student.uid)).toEqual(["10133", "20054"]);
   });
+
+  it("restricts pickupStudents to the subject event's recruitmentStudentUids when a group is shared", async () => {
+    const db = new FakeCommunityFeedD1Database();
+    mockedGetAllStudentsMap.mockResolvedValue({});
+    mockedGetGradingTagsByGradingUids.mockResolvedValue({});
+    mockedGetTimelineContentsByUids.mockResolvedValue([
+      {
+        uid: "content-1",
+        name: "이벤트#1",
+        recruitmentGroupUid: "shared-group",
+        recruitmentStudentUids: ["a"],
+      },
+    ] as Awaited<ReturnType<typeof getTimelineContentsByUids>>);
+    mockedGetRecruitmentGroupsByUids.mockResolvedValue([
+      {
+        uid: "shared-group",
+        recruitments: [
+          { pickup: true, recruitmentType: "limited", student: { uid: "a", name: "학생A" } },
+          { pickup: true, recruitmentType: "limited", student: { uid: "b", name: "학생B" } },
+        ],
+      },
+    ]);
+
+    const enriched = await enrichCommunityFeedPosts(createEnv(db), [createRecruitmentResultPost()]);
+
+    expect(enriched.posts[0].pickupStudents.map((student) => student.uid)).toEqual(["a"]);
+  });
 });

--- a/test/app/views/pyroxene.test.ts
+++ b/test/app/views/pyroxene.test.ts
@@ -1,6 +1,23 @@
-import { describe, expect, it } from "@jest/globals";
+import { describe, expect, it, jest } from "@jest/globals";
 import type { MainStoryVolume } from "~/models/main-story";
-import { buildMainStoryRewardContents } from "~/views/pyroxene";
+import type { TimelineContent } from "~/models/timeline-content";
+import { buildMainStoryRewardContents, getPyroxenePlannerContents } from "~/views/pyroxene";
+
+jest.mock("~/models/recruitment", () => ({
+  getRecruitmentGroupsByUids: jest.fn(),
+  getRecruitmentPoolStudents: jest.fn(),
+}));
+jest.mock("~/models/raid", () => ({ getRaidSchedule: jest.fn() }));
+jest.mock("~/models/student", () => ({ getAllStudentsMap: jest.fn() }));
+jest.mock("~/models/main-story", () => ({
+  ...jest.requireActual<typeof import("~/models/main-story")>("~/models/main-story"),
+  getMainStories: jest.fn(),
+}));
+jest.mock("~/models/timeline-content", () => ({
+  ...jest.requireActual<typeof import("~/models/timeline-content")>("~/models/timeline-content"),
+  getFutureRaidContents: jest.fn(),
+  getTimelineContents: jest.fn(),
+}));
 
 function mainStoryVolume(overrides: Partial<MainStoryVolume> = {}): MainStoryVolume {
   return {
@@ -85,5 +102,125 @@ describe("buildMainStoryRewardContents", () => {
     ]);
 
     expect(contents).toEqual([]);
+  });
+});
+
+function timelineContent(overrides: Partial<TimelineContent> & { uid: string }): TimelineContent {
+  return {
+    name: overrides.uid,
+    nameI18n: {},
+    startAt: "2026-11-10T02:00:00.000Z",
+    endAt: "2026-11-24T02:00:00.000Z",
+    endless: false,
+    imageUrl: null,
+    videos: [],
+    contentType: "event",
+    runType: "first",
+    occurrence: null,
+    contentUid: null,
+    shopContentUid: null,
+    recruitmentGroupUid: null,
+    recruitmentStudentUids: null,
+    confirmed: true,
+    isSpoiler: false,
+    tags: [],
+    earnablePyroxene: null,
+    syncedAt: null,
+    ...overrides,
+  };
+}
+
+function sharedGroupRecruitment(studentUid: string) {
+  return {
+    recruitmentType: "usual",
+    pickup: true,
+    rerun: false,
+    since: "2026-11-10T02:00:00.000Z",
+    until: null,
+    studentName: studentUid,
+    student: { uid: studentUid, name: studentUid, attackType: "explosive", defenseType: "light", role: "striker" },
+  };
+}
+
+describe("getPyroxenePlannerContents with a recruitment group shared by two events", () => {
+  it("splits into per-event reward-only entries plus one merged recruitment entry", async () => {
+    const { getRecruitmentGroupsByUids, getRecruitmentPoolStudents } =
+      jest.requireMock<typeof import("~/models/recruitment")>("~/models/recruitment");
+    const { getAllStudentsMap } = jest.requireMock<typeof import("~/models/student")>("~/models/student");
+    const { getMainStories } = jest.requireMock<typeof import("~/models/main-story")>("~/models/main-story");
+    const { getFutureRaidContents, getTimelineContents } =
+      jest.requireMock<typeof import("~/models/timeline-content")>("~/models/timeline-content");
+
+    const eventA = timelineContent({
+      uid: "event-a",
+      name: "이벤트A",
+      startAt: "2026-11-11T02:00:00.000Z",
+      endAt: "2026-11-20T02:00:00.000Z",
+      earnablePyroxene: 600,
+      tags: ["tag-a"],
+      recruitmentGroupUid: "shared-group",
+      recruitmentStudentUids: ["a", "b"],
+    });
+    const eventB = timelineContent({
+      uid: "event-b",
+      name: "이벤트B",
+      startAt: "2026-11-12T02:00:00.000Z",
+      endAt: "2026-11-22T02:00:00.000Z",
+      earnablePyroxene: 500,
+      tags: ["tag-b"],
+      recruitmentGroupUid: "shared-group",
+      recruitmentStudentUids: ["c", "d"],
+    });
+
+    (getTimelineContents as jest.MockedFunction<typeof getTimelineContents>).mockResolvedValue([eventA, eventB]);
+    (getFutureRaidContents as jest.MockedFunction<typeof getFutureRaidContents>).mockResolvedValue([]);
+    (getMainStories as jest.MockedFunction<typeof getMainStories>).mockResolvedValue([]);
+    (getAllStudentsMap as jest.MockedFunction<typeof getAllStudentsMap>).mockResolvedValue({});
+    (getRecruitmentPoolStudents as jest.MockedFunction<typeof getRecruitmentPoolStudents>).mockResolvedValue([]);
+    (getRecruitmentGroupsByUids as jest.MockedFunction<typeof getRecruitmentGroupsByUids>).mockResolvedValue([
+      {
+        uid: "shared-group",
+        startAt: "2026-11-10T02:00:00.000Z",
+        endAt: "2026-11-24T02:00:00.000Z",
+        recruitmentType: "usual",
+        recruitments: [
+          sharedGroupRecruitment("a"),
+          sharedGroupRecruitment("b"),
+          sharedGroupRecruitment("c"),
+          sharedGroupRecruitment("d"),
+        ],
+      },
+    ] as unknown as Awaited<ReturnType<typeof getRecruitmentGroupsByUids>>);
+
+    const contents = await getPyroxenePlannerContents({} as Env);
+
+    expect(new Set(contents.map((c) => c.uid))).toEqual(new Set(["event-a", "event-b", "group:shared-group"]));
+
+    const rewardA = contents.find((c) => c.uid === "event-a");
+    const rewardB = contents.find((c) => c.uid === "event-b");
+    expect(rewardA).toMatchObject({ earnablePyroxene: 600, recruitments: [] });
+    expect(rewardB).toMatchObject({ earnablePyroxene: 500, recruitments: [] });
+
+    const merged = contents.find((c) => c.uid === "group:shared-group");
+    expect(merged).toMatchObject({
+      name: "이벤트A / 이벤트B",
+      since: "2026-11-10T02:00:00.000Z",
+      until: "2026-11-24T02:00:00.000Z",
+      earnablePyroxene: null,
+    });
+    expect(merged && "recruitments" in merged ? merged.recruitments.map((r) => r.student?.uid) : null).toEqual([
+      "a",
+      "b",
+      "c",
+      "d",
+    ]);
+    expect(
+      merged && "recruitments" in merged ? merged.recruitments.map((r) => [r.student?.uid, r.sourceContentUid]) : null,
+    ).toEqual([
+      ["a", "event-a"],
+      ["b", "event-a"],
+      ["c", "event-b"],
+      ["d", "event-b"],
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

Link recruitment groups to timeline contents so shared recruitment groups can be represented correctly across event pages, futures, pickup history, community feed, student pages, and the pyroxene planner.

## Changes

- Add `timeline_contents.recruitment_student_uids` to restrict which students are shown for a timeline content that shares a recruitment group.
- Preserve multiple timeline contents for one recruitment group instead of collapsing them to one event.
- Update event detail, futures, home, community feed, student detail, pickup history, and pyroxene planner views to respect shared recruitment groups.
- Fix futures recruitment table grouping to use recruitment periods and show early-ending content separately.
- Add `FormContainer` and apply it to profile and pickup history forms.
- Refine pickup history form layout, event selector wrapping, placeholder tone, and simultaneous recruitment event card styling/copy.
- Add focused regression tests for recruitment filtering, shared recruitment groups, pickup history, futures table rows, community feed, and pyroxene planner behavior.

## Verification

- [x] I verified the related behavior myself.
- [ ] I ran `pnpm typecheck`, `pnpm exec biome check .`, and relevant tests when needed.
  - Ran `mise exec -- pnpm run typecheck`
  - Ran `mise exec -- pnpm test -- future-recruitment-table-model`
  - Did not run `pnpm exec biome check .`
- [x] (If AI tools were used) The generated content was reviewed by a person.

## Related issues

N/A