### PR TITLE
feat: add owned gift simulation to relationship calculator

### DIFF
--- a/app/components/features/relationship/FavoriteItemSelector.tsx
+++ b/app/components/features/relationship/FavoriteItemSelector.tsx
@@ -9,10 +9,12 @@ type FavoriteItemSelectorProps = {
   studentUid: string;
 
   quantities: Record<string, number>;
+  useOwnedQuantities: boolean;
   itemRequiredQuantities: Record<string, number> | null;
   itemQuantityBreakdowns: Record<string, ItemQuantityBreakdownEntry[]> | null;
   ownedQuantities: Record<string, number> | null;
   onQuantitiesChange: (quantities: Record<string, number>) => void;
+  onOwnedGiftQuantitiesChange: (quantities: Record<string, number>) => void;
   onSelectedItemExpChange: (exp: number) => void;
 };
 
@@ -21,10 +23,12 @@ const INSUFFICIENT_QUANTITY_CLASS = "text-red-600 dark:text-red-400";
 export default function FavoriteItemSelector({
   studentUid,
   quantities,
+  useOwnedQuantities,
   itemRequiredQuantities,
   itemQuantityBreakdowns,
   ownedQuantities,
   onQuantitiesChange,
+  onOwnedGiftQuantitiesChange,
   onSelectedItemExpChange,
 }: FavoriteItemSelectorProps) {
   const [filterFavorited, setFilterFavorited] = useState(true);
@@ -48,13 +52,20 @@ export default function FavoriteItemSelector({
   }, [fetcher.data]);
 
   const favoriteItems = fetcher.data?.uid === studentUid ? fetcher.data.favoriteItems : cachedFavoriteItems[studentUid];
+  const ownedGiftQuantities = useMemo(
+    () => getOwnedGiftQuantities(favoriteItems, ownedQuantities),
+    [favoriteItems, ownedQuantities],
+  );
+  const calculationQuantities = useOwnedQuantities ? ownedGiftQuantities : quantities;
   const filteredItems = useMemo(() => {
     if (!favoriteItems) {
       return [];
     }
 
     return favoriteItems
-      .filter(({ favorited }) => (filterFavorited ? favorited : true))
+      .filter(({ favorited, item }) =>
+        useOwnedQuantities ? (ownedGiftQuantities[item.uid] ?? 0) > 0 : filterFavorited ? favorited : true,
+      )
       .sort((a, b) => {
         if (a.item.rarity !== b.item.rarity) {
           return b.item.rarity - a.item.rarity;
@@ -64,34 +75,48 @@ export default function FavoriteItemSelector({
         }
         return Number.parseInt(a.item.uid, 10) - Number.parseInt(b.item.uid, 10);
       });
-  }, [favoriteItems, filterFavorited]);
+  }, [favoriteItems, filterFavorited, ownedGiftQuantities, useOwnedQuantities]);
+
+  useEffect(() => {
+    onOwnedGiftQuantitiesChange(ownedGiftQuantities);
+  }, [onOwnedGiftQuantitiesChange, ownedGiftQuantities]);
 
   useEffect(() => {
     if (!favoriteItems) {
       return;
     }
-    onSelectedItemExpChange(favoriteItems.reduce((acc, item) => acc + item.exp * (quantities[item.item.uid] ?? 0), 0));
-  }, [favoriteItems, onSelectedItemExpChange, quantities]);
+    onSelectedItemExpChange(
+      favoriteItems.reduce((acc, item) => acc + item.exp * (calculationQuantities[item.item.uid] ?? 0), 0),
+    );
+  }, [calculationQuantities, favoriteItems, onSelectedItemExpChange]);
 
   return (
     <SectionCard
       title="선물 목록"
-      description="선물할 개수를 입력하고 예상 도달 랭크를 계산해보세요"
+      description={
+        useOwnedQuantities
+          ? "현재 보유한 모든 선물을 주었을 때의 결과에요"
+          : "선물할 개수를 입력하고 예상 도달 랭크를 계산해보세요"
+      }
       action={
-        <Toggle
-          label="좋아하는 선물만 보기"
-          initialState={filterFavorited}
-          className="my-0"
-          onChange={setFilterFavorited}
-        />
+        useOwnedQuantities ? undefined : (
+          <Toggle
+            label="좋아하는 선물만 보기"
+            initialState={filterFavorited}
+            className="my-0"
+            onChange={setFilterFavorited}
+          />
+        )
       }
     >
       {!favoriteItems ? (
         <LoadingSkeleton />
+      ) : useOwnedQuantities && filteredItems.length === 0 ? (
+        <p className="py-6 text-center text-sm text-muted-foreground">재화 플래너에 등록된 보유 선물이 없어요.</p>
       ) : (
         <div className="grid grid-cols-[repeat(auto-fit,minmax(5rem,1fr))] justify-items-center gap-x-1 gap-y-0">
           {filteredItems.map(({ item, favoriteLevel, exp }) => {
-            const quantity = quantities[item.uid] || 0;
+            const quantity = calculationQuantities[item.uid] || 0;
             const totalItemExp = exp * quantity;
             const requiredQuantity = itemRequiredQuantities?.[item.uid] ?? 0;
             const ownedQuantity = ownedQuantities?.[item.uid] ?? 0;
@@ -110,10 +135,19 @@ export default function FavoriteItemSelector({
                 currentQuantity={quantity}
                 draftQuantity={quantity}
                 quantityLabel="목표"
+                showQuantityInput={!useOwnedQuantities}
                 inputProps={numberInputFlowNavigation.getInputProps()}
                 metrics={[
                   { label: "EXP", value: exp.toLocaleString() },
-                  ...(showQuantityComparison
+                  ...(useOwnedQuantities
+                    ? [
+                        {
+                          label: "사용",
+                          value: quantity.toLocaleString(),
+                        },
+                      ]
+                    : []),
+                  ...(!useOwnedQuantities && showQuantityComparison
                     ? [
                         {
                           label: "필요",
@@ -138,12 +172,29 @@ export default function FavoriteItemSelector({
                     hidden: quantity === 0,
                   },
                 ]}
-                onQuantityChange={(value) => onQuantitiesChange({ ...quantities, [item.uid]: value })}
+                onQuantityChange={
+                  useOwnedQuantities ? undefined : (value) => onQuantitiesChange({ ...quantities, [item.uid]: value })
+                }
               />
             );
           })}
         </div>
       )}
     </SectionCard>
+  );
+}
+
+export function getOwnedGiftQuantities(
+  favoriteItems: { item: { uid: string } }[] | null | undefined,
+  ownedQuantities: Record<string, number> | null,
+): Record<string, number> {
+  if (!favoriteItems || !ownedQuantities) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    favoriteItems
+      .map(({ item }) => [item.uid, ownedQuantities[item.uid] ?? 0] as const)
+      .filter(([, quantity]) => quantity > 0),
   );
 }

--- a/app/components/features/relationship/RelationshipStudentPicker.tsx
+++ b/app/components/features/relationship/RelationshipStudentPicker.tsx
@@ -42,7 +42,7 @@ export default function RelationshipStudentPicker({
         initialStudentUids={selectedStudentUid ? [selectedStudentUid] : undefined}
         placeholder={selectedStudent ? "다른 학생 검색..." : "이름으로 찾기..."}
         searchPlaceholder="학생 이름으로 검색"
-        className="max-w-none border-0 bg-transparent px-2 shadow-none hover:bg-muted/70 focus-visible:border-transparent"
+        className="max-w-none text-sm font-medium hover:border-foreground/30 hover:bg-background focus-visible:ring-ring"
         containerClassName="mt-0 mb-0"
         onSelect={(value) => {
           onSelectStudentUid(Array.isArray(value) ? (value[0] ?? null) : value || null);

--- a/app/components/primitives/SegmentedControl.tsx
+++ b/app/components/primitives/SegmentedControl.tsx
@@ -1,0 +1,60 @@
+import { useId } from "react";
+import { cn } from "~/lib/utils";
+
+export type SegmentedControlOption<T extends string> = {
+  value: T;
+  label: string;
+  disabled?: boolean;
+};
+
+type SegmentedControlProps<T extends string> = {
+  ariaLabel: string;
+  value: T;
+  options: SegmentedControlOption<T>[];
+  className?: string;
+  onChange: (value: T) => void;
+};
+
+export default function SegmentedControl<T extends string>({
+  ariaLabel,
+  value,
+  options,
+  className,
+  onChange,
+}: SegmentedControlProps<T>) {
+  const name = useId();
+
+  return (
+    <fieldset className={className}>
+      <legend className="sr-only">{ariaLabel}</legend>
+      <div className="flex gap-1 rounded-lg bg-muted p-1">
+        {options.map((option) => {
+          const active = value === option.value;
+          return (
+            <label
+              key={option.value}
+              className={cn(
+                "relative flex min-w-0 flex-1 cursor-pointer items-center justify-center rounded-md px-2 py-2 text-center text-sm font-medium transition-colors has-focus-visible:outline-none has-focus-visible:ring-2 has-focus-visible:ring-ring/30",
+                active
+                  ? "bg-card text-foreground shadow-sm shadow-black/5 dark:bg-background dark:shadow-none"
+                  : "text-muted-foreground hover:bg-foreground/10 hover:text-foreground",
+                option.disabled && "pointer-events-none opacity-50",
+              )}
+            >
+              <input
+                type="radio"
+                name={name}
+                value={option.value}
+                checked={active}
+                disabled={option.disabled}
+                className="sr-only"
+                onChange={() => onChange(option.value)}
+              />
+              <span className="min-w-0">{option.label}</span>
+            </label>
+          );
+        })}
+      </div>
+    </fieldset>
+  );
+}

--- a/app/components/primitives/index.ts
+++ b/app/components/primitives/index.ts
@@ -34,6 +34,8 @@ export { default as ResourceCard } from "./ResourceCard";
 export { default as Section } from "./Section";
 export type { SectionCardProps } from "./SectionCard";
 export { default as SectionCard } from "./SectionCard";
+export type { SegmentedControlOption } from "./SegmentedControl";
+export { default as SegmentedControl } from "./SegmentedControl";
 export { default as SubTitle } from "./SubTitle";
 export { default as TagIcon } from "./TagIcon";
 export { default as Textarea } from "./Textarea";

--- a/app/routes/utils.relationship._components/RelationshipGiftCalculationMode.tsx
+++ b/app/routes/utils.relationship._components/RelationshipGiftCalculationMode.tsx
@@ -40,9 +40,6 @@ export default function RelationshipGiftCalculationMode({
                 ? `총 ${ownedGiftCount.toLocaleString()}개로 ${ownedGiftExp.toLocaleString()} EXP를 얻을 수 있어요.`
                 : "재화 플래너에 등록된 보유 선물이 없어요."}
             </p>
-            <p className="mt-0.5 text-xs text-muted-foreground">
-              다른 학생의 선물 계획은 차감하지 않고, 현재 보유 수량 그대로 계산해요.
-            </p>
           </div>
           <Button
             text="선물 계획으로 저장"

--- a/app/routes/utils.relationship._components/RelationshipGiftCalculationMode.tsx
+++ b/app/routes/utils.relationship._components/RelationshipGiftCalculationMode.tsx
@@ -40,6 +40,9 @@ export default function RelationshipGiftCalculationMode({
                 ? `총 ${ownedGiftCount.toLocaleString()}개로 ${ownedGiftExp.toLocaleString()} EXP를 얻을 수 있어요.`
                 : "재화 플래너에 등록된 보유 선물이 없어요."}
             </p>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              다른 학생의 선물 계획은 차감하지 않고, 현재 보유 수량 그대로 계산해요.
+            </p>
           </div>
           <Button
             text="선물 계획으로 저장"

--- a/app/routes/utils.relationship._components/RelationshipGiftCalculationMode.tsx
+++ b/app/routes/utils.relationship._components/RelationshipGiftCalculationMode.tsx
@@ -1,0 +1,56 @@
+import { Button, SegmentedControl } from "~/components/primitives";
+
+export type RelationshipGiftCalculationModeValue = "manual" | "owned";
+
+type RelationshipGiftCalculationModeProps = {
+  mode: RelationshipGiftCalculationModeValue;
+  ownedGiftCount: number;
+  ownedGiftExp: number;
+  canSaveOwnedGiftPlan: boolean;
+  onModeChange: (mode: RelationshipGiftCalculationModeValue) => void;
+  onSaveOwnedGiftPlan: () => void;
+};
+
+const options: Array<{
+  value: RelationshipGiftCalculationModeValue;
+  label: string;
+}> = [
+  { value: "manual", label: "선물 수량 입력" },
+  { value: "owned", label: "보유한 모든 선물 주기" },
+];
+
+export default function RelationshipGiftCalculationMode({
+  mode,
+  ownedGiftCount,
+  ownedGiftExp,
+  canSaveOwnedGiftPlan,
+  onModeChange,
+  onSaveOwnedGiftPlan,
+}: RelationshipGiftCalculationModeProps) {
+  return (
+    <section className="mb-3 md:mb-4">
+      <SegmentedControl ariaLabel="선물 계산 방식" value={mode} options={options} onChange={onModeChange} />
+
+      {mode === "owned" ? (
+        <div className="mt-2 flex flex-col gap-2 rounded-md bg-primary/10 px-3 py-2.5 sm:flex-row sm:items-center sm:justify-between">
+          <div className="min-w-0">
+            <p className="text-sm font-medium text-foreground">보유 선물을 모두 주었을 때</p>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              {ownedGiftCount > 0
+                ? `총 ${ownedGiftCount.toLocaleString()}개로 ${ownedGiftExp.toLocaleString()} EXP를 얻을 수 있어요.`
+                : "재화 플래너에 등록된 보유 선물이 없어요."}
+            </p>
+          </div>
+          <Button
+            text="선물 계획으로 저장"
+            variant="primary"
+            size="sm"
+            className="shrink-0"
+            disabled={!canSaveOwnedGiftPlan}
+            onClick={onSaveOwnedGiftPlan}
+          />
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/app/routes/utils.relationship.tsx
+++ b/app/routes/utils.relationship.tsx
@@ -34,6 +34,9 @@ import {
 import { getAllStudentsFavoriteItems } from "~/models/resource";
 import { formatVisibleName, getAllStudents } from "~/models/student";
 import { getUserResourceInventoryMap } from "~/models/user-resource-inventory";
+import RelationshipGiftCalculationMode, {
+  type RelationshipGiftCalculationModeValue,
+} from "./utils.relationship._components/RelationshipGiftCalculationMode";
 
 export const meta: MetaFunction = ({ location }) => {
   const title = "인연 랭크 계산기 | 몰루로그";
@@ -177,6 +180,7 @@ type RelationshipStudentState = {
 
 const RELATIONSHIP_STUDENT_PATH = "/utils/relationship";
 const RELATIONSHIP_ITEM_SEARCH = "?mode=item";
+const EMPTY_GIFT_QUANTITIES: Record<string, number> = {};
 
 const emptyRelationship: Relationship = {
   currentLevel: 1,
@@ -211,6 +215,7 @@ export default function RelationshipUtil() {
   const initialSelectedStudentUid =
     queryStudentUid && students.some((student) => student.uid === queryStudentUid) ? queryStudentUid : null;
   const [selectedStudentUid, setSelectedStudentUid] = useState<string | null>(initialSelectedStudentUid);
+  const [giftCalculationMode, setGiftCalculationMode] = useState<RelationshipGiftCalculationModeValue>("manual");
   const syncedQueryStudentUidRef = useRef<string | null>(initialSelectedStudentUid);
   const selectedStudent = useMemo(
     () => managedStudents.find((student) => student.uid === selectedStudentUid) ?? null,
@@ -224,8 +229,19 @@ export default function RelationshipUtil() {
     return buildRelationshipItemQuantityState(managedStudents);
   }, [isAuthenticated, managedStudents]);
   const [selectedItemExp, setSelectedItemExp] = useState<number>(0);
+
+  const handleGiftCalculationModeChange = (mode: RelationshipGiftCalculationModeValue) => {
+    if (mode === "owned" && !isAuthenticated) {
+      showSignIn();
+      return;
+    }
+    setSelectedItemExp(0);
+    setGiftCalculationMode(mode);
+  };
+
   const handleSelectStudentUid = (studentUid: string | null) => {
     setSaveSuccess(false);
+    setSelectedItemExp(0);
     setSelectedStudentUid(studentUid);
   };
 
@@ -277,6 +293,7 @@ export default function RelationshipUtil() {
 
     syncedQueryStudentUidRef.current = queryStudentUid;
     setSaveSuccess(false);
+    setSelectedItemExp(0);
     setSelectedStudentUid(queryStudentUid);
   }, [queryStudentUid, managedStudents]);
 
@@ -538,6 +555,7 @@ export default function RelationshipUtil() {
           selectedStudentUid={selectedStudentUid}
           selectedStudent={selectedStudent}
           currentRelationship={currentRelationship}
+          giftCalculationMode={giftCalculationMode}
           selectedItemExp={selectedItemExp}
           saveState={savePending ? "pending" : saveFetcher.state}
           saveError={saveError}
@@ -545,6 +563,7 @@ export default function RelationshipUtil() {
           itemRequiredQuantities={itemQuantityState?.requiredQuantities ?? null}
           itemQuantityBreakdowns={itemQuantityState?.breakdowns ?? null}
           ownedQuantities={ownedQuantities}
+          onGiftCalculationModeChange={handleGiftCalculationModeChange}
           onCurrentRelationshipChange={setCurrentRelationship}
           onSelectedItemExpChange={setSelectedItemExp}
           onDelete={handleDelete}
@@ -559,6 +578,7 @@ function RelationshipStudentScreen({
   selectedStudentUid,
   selectedStudent,
   currentRelationship,
+  giftCalculationMode,
   selectedItemExp,
   saveState,
   saveError,
@@ -566,6 +586,7 @@ function RelationshipStudentScreen({
   itemRequiredQuantities,
   itemQuantityBreakdowns,
   ownedQuantities,
+  onGiftCalculationModeChange,
   onCurrentRelationshipChange,
   onSelectedItemExpChange,
   onDelete,
@@ -574,6 +595,7 @@ function RelationshipStudentScreen({
   selectedStudentUid: string | null;
   selectedStudent: RelationshipStudentState | null;
   currentRelationship: Relationship;
+  giftCalculationMode: RelationshipGiftCalculationModeValue;
   selectedItemExp: number;
   saveState: SaveState;
   saveError: string | null;
@@ -581,10 +603,45 @@ function RelationshipStudentScreen({
   itemRequiredQuantities: Record<string, number> | null;
   itemQuantityBreakdowns: Record<string, ItemQuantityBreakdownEntry[]> | null;
   ownedQuantities: Record<string, number> | null;
+  onGiftCalculationModeChange: (mode: RelationshipGiftCalculationModeValue) => void;
   onCurrentRelationshipChange: Dispatch<SetStateAction<Relationship>>;
   onSelectedItemExpChange: (exp: number) => void;
   onDelete: () => void;
 }) {
+  const [ownedGiftPlan, setOwnedGiftPlan] = useState<{
+    studentUid: string;
+    quantities: Record<string, number>;
+  } | null>(null);
+  const ownedGiftQuantities =
+    ownedGiftPlan?.studentUid === selectedStudentUid ? ownedGiftPlan.quantities : EMPTY_GIFT_QUANTITIES;
+  const ownedGiftCount = useMemo(
+    () => Object.values(ownedGiftQuantities).reduce((total, quantity) => total + quantity, 0),
+    [ownedGiftQuantities],
+  );
+  const handleOwnedGiftQuantitiesChange = useCallback(
+    (quantities: Record<string, number>) => {
+      if (!selectedStudentUid) {
+        return;
+      }
+      setOwnedGiftPlan({ studentUid: selectedStudentUid, quantities });
+    },
+    [selectedStudentUid],
+  );
+
+  const handleSaveOwnedGiftPlan = () => {
+    if (ownedGiftCount <= 0) {
+      return;
+    }
+
+    const hasExistingGiftPlan = Object.values(currentRelationship.items).some((quantity) => quantity > 0);
+    if (hasExistingGiftPlan && !window.confirm("현재 학생의 기존 선물 계획을 보유 선물 수량으로 변경할까요?")) {
+      return;
+    }
+
+    onCurrentRelationshipChange((previous) => ({ ...previous, items: ownedGiftQuantities }));
+    onGiftCalculationModeChange("manual");
+  };
+
   return (
     <div className="min-w-0 overflow-x-hidden">
       {selectedStudentUid && selectedStudent ? (
@@ -594,6 +651,15 @@ function RelationshipStudentScreen({
             saveState={saveState}
             saveError={saveError}
             saveSuccess={saveSuccess}
+          />
+
+          <RelationshipGiftCalculationMode
+            mode={giftCalculationMode}
+            ownedGiftCount={ownedGiftCount}
+            ownedGiftExp={selectedItemExp}
+            canSaveOwnedGiftPlan={ownedGiftCount > 0}
+            onModeChange={onGiftCalculationModeChange}
+            onSaveOwnedGiftPlan={handleSaveOwnedGiftPlan}
           />
 
           <StudentRelationshipLevel
@@ -616,10 +682,12 @@ function RelationshipStudentScreen({
           <FavoriteItemSelector
             studentUid={selectedStudentUid}
             quantities={currentRelationship.items}
+            useOwnedQuantities={giftCalculationMode === "owned"}
             itemRequiredQuantities={itemRequiredQuantities}
             itemQuantityBreakdowns={itemQuantityBreakdowns}
             ownedQuantities={ownedQuantities}
             onQuantitiesChange={(quantities) => onCurrentRelationshipChange((prev) => ({ ...prev, items: quantities }))}
+            onOwnedGiftQuantitiesChange={handleOwnedGiftQuantitiesChange}
             onSelectedItemExpChange={onSelectedItemExpChange}
           />
 

--- a/test/app/components/features/relationship/favorite-item-selector.test.ts
+++ b/test/app/components/features/relationship/favorite-item-selector.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "@jest/globals";
+import { getOwnedGiftQuantities } from "~/components/features/relationship/FavoriteItemSelector";
+
+describe("getOwnedGiftQuantities", () => {
+  const favoriteItems = [{ item: { uid: "gift-a" } }, { item: { uid: "gift-b" } }, { item: { uid: "gift-c" } }];
+
+  it("keeps only positive inventory quantities for gifts the selected student can receive", () => {
+    expect(
+      getOwnedGiftQuantities(favoriteItems, {
+        "gift-a": 3,
+        "gift-b": 0,
+        "other-resource": 99,
+      }),
+    ).toEqual({ "gift-a": 3 });
+  });
+
+  it("returns an empty plan before gift or inventory data is available", () => {
+    expect(getOwnedGiftQuantities(undefined, { "gift-a": 3 })).toEqual({});
+    expect(getOwnedGiftQuantities(favoriteItems, null)).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary

Adds an owned-gift simulation mode to the relationship calculator so signed-in users can preview the expected relationship rank after giving all gifts currently in their inventory.

The simulation remains separate from saved gift plans and does not deduct gifts assigned to other students. Users can explicitly save the simulated quantities as the selected student's gift plan.

## Changes

- Add `선물 수량 입력` and `보유한 모든 선물 주기` calculation modes.
- Use every positive gift quantity in the user's inventory for the selected student, including non-preferred gifts.
- Keep the owned-gift simulation read-only and show the total gift count and expected EXP.
- Add an explicit `선물 계획으로 저장` action with confirmation before overwriting an existing plan.
- Keep other students' gift plans independent from the inventory simulation.
- Prompt guests to sign in when selecting the owned-gift mode.
- Add a reusable segmented control primitive.
- Improve the student selector so it is visually recognizable as an interactive control.
- Add regression coverage for converting owned inventory into gift quantities.

## Verification

- [x] I verified the related behavior myself.
- [ ] I ran `pnpm typecheck`, `pnpm exec biome check .`, and relevant tests when needed.
- [ ] (If AI tools were used) The generated content was reviewed by a person.

Additional verification:

- [x] `pnpm run typecheck`
- [x] `pnpm test --runInBand` — 113 suites and 680 tests passed
- [x] `pnpm run prod:build`
- [x] Biome checks for all changed files
- [x] `git diff --check`
- [ ] `pnpm exec biome check .` — reports existing diagnostics from generated `.react-router/types/**` files

## Related issues

None.
