### PR TITLE
feat: add guest access and data import to pyroxene planner

### DIFF
--- a/app/components/features/futures/PyroxeneChart.tsx
+++ b/app/components/features/futures/PyroxeneChart.tsx
@@ -187,7 +187,7 @@ export default function PyroxeneChart({ timeline }: PyroxeneChartProps) {
             domain={["dataMin", "dataMax"]}
             scale="time"
             ticks={monthlyTicks}
-            tickFormatter={(v) => dayjs(v as number).format("M/D")}
+            tickFormatter={(v) => dayjs(v as number).format("MM/DD")}
             tick={{ fontSize: 11, fill: axisColor }}
             axisLine={false}
             tickLine={false}
@@ -225,9 +225,7 @@ export default function PyroxeneChart({ timeline }: PyroxeneChartProps) {
                     padding: "8px 12px",
                   }}
                 >
-                  <p style={{ color: axisColor, fontSize: 11, marginBottom: 2 }}>
-                    {dayjs(item.ts).format("YYYY-MM-DD")}
-                  </p>
+                  <p style={{ color: axisColor, fontSize: 11, marginBottom: 2 }}>{dayjs(item.ts).format("MM/DD")}</p>
                   <p style={{ color: tooltipText, fontSize: 13, fontWeight: 600 }}>
                     {item.pyroxene.toLocaleString()}개
                   </p>

--- a/app/components/features/futures/PyroxeneInitialResources.tsx
+++ b/app/components/features/futures/PyroxeneInitialResources.tsx
@@ -5,6 +5,7 @@ import type { PyroxeneCollectedSourceCandidate } from "~/domain/pyroxene-schedul
 import { PYROXENE_RESOURCE_UIDS } from "~/domain/pyroxene-sources";
 import type { PickupResources } from "~/domain/pyroxene-timeline";
 import { ResourceTypeEnum } from "~/graphql/graphql";
+import { cn } from "~/lib/utils";
 import ResourcesInput from "./planner-input/ResourcesInput";
 
 const resourceItems = [
@@ -111,24 +112,32 @@ export default function PyroxeneInitialResources({
             <div className="mt-4 border-t border-border pt-4">
               <p className="text-sm font-semibold">이미 받은 보상</p>
               <p className="mt-1 text-xs text-muted-foreground">
-                선택한 이벤트 보상은 이후 그래프에서 중복 계산하지 않아요.
+                이미 받은 보상이 있다면 중복 계산이 되지 않도록 선택해주세요.
               </p>
               <div className="mt-3 space-y-2">
-                {collectedSourceCandidates.map((candidate) => (
-                  <Checkbox
-                    key={candidate.sourceKey}
-                    checked={selectedCollectedSourceKeys.includes(candidate.sourceKey)}
-                    onChange={(checked) => handleToggleCollectedSource(candidate.sourceKey, checked)}
-                    label={
-                      <span className="flex flex-col">
-                        <span className="font-medium">{candidate.title}</span>
-                        {candidate.description && (
-                          <span className="text-xs text-muted-foreground">{candidate.description}</span>
-                        )}
-                      </span>
-                    }
-                  />
-                ))}
+                {collectedSourceCandidates.map((candidate) => {
+                  const checked = selectedCollectedSourceKeys.includes(candidate.sourceKey);
+                  return (
+                    <Checkbox
+                      key={candidate.sourceKey}
+                      checked={checked}
+                      onChange={(nextChecked) => handleToggleCollectedSource(candidate.sourceKey, nextChecked)}
+                      className={cn(
+                        "w-full items-start rounded-lg border px-4 py-3 transition-colors",
+                        checked ? "border-primary/50 bg-primary/5" : "border-border bg-card hover:bg-muted/50",
+                      )}
+                      aria-label={candidate.title}
+                      label={
+                        <span className="min-w-0">
+                          <span className="block text-sm font-medium text-foreground">{candidate.title}</span>
+                          {candidate.description && (
+                            <span className="mt-0.5 block text-sm text-muted-foreground">{candidate.description}</span>
+                          )}
+                        </span>
+                      }
+                    />
+                  );
+                })}
               </div>
             </div>
           )}

--- a/app/components/features/futures/PyroxeneSchedule.tsx
+++ b/app/components/features/futures/PyroxeneSchedule.tsx
@@ -1,8 +1,12 @@
 import dayjs from "dayjs";
-import { useMemo } from "react";
-import { Callout, EmptyView, Section, SectionCard } from "~/components/primitives";
+import { useEffect, useMemo, useState } from "react";
+import { EmptyView, Section, SectionCard, Toggle } from "~/components/primitives";
 import type { PyroxeneCalculationOptions, PyroxenePlannerOptions } from "~/domain/pyroxene-planner";
-import type { PyroxeneCollectedSourceCandidate, PyroxeneScheduleItem } from "~/domain/pyroxene-schedule";
+import {
+  buildPyroxeneDisplayTimeline,
+  type PyroxeneCollectedSourceCandidate,
+  type PyroxeneScheduleItem,
+} from "~/domain/pyroxene-schedule";
 import { collectedSourceKeyForEventReward } from "~/domain/pyroxene-sources";
 import type { PickupResources } from "~/domain/pyroxene-timeline";
 import PyroxeneAvailableOneTimePackages from "./PyroxeneAvailableOneTimePackages";
@@ -19,12 +23,15 @@ type PyroxeneScheduleProps = {
   scheduleItems: PyroxeneScheduleItem[];
   options: PyroxenePlannerOptions;
   collectedSourceKeys: string[];
+  recruitedStudentUids: string[];
 
   onPickupComplete: (eventUid: string | null, resources: PickupResources, collectedSourceKeys?: string[]) => void;
   onDeletePickupComplete: (eventUid: string) => void;
   onDeleteItem: (itemUid: string) => void;
   onUpdateEventData: (eventUid: string, data: { expectedTrials?: number | null }) => void;
   onCollectedSourceChange: (sourceKey: string, collected: boolean) => void;
+  allowPickupCompletion: boolean;
+  onFavoriteChange: (contentUid: string, studentUid: string, favorited: boolean) => void;
 };
 
 const deletableTimelineSourceTypes = new Set([
@@ -36,6 +43,7 @@ const deletableTimelineSourceTypes = new Set([
   "other",
 ]);
 const availablePackageSourceTypes = new Set(["package_onetime", "package_ap"]);
+const hideUnfavoritedEventsStorageKey = "pyroxene-planner::hide-unfavorited-events";
 
 function getAvailablePackageDate({
   date,
@@ -65,12 +73,34 @@ export default function PyroxeneSchedule({
   scheduleItems,
   options,
   collectedSourceKeys,
+  recruitedStudentUids,
   onPickupComplete,
   onDeletePickupComplete,
   onDeleteItem,
   onUpdateEventData,
   onCollectedSourceChange,
+  allowPickupCompletion,
+  onFavoriteChange,
 }: PyroxeneScheduleProps) {
+  const [hideUnfavoritedEvents, setHideUnfavoritedEvents] = useState(false);
+
+  useEffect(() => {
+    try {
+      setHideUnfavoritedEvents(localStorage.getItem(hideUnfavoritedEventsStorageKey) === "true");
+    } catch (_error) {
+      // Ignore unavailable local storage and keep the default display.
+    }
+  }, []);
+
+  const handleHideUnfavoritedEventsChange = (value: boolean) => {
+    setHideUnfavoritedEvents(value);
+    try {
+      localStorage.setItem(hideUnfavoritedEventsStorageKey, String(value));
+    } catch (_error) {
+      // Ignore unavailable local storage and keep the setting for this tab.
+    }
+  };
+
   // 표시 필터(timeline.display)는 계산 결과에 영향을 주지 않으므로 계산 입력에서 제외합니다.
   // 이렇게 하면 표시 토글이 무거운 재계산을 유발하지 않습니다.
   const calcOptions = useMemo<PyroxeneCalculationOptions>(
@@ -95,6 +125,22 @@ export default function PyroxeneSchedule({
     options.event.pickupChance === "ceil"
       ? "설정한 목표를 모두 천장으로 계산한 시뮬레이션 결과에요"
       : "설정한 목표와, 상위/하위 10% 범위의 시뮬레이션 결과에요";
+
+  // 관심 학생이 아직 없는 모집도 선택 진입점으로 보여주되 계산 결과에는 포함하지 않습니다.
+  const displayTimeline = useMemo(
+    () => buildPyroxeneDisplayTimeline(timeline, scheduleItems, initialDate ?? new Date(), initialResources),
+    [initialDate, initialResources, scheduleItems, timeline],
+  );
+  const visibleDisplayTimeline = useMemo(() => {
+    if (!hideUnfavoritedEvents) return displayTimeline;
+
+    return displayTimeline.filter(({ source }) => {
+      const event = source.event;
+      if (!event) return true;
+      if (eventDataMap.get(event.uid)?.completed) return true;
+      return event.recruitments.some(({ favorited, pickup, student }) => pickup && student && favorited);
+    });
+  }, [displayTimeline, eventDataMap, hideUnfavoritedEvents]);
 
   // 적용 중인 패키지는 삭제가 가능하도록 별도 레이아웃에서 표시
   const availableOneTimePackages = useMemo(() => {
@@ -143,6 +189,7 @@ export default function PyroxeneSchedule({
   }, [initialDate, scheduleItems]);
 
   const collectedSourceKeySet = useMemo(() => new Set(collectedSourceKeys), [collectedSourceKeys]);
+  const recruitedStudentUidSet = useMemo(() => new Set(recruitedStudentUids), [recruitedStudentUids]);
   const collectableSourceKeySet = useMemo(() => {
     const currentDate = dayjs();
     const sourceKeys = new Set<string>();
@@ -207,12 +254,11 @@ export default function PyroxeneSchedule({
         title="현재 보유 재화"
         description={
           initialDate
-            ? `마지막 입력 : ${dayjs(initialDate).format("YYYY-MM-DD HH:mm")}`
+            ? `마지막 입력 : ${dayjs(initialDate).format("MM/DD HH:mm")}`
             : "현재 보유중인 재화 수량을 입력해주세요"
         }
       >
         <div className="space-y-3">
-          {!initialDate && <Callout>현재 보유중인 재화 수량을 입력해주세요.</Callout>}
           <PyroxeneInitialResources
             resources={initialResources}
             collectedSourceCandidates={collectedSourceCandidates}
@@ -238,16 +284,25 @@ export default function PyroxeneSchedule({
         </SectionCard>
       </Section>
 
-      <Section
-        title="타임라인"
-        description="미래시 페이지에서 등록한 관심 학생의 모집 시점의 예상 청휘석을 확인할 수 있어요"
-      >
-        <div className="space-y-2">
+      <section>
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+          <div className="min-w-0 grow">
+            <h2 className="text-lg font-semibold text-foreground">타임라인</h2>
+            <p className="mt-1 text-sm text-muted-foreground">관심 학생의 모집 시점의 예상 청휘석을 확인할 수 있어요</p>
+          </div>
+          <Toggle
+            label="관심 학생이 없는 이벤트 숨기기"
+            initialState={hideUnfavoritedEvents}
+            className="my-0 shrink-0"
+            onChange={handleHideUnfavoritedEventsChange}
+          />
+        </div>
+        <div className="mt-4 space-y-2">
           {!isTimelinePending &&
-            timeline.every(
+            visibleDisplayTimeline.every(
               ({ source }) => source.type !== "event" && !options.timeline.display.includes(source.type),
             ) && <EmptyView text="표시할 일정이 없어요. 미래시에서 관심 학생을 등록하거나 수급 계획을 추가해보세요." />}
-          {timeline.map(({ date, accumulatedResources, resourceDelta, source }, index) => {
+          {visibleDisplayTimeline.map(({ date, accumulatedResources, resourceDelta, source }, index) => {
             if (source.type !== "event" && !options.timeline.display.includes(source.type)) {
               return null;
             }
@@ -267,6 +322,9 @@ export default function PyroxeneSchedule({
                     completed={eventData?.completed ?? false}
                     expectedTrials={eventData?.expectedTrials ?? null}
                     pickupChance={options.event.pickupChance}
+                    allowPickupCompletion={allowPickupCompletion}
+                    recruitedStudentUids={recruitedStudentUidSet}
+                    onFavoriteChange={onFavoriteChange}
                     accumulatedResources={accumulatedResources}
                     resourceDelta={resourceDelta}
                     onDeletePickupComplete={onDeletePickupComplete}
@@ -310,7 +368,7 @@ export default function PyroxeneSchedule({
             return null;
           })}
         </div>
-      </Section>
+      </section>
     </div>
   );
 }

--- a/app/components/features/futures/PyroxeneTimelineEvent.tsx
+++ b/app/components/features/futures/PyroxeneTimelineEvent.tsx
@@ -18,6 +18,9 @@ type PyroxeneTimelineEventProps = {
   completed: boolean;
   expectedTrials: number | null;
   pickupChance: PyroxenePickupChance;
+  allowPickupCompletion: boolean;
+  recruitedStudentUids: ReadonlySet<string>;
+  onFavoriteChange: (contentUid: string, studentUid: string, favorited: boolean) => void;
   onDeletePickupComplete: (eventUid: string) => void;
   onPickupComplete: (eventUid: string, resources: PickupResources) => void;
   onUpdateEventData: (eventUid: string, data: { expectedTrials?: number | null }) => void;
@@ -30,6 +33,9 @@ export default function PyroxeneTimelineEvent({
   completed,
   expectedTrials,
   pickupChance,
+  allowPickupCompletion,
+  recruitedStudentUids,
+  onFavoriteChange,
   onDeletePickupComplete,
   onPickupComplete,
   onUpdateEventData,
@@ -38,18 +44,31 @@ export default function PyroxeneTimelineEvent({
   const [showExpectedTrialsAction, setShowExpectedTrialsAction] = useState(false);
   const [expectedTrialsInputValue, setExpectedTrialsInputValue] = useState<number>(expectedTrials ?? 0);
   const [confirmingPickupDelete, setConfirmingPickupDelete] = useState(false);
-  const favoritedStudents = useMemo(
+  const pickupStudents = useMemo(
     () =>
-      event.recruitments.flatMap(({ favorited, student }) => {
-        if (!favorited || !student) {
+      event.recruitments.flatMap(({ pickup, favorited, sourceContentUid, student }) => {
+        if (!pickup || !student) {
           return [];
         }
-        return [{ uid: student.uid, name: student.name, tier: student.initialTier }];
+        const contentUid = sourceContentUid ?? event.uid;
+        return [
+          {
+            uid: student.uid,
+            selectionKey: `${contentUid}\u0000${student.uid}`,
+            contentUid,
+            name: student.name,
+            tier: recruitedStudentUids.has(student.uid) ? undefined : student.initialTier,
+            label: recruitedStudentUids.has(student.uid) ? "모집함" : undefined,
+            grayscale: !favorited,
+            state: { favorited },
+          },
+        ];
       }),
-    [event.recruitments],
+    [event.recruitments, event.uid, recruitedStudentUids],
   );
 
-  const canComplete = !completed && dayjs(event.since).isBefore(dayjs());
+  const canComplete = allowPickupCompletion && !completed && dayjs(event.since).isBefore(dayjs());
+  const selectedStudentCount = pickupStudents.filter((student) => student.state.favorited).length;
   const freeRecruitment100 = isFreeRecruitment100Event(event);
   const expectedTrialsLabel =
     expectedTrials !== null
@@ -70,6 +89,44 @@ export default function PyroxeneTimelineEvent({
     setTimeout(() => setConfirmingPickupDelete(false), 3000);
   };
 
+  if (!completed && selectedStudentCount === 0) {
+    return (
+      <div className="relative py-1">
+        <SectionCard className="p-3 shadow-md dark:shadow-md md:p-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div className="min-w-0">
+              <div className="mb-1 flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
+                <span>
+                  {dayjs(event.since).format("MM/DD")} ~ {dayjs(event.until).format("MM/DD")}
+                </span>
+                {freeRecruitment100 && (
+                  <span className="inline-flex items-center rounded-full bg-yellow-100 px-2 py-0.5 font-medium text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200">
+                    <StarIcon className="mr-1 size-3.5" />
+                    100회 무료
+                  </span>
+                )}
+              </div>
+              <h3 className="line-clamp-2 whitespace-pre-line text-sm font-semibold leading-tight text-foreground md:text-base">
+                {event.name}
+              </h3>
+            </div>
+            <StudentCards
+              students={pickupStudents}
+              layout="wrap"
+              cardSize="xs"
+              gap="tight"
+              namePlacement="overlay"
+              onSelect={(selectionKey) => {
+                const [contentUid, studentUid] = selectionKey.split("\u0000");
+                if (contentUid && studentUid) onFavoriteChange(contentUid, studentUid, true);
+              }}
+            />
+          </div>
+        </SectionCard>
+      </div>
+    );
+  }
+
   return (
     <div className="relative py-1">
       <SectionCard className="p-4 shadow-md dark:shadow-md md:p-5">
@@ -78,7 +135,7 @@ export default function PyroxeneTimelineEvent({
             <div className="min-w-0">
               <div className="mb-1 flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
                 <span>
-                  {dayjs(event.since).format("MM.DD")} ~ {dayjs(event.until).format("MM.DD")}
+                  {dayjs(event.since).format("MM/DD")} ~ {dayjs(event.until).format("MM/DD")}
                 </span>
                 {freeRecruitment100 && (
                   <span className="inline-flex items-center rounded-full bg-yellow-100 px-2 py-0.5 font-medium text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200">
@@ -92,14 +149,26 @@ export default function PyroxeneTimelineEvent({
               </h3>
             </div>
 
-            {favoritedStudents.length > 0 && (
-              <StudentCards
-                students={favoritedStudents}
-                layout="wrap"
-                cardSize="md"
-                gap="tight"
-                namePlacement="overlay"
-              />
+            {pickupStudents.length > 0 && (
+              <div className="space-y-1.5">
+                <p className="text-xs text-muted-foreground">
+                  모집 목표 {selectedStudentCount}명 · 학생을 눌러 변경할 수 있어요
+                </p>
+                <StudentCards
+                  students={pickupStudents}
+                  layout="wrap"
+                  cardSize="md"
+                  gap="tight"
+                  namePlacement="overlay"
+                  onSelect={(selectionKey) => {
+                    const [contentUid, studentUid] = selectionKey.split("\u0000");
+                    const student = pickupStudents.find((item) => item.selectionKey === selectionKey);
+                    if (contentUid && studentUid && student) {
+                      onFavoriteChange(contentUid, studentUid, !student.state.favorited);
+                    }
+                  }}
+                />
+              </div>
             )}
           </div>
 

--- a/app/components/features/futures/PyroxeneTimelineEvent.tsx
+++ b/app/components/features/futures/PyroxeneTimelineEvent.tsx
@@ -150,25 +150,20 @@ export default function PyroxeneTimelineEvent({
             </div>
 
             {pickupStudents.length > 0 && (
-              <div className="space-y-1.5">
-                <p className="text-xs text-muted-foreground">
-                  모집 목표 {selectedStudentCount}명 · 학생을 눌러 변경할 수 있어요
-                </p>
-                <StudentCards
-                  students={pickupStudents}
-                  layout="wrap"
-                  cardSize="md"
-                  gap="tight"
-                  namePlacement="overlay"
-                  onSelect={(selectionKey) => {
-                    const [contentUid, studentUid] = selectionKey.split("\u0000");
-                    const student = pickupStudents.find((item) => item.selectionKey === selectionKey);
-                    if (contentUid && studentUid && student) {
-                      onFavoriteChange(contentUid, studentUid, !student.state.favorited);
-                    }
-                  }}
-                />
-              </div>
+              <StudentCards
+                students={pickupStudents}
+                layout="wrap"
+                cardSize="md"
+                gap="tight"
+                namePlacement="overlay"
+                onSelect={(selectionKey) => {
+                  const [contentUid, studentUid] = selectionKey.split("\u0000");
+                  const student = pickupStudents.find((item) => item.selectionKey === selectionKey);
+                  if (contentUid && studentUid && student) {
+                    onFavoriteChange(contentUid, studentUid, !student.state.favorited);
+                  }
+                }}
+              />
             )}
           </div>
 

--- a/app/components/features/futures/PyroxeneTimelineResources.tsx
+++ b/app/components/features/futures/PyroxeneTimelineResources.tsx
@@ -53,7 +53,7 @@ export default function PyroxeneTimelineResources({
       <div className="min-w-0 flex-1">
         <div className="flex flex-col gap-0.5 sm:flex-row sm:items-baseline sm:gap-3">
           <p className="shrink-0 text-xs font-semibold sm:text-sm">
-            {date.format("MM.DD")}({date.format("ddd")})
+            {date.format("MM/DD")}({date.format("ddd")})
           </p>
           <TimelineResourceDescription description={description} />
         </div>

--- a/app/components/features/futures/index.ts
+++ b/app/components/features/futures/index.ts
@@ -2,4 +2,5 @@ export { default as ContentFilterPanel } from "./ContentFilterPanel";
 export { default as PyroxenePlannerOptionsPanel } from "./PyroxenePlannerOptionsPanel";
 export { default as PyroxenePlannerSourcePanel } from "./PyroxenePlannerSourcePanel";
 export { default as PyroxeneSchedule } from "./PyroxeneSchedule";
+export { useGuestPyroxenePlanner } from "./useGuestPyroxenePlanner";
 export { usePyroxeneScheduleItems } from "./usePyroxeneScheduleItems";

--- a/app/components/features/futures/planner-input/PackageInput.tsx
+++ b/app/components/features/futures/planner-input/PackageInput.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useMemo, useState } from "react";
 import { Button, Checkbox, Field, FilterButtons, Input, NumberInput } from "~/components/primitives";
 import {
+  calculatePackageStartDateFromRemainingDays,
   PYROXENE_AP_PACKAGE_CONFIG,
   PYROXENE_MONTHLY_PACKAGE_CONFIG,
   type PyroxeneMonthlyPackageType,
-  calculatePackageStartDateFromRemainingDays,
 } from "~/domain/pyroxene-sources";
 import dayjs from "~/lib/dayjs";
 
@@ -98,7 +98,7 @@ function PackageStartDateInput({ packageDurationDays, startDate, onStartDateChan
             }}
           />
           <p className="text-xs text-muted-foreground">
-            {dayjs(calculatedStartDate).tz("Asia/Seoul").format("YYYY-MM-DD")} 패키지 시작
+            {dayjs(calculatedStartDate).tz("Asia/Seoul").format("MM/DD")} 패키지 시작
           </p>
         </div>
       )}

--- a/app/components/features/futures/useGuestPyroxenePlanner.ts
+++ b/app/components/features/futures/useGuestPyroxenePlanner.ts
@@ -1,0 +1,33 @@
+import { useCallback, useEffect, useState } from "react";
+import type { GuestPyroxenePlannerData } from "~/domain/guest-pyroxene-planner";
+import {
+  type GuestPyroxeneSnapshot,
+  readGuestPyroxenePlanner,
+  resetGuestPyroxenePlanner,
+  subscribeGuestPyroxenePlanner,
+  updateGuestPyroxenePlanner,
+} from "~/lib/guest-pyroxene-planner.client";
+
+export function useGuestPyroxenePlanner() {
+  const [snapshot, setSnapshot] = useState<GuestPyroxeneSnapshot | null>(null);
+
+  useEffect(() => {
+    const refresh = () => setSnapshot(readGuestPyroxenePlanner());
+    refresh();
+    return subscribeGuestPyroxenePlanner(refresh);
+  }, []);
+
+  const update = useCallback(async (updater: (data: GuestPyroxenePlannerData) => GuestPyroxenePlannerData) => {
+    const next = await updateGuestPyroxenePlanner(updater);
+    setSnapshot(next);
+    return next;
+  }, []);
+
+  const reset = useCallback(() => {
+    const next = resetGuestPyroxenePlanner();
+    setSnapshot(next);
+    return next;
+  }, []);
+
+  return { snapshot, update, reset };
+}

--- a/app/components/features/layout/NavigationBar.tsx
+++ b/app/components/features/layout/NavigationBar.tsx
@@ -640,6 +640,7 @@ function DesktopMenuContent({
     upcomingEvent,
     hasOngoingRaid,
     hasUnconsumedCoupons,
+    isSignedIn: currentUsername !== null,
     sectionStates,
   });
   const contentSection = menuSections.find((section) => section.name === "컨텐츠");

--- a/app/components/features/layout/navigation-menu.ts
+++ b/app/components/features/layout/navigation-menu.ts
@@ -203,6 +203,7 @@ export function getNavigationSections({
           to: "/utils/pyroxene",
           name: "청휘석 플래너",
           description: "모집 시점의 청휘석을 계산해보세요",
+          badgeLabel: "로그인 없이 사용",
           OutlineIcon: CreditCardIconOutline,
           SolidIcon: CreditCardIconSolid,
           isActive: pathname.startsWith("/utils/pyroxene"),

--- a/app/components/features/layout/navigation-menu.ts
+++ b/app/components/features/layout/navigation-menu.ts
@@ -121,6 +121,7 @@ export function getNavigationSections({
   now = nowUtcIso(),
   hasOngoingRaid,
   hasUnconsumedCoupons,
+  isSignedIn,
   sectionStates = getNavigationSectionStates(pathname, upcomingEvent),
 }: {
   pathname: string;
@@ -128,6 +129,7 @@ export function getNavigationSections({
   now?: UtcIsoString;
   hasOngoingRaid: boolean;
   hasUnconsumedCoupons: boolean;
+  isSignedIn: boolean;
   sectionStates?: NavigationSectionStates;
 }): NavigationSection[] {
   return [
@@ -203,7 +205,7 @@ export function getNavigationSections({
           to: "/utils/pyroxene",
           name: "청휘석 플래너",
           description: "모집 시점의 청휘석을 계산해보세요",
-          badgeLabel: "로그인 없이 사용",
+          badgeLabel: isSignedIn ? undefined : "로그인 없이 사용",
           OutlineIcon: CreditCardIconOutline,
           SolidIcon: CreditCardIconSolid,
           isActive: pathname.startsWith("/utils/pyroxene"),
@@ -290,6 +292,7 @@ export function getSearchableMenuItems(): SearchableMenuItem[] {
     upcomingEvent: null,
     hasOngoingRaid: false,
     hasUnconsumedCoupons: false,
+    isSignedIn: false,
     sectionStates: {
       isCommunityActive: false,
       isContentActive: false,

--- a/app/components/features/students/StudentCard.tsx
+++ b/app/components/features/students/StudentCard.tsx
@@ -6,6 +6,7 @@ import { Link } from "react-router";
 import { AttributeBadge } from "~/components/primitives";
 import { useStudentCardPopup } from "~/contexts/StudentCardPopupProvider";
 import type { Attack, Defense } from "~/graphql/graphql";
+import { cn } from "~/lib/utils";
 import {
   attackTypeColor,
   attackTypeLocale,
@@ -17,7 +18,6 @@ import {
 import { studentImageUrl } from "~/models/assets";
 import type { Role } from "~/models/content.d";
 import { parseVisibleNames } from "~/models/student";
-import { cn } from "~/lib/utils";
 
 type StudentCardProps = {
   uid: string | null;
@@ -307,10 +307,14 @@ export default function StudentCard({
 
               {showsOverlayName ? (
                 <div className="absolute inset-0 bg-linear-15 from-black/60 from-10% via-transparent via-50% to-transparent px-1 pb-0.5 md:px-1.5 md:pb-1 text-left flex flex-col justify-end dark:from-black/80">
-                  <p className="whitespace-nowrap text-xs fond-bold scale-75 origin-left leading-none tracking-tighter text-white">
+                  <p
+                    className={`whitespace-nowrap font-bold scale-75 origin-left leading-none tracking-tighter text-white ${nameSize === "small" ? "text-[10px]" : "text-xs"}`}
+                  >
                     {overlaySubName}
                   </p>
-                  <p className="text-xs font-bold leading-tight tracking-tighter text-white line-clamp-1">
+                  <p
+                    className={`${nameSize === "small" ? "text-[10px]" : "text-xs"} font-bold leading-tight tracking-tighter text-white line-clamp-1`}
+                  >
                     {overlayMainName}
                   </p>
                 </div>

--- a/app/components/features/students/StudentCards.tsx
+++ b/app/components/features/students/StudentCards.tsx
@@ -6,6 +6,7 @@ import StudentCard from "./StudentCard";
 type StudentCardsProps = {
   students?: {
     uid: string | null;
+    selectionKey?: string;
     name?: string | null;
     attackType?: Attack;
     defenseType?: Defense;
@@ -97,11 +98,12 @@ export default function StudentCards({
 
   return (
     <div className={containerClassName}>
-      {students?.map((student, index) => {
+      {students?.map((student) => {
         const { uid } = student;
+        const selectionKey = student.selectionKey ?? uid;
         return (
           <div
-            key={`student-card-${student.name ?? uid}-${index}`}
+            key={`student-card-${selectionKey ?? student.name ?? "unknown"}`}
             ref={(ref) => {
               if (uid) {
                 onRef?.(uid, ref);
@@ -112,10 +114,11 @@ export default function StudentCards({
             <StudentCard
               {...student}
               namePlacement={namePlacement}
+              nameSize={cardSize === "xs" && namePlacement === "overlay" ? "small" : undefined}
               favorited={student.state?.favorited}
               favoritedCount={student.state?.favoritedCount}
               completed={student.state?.completed}
-              onSelect={onSelect}
+              onSelect={selectionKey && onSelect ? () => onSelect(selectionKey) : undefined}
             />
           </div>
         );

--- a/app/domain/guest-pyroxene-planner.ts
+++ b/app/domain/guest-pyroxene-planner.ts
@@ -1,0 +1,402 @@
+import { nanoid } from "nanoid/non-secure";
+import {
+  defaultPyroxenePlannerOptions,
+  normalizePyroxenePlannerOptions,
+  type PyroxenePlannerOptions,
+  type StoredPyroxenePlannerOptions,
+} from "~/domain/pyroxene-planner";
+import {
+  createOptimisticApPackageTimelineItems,
+  createOptimisticAttendanceTimelineItems,
+  createOptimisticBuyTimelineItems,
+  createOptimisticMonthlyPackageTimelineItems,
+  createOptimisticOtherTimelineItems,
+  PYROXENE_AP_CHARGE_MAX_COUNT,
+  PYROXENE_SOURCE_DEFINITIONS,
+  type PyroxeneMonthlyPackageType,
+} from "~/domain/pyroxene-sources";
+import type { PickupResources } from "~/domain/pyroxene-timeline";
+import type { PyroxeneTimelineItem, PyroxeneTimelineRepeatType } from "~/models/pyroxene-planner";
+
+export const GUEST_PYROXENE_PLANNER_VERSION = 1 as const;
+export const GUEST_PYROXENE_PLANNER_STORAGE_KEY = "mollulog::guest-pyroxene-planner::v1";
+
+export type GuestPyroxeneResources = PickupResources & { inputAt: string };
+export type GuestPyroxeneFavorite = { contentUid: string; studentUid: string };
+
+type GuestRecordBase = { recordId: string; createdAt: string };
+export type GuestPyroxeneRecord =
+  | (GuestRecordBase & {
+      kind: "buy";
+      quantity: number;
+      date: string;
+      repeatType?: PyroxeneTimelineRepeatType;
+      monthlyCount?: number;
+    })
+  | (GuestRecordBase & {
+      kind: "monthlyPackage";
+      startDate: string;
+      packageType: PyroxeneMonthlyPackageType;
+      autoRepurchase: boolean;
+    })
+  | (GuestRecordBase & { kind: "apPackage"; startDate: string; autoRepurchase: boolean })
+  | (GuestRecordBase & { kind: "attendance"; startDate: string })
+  | (GuestRecordBase & {
+      kind: "other";
+      resources: PickupResources;
+      description: string;
+      date: string;
+    });
+
+export type GuestPyroxenePlannerData = {
+  resources: GuestPyroxeneResources | null;
+  records: GuestPyroxeneRecord[];
+  options: PyroxenePlannerOptions;
+  optionsChanged: boolean;
+  collectedSourceKeys: string[];
+  eventTrials: Record<string, number>;
+  favoriteStudents: GuestPyroxeneFavorite[];
+};
+
+export type GuestPyroxenePlannerEnvelope = {
+  version: typeof GUEST_PYROXENE_PLANNER_VERSION;
+  datasetId: string;
+  revision: number;
+  updatedAt: string;
+  data: GuestPyroxenePlannerData;
+};
+
+export type VerifiedGuestPyroxeneImport = {
+  resources: boolean;
+  options: boolean;
+  recordIds: string[];
+  sourceKeys: string[];
+  eventUids: string[];
+  favorites: GuestPyroxeneFavorite[];
+};
+
+export function createEmptyGuestPyroxenePlanner(): GuestPyroxenePlannerEnvelope {
+  return {
+    version: GUEST_PYROXENE_PLANNER_VERSION,
+    datasetId: nanoid(16),
+    revision: 0,
+    updatedAt: new Date().toISOString(),
+    data: {
+      resources: null,
+      records: [],
+      options: defaultPyroxenePlannerOptions,
+      optionsChanged: false,
+      collectedSourceKeys: [],
+      eventTrials: {},
+      favoriteStudents: [],
+    },
+  };
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isFiniteInteger(value: unknown, min = 0, max = 10_000_000): value is number {
+  return typeof value === "number" && Number.isFinite(value) && Number.isInteger(value) && value >= min && value <= max;
+}
+
+function isIsoDate(value: unknown): value is string {
+  return typeof value === "string" && value.length <= 40 && Number.isFinite(Date.parse(value));
+}
+
+function isStableId(value: unknown, length: number): value is string {
+  return typeof value === "string" && new RegExp(`^[A-Za-z0-9_-]{${length}}$`).test(value);
+}
+
+function parseResources(value: unknown): GuestPyroxeneResources | null | undefined {
+  if (value === null) return null;
+  if (!isPlainObject(value) || !isIsoDate(value.inputAt)) return undefined;
+  if (
+    !isFiniteInteger(value.pyroxene) ||
+    !isFiniteInteger(value.oneTimeTicket) ||
+    !isFiniteInteger(value.tenTimeTicket)
+  ) {
+    return undefined;
+  }
+  return {
+    inputAt: value.inputAt,
+    pyroxene: value.pyroxene,
+    oneTimeTicket: value.oneTimeTicket,
+    tenTimeTicket: value.tenTimeTicket,
+  };
+}
+
+function parseOptions(value: unknown): PyroxenePlannerOptions | null {
+  if (!isPlainObject(value)) return null;
+  const { event, raid, tactical, consumption, timeline } = value;
+  if (
+    !isPlainObject(event) ||
+    !["average", "average_pity", "ceil"].includes(String(event.pickupChance)) ||
+    !isPlainObject(raid) ||
+    !["platinum", "gold", "silver", "bronze"].includes(String(raid.tier)) ||
+    !isPlainObject(tactical) ||
+    !["in10", "in100", "in200", "over200"].includes(String(tactical.level)) ||
+    !isPlainObject(consumption) ||
+    !isFiniteInteger(consumption.apChargeCount, 0, PYROXENE_AP_CHARGE_MAX_COUNT) ||
+    !isPlainObject(timeline) ||
+    !Array.isArray(timeline.display)
+  ) {
+    return null;
+  }
+  const validSources = new Set<string>(PYROXENE_SOURCE_DEFINITIONS.map(({ type }) => type));
+  if (!timeline.display.every((source) => typeof source === "string" && validSources.has(source))) return null;
+  return normalizePyroxenePlannerOptions(value as StoredPyroxenePlannerOptions);
+}
+
+function parseRecord(value: unknown): GuestPyroxeneRecord | null {
+  if (!isPlainObject(value) || !isStableId(value.recordId, 12) || !isIsoDate(value.createdAt)) {
+    return null;
+  }
+  const base = { recordId: value.recordId, createdAt: value.createdAt };
+  if (
+    value.kind === "buy" &&
+    isFiniteInteger(value.quantity, 1) &&
+    isIsoDate(value.date) &&
+    (value.repeatType === undefined || value.repeatType === "fixed_days" || value.repeatType === "monthly_first") &&
+    (value.monthlyCount === undefined || isFiniteInteger(value.monthlyCount, 1, 120))
+  ) {
+    const repeatType = value.repeatType ?? "fixed_days";
+    const monthlyCount = value.monthlyCount;
+    return { ...base, kind: "buy", quantity: value.quantity, date: value.date, repeatType, monthlyCount };
+  }
+  if (
+    value.kind === "monthlyPackage" &&
+    isIsoDate(value.startDate) &&
+    (value.packageType === "half" || value.packageType === "full") &&
+    typeof value.autoRepurchase === "boolean"
+  ) {
+    return {
+      ...base,
+      kind: value.kind,
+      startDate: value.startDate,
+      packageType: value.packageType,
+      autoRepurchase: value.autoRepurchase,
+    };
+  }
+  if (value.kind === "apPackage" && isIsoDate(value.startDate) && typeof value.autoRepurchase === "boolean") {
+    return { ...base, kind: value.kind, startDate: value.startDate, autoRepurchase: value.autoRepurchase };
+  }
+  if (value.kind === "attendance" && isIsoDate(value.startDate)) {
+    return { ...base, kind: value.kind, startDate: value.startDate };
+  }
+  if (
+    value.kind === "other" &&
+    isPlainObject(value.resources) &&
+    typeof value.description === "string" &&
+    value.description.length <= 200 &&
+    isIsoDate(value.date)
+  ) {
+    const resources = value.resources;
+    if (
+      isFiniteInteger(resources.pyroxene) &&
+      isFiniteInteger(resources.oneTimeTicket) &&
+      isFiniteInteger(resources.tenTimeTicket)
+    ) {
+      return {
+        ...base,
+        kind: value.kind,
+        date: value.date,
+        description: value.description,
+        resources: {
+          pyroxene: resources.pyroxene,
+          oneTimeTicket: resources.oneTimeTicket,
+          tenTimeTicket: resources.tenTimeTicket,
+        },
+      };
+    }
+  }
+  return null;
+}
+
+export function parseGuestPyroxenePlanner(raw: string): GuestPyroxenePlannerEnvelope | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (
+    !isPlainObject(parsed) ||
+    parsed.version !== 1 ||
+    !isStableId(parsed.datasetId, 16) ||
+    !isFiniteInteger(parsed.revision, 0) ||
+    !isIsoDate(parsed.updatedAt) ||
+    !isPlainObject(parsed.data)
+  ) {
+    return null;
+  }
+  const data = parsed.data;
+  const resources = parseResources(data.resources);
+  if (resources === undefined || !Array.isArray(data.records) || data.records.length > 500) return null;
+  const records = data.records.map(parseRecord);
+  if (records.some((record) => record === null)) return null;
+
+  if (
+    !Array.isArray(data.collectedSourceKeys) ||
+    data.collectedSourceKeys.length > 1_000 ||
+    !data.collectedSourceKeys.every((value) => typeof value === "string" && value.length > 0 && value.length <= 200) ||
+    !Array.isArray(data.favoriteStudents) ||
+    data.favoriteStudents.length > 1_000 ||
+    !data.favoriteStudents.every(
+      (value) =>
+        isPlainObject(value) &&
+        typeof value.contentUid === "string" &&
+        typeof value.studentUid === "string" &&
+        value.contentUid.length > 0 &&
+        value.studentUid.length > 0 &&
+        value.contentUid.length <= 200 &&
+        value.studentUid.length <= 200,
+    ) ||
+    !isPlainObject(data.eventTrials) ||
+    typeof data.optionsChanged !== "boolean"
+  ) {
+    return null;
+  }
+  const collectedSourceKeys = [...new Set(data.collectedSourceKeys as string[])];
+  const favoriteStudents = (data.favoriteStudents as GuestPyroxeneFavorite[]).filter(
+    (favorite, index, all) =>
+      all.findIndex(
+        (candidate) => candidate.contentUid === favorite.contentUid && candidate.studentUid === favorite.studentUid,
+      ) === index,
+  );
+  const eventTrials: Record<string, number> = {};
+  for (const [key, value] of Object.entries(data.eventTrials)) {
+    if (key.length === 0 || key.length > 200 || !isFiniteInteger(value, 0, 10_000)) return null;
+    eventTrials[key] = value;
+  }
+  const options = parseOptions(data.options);
+  if (!options) return null;
+  return {
+    version: 1,
+    datasetId: parsed.datasetId,
+    revision: parsed.revision,
+    updatedAt: parsed.updatedAt,
+    data: {
+      resources,
+      records: records as GuestPyroxeneRecord[],
+      options,
+      optionsChanged: data.optionsChanged,
+      collectedSourceKeys,
+      eventTrials,
+      favoriteStudents,
+    },
+  };
+}
+
+export function guestPyroxeneRecordToTimelineItems(record: GuestPyroxeneRecord): PyroxeneTimelineItem[] {
+  switch (record.kind) {
+    case "buy":
+      return createOptimisticBuyTimelineItems(record.quantity, new Date(record.date), {
+        repeatType: record.repeatType,
+        monthlyCount: record.monthlyCount,
+        uid: record.recordId,
+      });
+    case "monthlyPackage":
+      return createOptimisticMonthlyPackageTimelineItems(
+        new Date(record.startDate),
+        record.packageType,
+        record.autoRepurchase,
+        record.recordId,
+      );
+    case "apPackage":
+      return createOptimisticApPackageTimelineItems(new Date(record.startDate), record.autoRepurchase, record.recordId);
+    case "attendance":
+      return createOptimisticAttendanceTimelineItems(new Date(record.startDate), record.recordId);
+    case "other":
+      return createOptimisticOtherTimelineItems(
+        record.resources,
+        record.description,
+        new Date(record.date),
+        record.recordId,
+      );
+  }
+}
+
+export function guestPyroxeneTimelineItems(data: GuestPyroxenePlannerData): PyroxeneTimelineItem[] {
+  return data.records.flatMap(guestPyroxeneRecordToTimelineItems);
+}
+
+export function pyroxeneTimelineItemFingerprint(item: PyroxeneTimelineItem): string {
+  return JSON.stringify({
+    eventAt: item.eventAt,
+    source: item.source,
+    repeatType: item.repeatType,
+    repeatIntervalDays: item.repeatIntervalDays,
+    repeatCount: item.repeatCount,
+    autoRepurchase: item.autoRepurchase,
+    description: item.description,
+    pyroxeneDelta: item.pyroxeneDelta,
+    oneTimeTicketDelta: item.oneTimeTicketDelta,
+    tenTimeTicketDelta: item.tenTimeTicketDelta,
+  });
+}
+
+export function guestPyroxeneRecordFingerprint(record: GuestPyroxeneRecord): string {
+  return guestPyroxeneRecordToTimelineItems(record).map(pyroxeneTimelineItemFingerprint).sort().join("|");
+}
+
+export function hasGuestPyroxenePlannerData(data: GuestPyroxenePlannerData): boolean {
+  return Boolean(
+    data.resources ||
+      data.records.length ||
+      data.optionsChanged ||
+      data.collectedSourceKeys.length ||
+      Object.keys(data.eventTrials).length ||
+      data.favoriteStudents.length,
+  );
+}
+
+function isSameValue(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+export function clearVerifiedGuestPyroxeneImport(
+  current: GuestPyroxenePlannerData,
+  submitted: GuestPyroxenePlannerData,
+  verified: VerifiedGuestPyroxeneImport,
+): GuestPyroxenePlannerData {
+  const verifiedRecordIds = new Set(verified.recordIds);
+  const submittedRecords = new Map(submitted.records.map((record) => [record.recordId, record]));
+  const verifiedSourceKeys = new Set(verified.sourceKeys);
+  const verifiedEventUids = new Set(verified.eventUids);
+  const verifiedFavoriteKeys = new Set(
+    verified.favorites.map((favorite) => `${favorite.contentUid}\u0000${favorite.studentUid}`),
+  );
+  const eventTrials = { ...current.eventTrials };
+
+  for (const eventUid of verifiedEventUids) {
+    if (current.eventTrials[eventUid] === submitted.eventTrials[eventUid]) delete eventTrials[eventUid];
+  }
+
+  const clearResources =
+    verified.resources && current.resources !== null && isSameValue(current.resources, submitted.resources);
+  const clearOptions = verified.options && current.optionsChanged && isSameValue(current.options, submitted.options);
+
+  return {
+    ...current,
+    resources: clearResources ? null : current.resources,
+    options: clearOptions ? defaultPyroxenePlannerOptions : current.options,
+    optionsChanged: clearOptions ? false : current.optionsChanged,
+    records: current.records.filter((record) => {
+      if (!verifiedRecordIds.has(record.recordId)) return true;
+      return !isSameValue(record, submittedRecords.get(record.recordId));
+    }),
+    collectedSourceKeys: current.collectedSourceKeys.filter((key) => !verifiedSourceKeys.has(key)),
+    eventTrials,
+    favoriteStudents: current.favoriteStudents.filter(
+      (favorite) => !verifiedFavoriteKeys.has(`${favorite.contentUid}\u0000${favorite.studentUid}`),
+    ),
+  };
+}
+
+export function createGuestRecord<T extends Omit<GuestPyroxeneRecord, "recordId" | "createdAt">>(
+  record: T,
+): T & GuestRecordBase {
+  return { ...record, recordId: nanoid(12), createdAt: new Date().toISOString() };
+}

--- a/app/domain/pyroxene-schedule.ts
+++ b/app/domain/pyroxene-schedule.ts
@@ -1,8 +1,10 @@
 import type { TimelineSourceType } from "~/domain/pyroxene-planner";
 import type { RecruitmentTypeEnum } from "~/graphql/graphql";
 import type { UtcIsoString } from "~/lib/date-time";
+import dayjs from "~/lib/dayjs";
 import type { RaidType } from "~/models/content.d";
 import type { PyroxeneTimelineItem, PyroxeneTimelineRepeatType } from "~/models/pyroxene-planner";
+import type { PickupResources, Timeline } from "./pyroxene-timeline";
 
 export type PyroxeneScheduleContent =
   | {
@@ -105,6 +107,46 @@ export type PyroxeneCollectedSourceCandidate = {
   title: string;
   description?: string;
 };
+
+export function buildPyroxeneDisplayTimeline(
+  timeline: Timeline,
+  scheduleItems: PyroxeneScheduleItem[],
+  displayStartDate: Date,
+  initialResources: PickupResources,
+): Timeline {
+  const timelineEventUids = new Set(
+    timeline.flatMap((entry) => (entry.source.type === "event" && entry.source.event ? [entry.source.event.uid] : [])),
+  );
+  const displayStart = dayjs(displayStartDate);
+  const missingEvents = scheduleItems.flatMap((item) => {
+    const event = item.event;
+    if (
+      !event ||
+      timelineEventUids.has(event.uid) ||
+      !event.recruitments.some(({ pickup, student }) => pickup && student) ||
+      !dayjs(event.until).isAfter(displayStart)
+    ) {
+      return [];
+    }
+
+    const date = dayjs(event.since);
+    let resources = initialResources;
+    for (const entry of timeline) {
+      if (entry.date.isAfter(date)) break;
+      resources = entry.accumulatedResources;
+    }
+    return [
+      {
+        date,
+        source: { type: "event" as const, event },
+        accumulatedResources: resources,
+        resourceDelta: { pyroxene: 0, oneTimeTicket: 0, tenTimeTicket: 0 },
+      },
+    ];
+  });
+
+  return [...timeline, ...missingEvents].sort((a, b) => a.date.valueOf() - b.date.valueOf());
+}
 
 export function buildPyroxeneScheduleItems(
   contents: PyroxeneScheduleContent[],

--- a/app/domain/pyroxene-sources.ts
+++ b/app/domain/pyroxene-sources.ts
@@ -212,6 +212,7 @@ function createOptimisticTimelineItem(input: OptimisticTimelineItemInput): Pyrox
 type OptimisticBuyTimelineOptions = {
   repeatType?: PyroxeneTimelineRepeatType;
   monthlyCount?: number;
+  uid?: string;
 };
 
 function normalizeMonthlyCount(monthlyCount: number | undefined): number {
@@ -230,6 +231,7 @@ export function createOptimisticBuyTimelineItems(
 
   return [
     createOptimisticTimelineItem({
+      uid: options.uid,
       eventAt: date,
       source: "buy",
       description: "청휘석 구매",
@@ -243,8 +245,9 @@ export function createOptimisticMonthlyPackageTimelineItems(
   startDate: Date,
   packageType: PyroxeneMonthlyPackageType,
   autoRepurchase = false,
+  baseUid = nanoid(8),
 ): PyroxeneTimelineItem[] {
-  const uid = nanoid(8);
+  const uid = baseUid;
   const eventAt = normalizePyroxeneTimelineEventAt(startDate);
   const { name, oneTime, daily, repurchaseIntervalDays } = PYROXENE_MONTHLY_PACKAGE_CONFIG[packageType];
 
@@ -275,8 +278,9 @@ export function createOptimisticMonthlyPackageTimelineItems(
 export function createOptimisticApPackageTimelineItems(
   startDate: Date,
   autoRepurchase = false,
+  baseUid = nanoid(8),
 ): PyroxeneTimelineItem[] {
-  const uid = nanoid(8);
+  const uid = baseUid;
   const eventAt = normalizePyroxeneTimelineEventAt(startDate);
 
   return [
@@ -293,8 +297,8 @@ export function createOptimisticApPackageTimelineItems(
   ];
 }
 
-export function createOptimisticAttendanceTimelineItems(startDate: Date): PyroxeneTimelineItem[] {
-  const uid = nanoid(8);
+export function createOptimisticAttendanceTimelineItems(startDate: Date, baseUid = nanoid(8)): PyroxeneTimelineItem[] {
+  const uid = baseUid;
   const start = dayjs(startDate);
 
   return PYROXENE_ATTENDANCE_CONFIG.map(({ day, pyroxene }) =>
@@ -313,9 +317,11 @@ export function createOptimisticOtherTimelineItems(
   resources: PickupResources,
   description: string,
   date: Date,
+  uid?: string,
 ): PyroxeneTimelineItem[] {
   return [
     createOptimisticTimelineItem({
+      uid,
       eventAt: date,
       source: "other",
       description,

--- a/app/lib/guest-pyroxene-planner.client.ts
+++ b/app/lib/guest-pyroxene-planner.client.ts
@@ -1,0 +1,98 @@
+import {
+  createEmptyGuestPyroxenePlanner,
+  GUEST_PYROXENE_PLANNER_STORAGE_KEY,
+  type GuestPyroxenePlannerData,
+  type GuestPyroxenePlannerEnvelope,
+  parseGuestPyroxenePlanner,
+} from "~/domain/guest-pyroxene-planner";
+
+export type GuestPyroxeneStorageStatus = "ready" | "memory" | "corrupt";
+export type GuestPyroxeneSnapshot = { status: GuestPyroxeneStorageStatus; envelope: GuestPyroxenePlannerEnvelope };
+
+let memorySnapshot: GuestPyroxeneSnapshot | null = null;
+let updateQueue = Promise.resolve();
+const listeners = new Set<() => void>();
+
+function emit() {
+  for (const listener of listeners) listener();
+}
+
+function readStorage(): GuestPyroxeneSnapshot {
+  if (memorySnapshot?.status === "memory") return memorySnapshot;
+  try {
+    const raw = window.localStorage.getItem(GUEST_PYROXENE_PLANNER_STORAGE_KEY);
+    if (!raw) return { status: "ready", envelope: createEmptyGuestPyroxenePlanner() };
+    const envelope = parseGuestPyroxenePlanner(raw);
+    if (!envelope) return { status: "corrupt", envelope: createEmptyGuestPyroxenePlanner() };
+    return { status: "ready", envelope };
+  } catch {
+    return memorySnapshot ?? { status: "memory", envelope: createEmptyGuestPyroxenePlanner() };
+  }
+}
+
+function writeStorage(envelope: GuestPyroxenePlannerEnvelope): GuestPyroxeneSnapshot {
+  try {
+    window.localStorage.setItem(GUEST_PYROXENE_PLANNER_STORAGE_KEY, JSON.stringify(envelope));
+    memorySnapshot = { status: "ready", envelope };
+  } catch {
+    memorySnapshot = { status: "memory", envelope };
+  }
+  emit();
+  return memorySnapshot;
+}
+
+export function readGuestPyroxenePlanner(): GuestPyroxeneSnapshot {
+  const snapshot = readStorage();
+  memorySnapshot = snapshot;
+  return snapshot;
+}
+
+export function updateGuestPyroxenePlanner(
+  update: (data: GuestPyroxenePlannerData) => GuestPyroxenePlannerData,
+): Promise<GuestPyroxeneSnapshot> {
+  let result: GuestPyroxeneSnapshot;
+  updateQueue = updateQueue.then(async () => {
+    const performUpdate = () => {
+      const current = readStorage();
+      if (current.status === "corrupt") return current;
+      const envelope = {
+        ...current.envelope,
+        revision: current.envelope.revision + 1,
+        updatedAt: new Date().toISOString(),
+        data: update(current.envelope.data),
+      };
+      return writeStorage(envelope);
+    };
+    result = navigator.locks
+      ? await navigator.locks.request(GUEST_PYROXENE_PLANNER_STORAGE_KEY, performUpdate)
+      : performUpdate();
+  });
+  return updateQueue.then(() => result);
+}
+
+export function resetGuestPyroxenePlanner(): GuestPyroxeneSnapshot {
+  const envelope = createEmptyGuestPyroxenePlanner();
+  try {
+    window.localStorage.removeItem(GUEST_PYROXENE_PLANNER_STORAGE_KEY);
+    memorySnapshot = { status: "ready", envelope };
+  } catch {
+    memorySnapshot = { status: "memory", envelope };
+  }
+  emit();
+  return memorySnapshot;
+}
+
+export function subscribeGuestPyroxenePlanner(listener: () => void): () => void {
+  listeners.add(listener);
+  const onStorage = (event: StorageEvent) => {
+    if (event.key === GUEST_PYROXENE_PLANNER_STORAGE_KEY) {
+      memorySnapshot = readStorage();
+      listener();
+    }
+  };
+  window.addEventListener("storage", onStorage);
+  return () => {
+    listeners.delete(listener);
+    window.removeEventListener("storage", onStorage);
+  };
+}

--- a/app/models/guest-pyroxene-import.ts
+++ b/app/models/guest-pyroxene-import.ts
@@ -1,0 +1,144 @@
+import { and, eq, like, or } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+import { int, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
+import type { GuestPyroxeneRecord } from "~/domain/guest-pyroxene-planner";
+import {
+  createAttendance,
+  createBuyPyroxene,
+  createOtherPyroxeneGain,
+  createPyroxeneApPackage,
+  createPyroxeneMonthlyPackage,
+  createPyroxeneOwnedResource,
+  pyroxeneOwnedResourcesTable,
+  pyroxeneTimelineItemsTable,
+} from "~/models/pyroxene-planner";
+
+export const pyroxeneGuestImportItemsTable = sqliteTable(
+  "pyroxene_guest_import_items",
+  {
+    id: int().primaryKey({ autoIncrement: true }),
+    userId: int().notNull(),
+    datasetId: text().notNull(),
+    itemType: text().notNull(),
+    itemKey: text().notNull(),
+    importedAt: text().notNull(),
+  },
+  (table) => [
+    uniqueIndex("pyroxene_guest_import_items_user_dataset_item").on(
+      table.userId,
+      table.datasetId,
+      table.itemType,
+      table.itemKey,
+    ),
+  ],
+);
+
+export type GuestImportItemType = "resources" | "options" | "record" | "source" | "event" | "favorite";
+
+export async function hasGuestImportReceipt(
+  env: Env,
+  userId: number,
+  datasetId: string,
+  itemType: GuestImportItemType,
+  itemKey: string,
+): Promise<boolean> {
+  const db = drizzle(env.DB);
+  const [row] = await db
+    .select({ id: pyroxeneGuestImportItemsTable.id })
+    .from(pyroxeneGuestImportItemsTable)
+    .where(
+      and(
+        eq(pyroxeneGuestImportItemsTable.userId, userId),
+        eq(pyroxeneGuestImportItemsTable.datasetId, datasetId),
+        eq(pyroxeneGuestImportItemsTable.itemType, itemType),
+        eq(pyroxeneGuestImportItemsTable.itemKey, itemKey),
+      ),
+    )
+    .limit(1);
+  return Boolean(row);
+}
+
+export async function markGuestImportReceipt(
+  env: Env,
+  userId: number,
+  datasetId: string,
+  itemType: GuestImportItemType,
+  itemKey: string,
+): Promise<void> {
+  await drizzle(env.DB)
+    .insert(pyroxeneGuestImportItemsTable)
+    .values({ userId, datasetId, itemType, itemKey, importedAt: new Date().toISOString() })
+    .onConflictDoNothing();
+}
+
+function deterministicImportUid(userId: number, datasetId: string, recordId: string): string {
+  return `guest-${userId}-${datasetId}-${recordId}`;
+}
+
+export async function importGuestResources(
+  env: Env,
+  userId: number,
+  datasetId: string,
+  resources: { pyroxene: number; oneTimeTicket: number; tenTimeTicket: number },
+): Promise<void> {
+  const uid = deterministicImportUid(userId, datasetId, "resources");
+  const db = drizzle(env.DB);
+  const [existing] = await db
+    .select({ id: pyroxeneOwnedResourcesTable.id })
+    .from(pyroxeneOwnedResourcesTable)
+    .where(and(eq(pyroxeneOwnedResourcesTable.userId, userId), eq(pyroxeneOwnedResourcesTable.uid, uid)))
+    .limit(1);
+  if (!existing) await createPyroxeneOwnedResource(env, userId, resources, { uid });
+}
+
+export async function importGuestRecord(
+  env: Env,
+  userId: number,
+  datasetId: string,
+  record: GuestPyroxeneRecord,
+): Promise<void> {
+  const uid = deterministicImportUid(userId, datasetId, record.recordId);
+  const db = drizzle(env.DB);
+  const [existing] = await db
+    .select({ id: pyroxeneTimelineItemsTable.id })
+    .from(pyroxeneTimelineItemsTable)
+    .where(
+      and(
+        eq(pyroxeneTimelineItemsTable.userId, userId),
+        or(eq(pyroxeneTimelineItemsTable.uid, uid), like(pyroxeneTimelineItemsTable.uid, `${uid}::%`)),
+      ),
+    )
+    .limit(1);
+  if (existing) return;
+
+  switch (record.kind) {
+    case "buy":
+      await createBuyPyroxene(env, userId, record.date, record.quantity, {
+        repeatType: record.repeatType,
+        monthlyCount: record.monthlyCount,
+        uid,
+      });
+      break;
+    case "monthlyPackage":
+      await createPyroxeneMonthlyPackage(env, userId, record.startDate, record.packageType, record.autoRepurchase, uid);
+      break;
+    case "apPackage":
+      await createPyroxeneApPackage(env, userId, record.startDate, record.autoRepurchase, uid);
+      break;
+    case "attendance":
+      await createAttendance(env, userId, record.startDate, uid);
+      break;
+    case "other":
+      await createOtherPyroxeneGain(
+        env,
+        userId,
+        record.date,
+        record.resources.pyroxene,
+        record.resources.oneTimeTicket,
+        record.resources.tenTimeTicket,
+        record.description,
+        uid,
+      );
+      break;
+  }
+}

--- a/app/models/pyroxene-planner.ts
+++ b/app/models/pyroxene-planner.ts
@@ -4,13 +4,15 @@ import { drizzle } from "drizzle-orm/d1";
 import { int, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
 import { nanoid } from "nanoid/non-secure";
 import {
+  defaultPyroxenePlannerOptions,
+  normalizePyroxenePlannerOptions,
   type PyroxenePlannerOptions,
   type StoredPyroxenePlannerOptions,
   type TimelineSourceType,
-  defaultPyroxenePlannerOptions,
-  normalizePyroxenePlannerOptions,
 } from "~/domain/pyroxene-planner";
 import {
+  extractPyroxeneTimelineBaseUid,
+  normalizePyroxeneTimelineEventAt,
   PYROXENE_AP_PACKAGE_CONFIG,
   PYROXENE_ATTENDANCE_CONFIG,
   PYROXENE_ATTENDANCE_REPEAT_INTERVAL_DAYS,
@@ -18,10 +20,8 @@ import {
   PYROXENE_PACKAGE_DAILY_REPEAT_COUNT,
   PYROXENE_PACKAGE_DAILY_REPEAT_INTERVAL_DAYS,
   type PyroxeneMonthlyPackageType,
-  extractPyroxeneTimelineBaseUid,
-  normalizePyroxeneTimelineEventAt,
 } from "~/domain/pyroxene-sources";
-import { type UtcIsoString, nowUtcIso } from "~/lib/date-time";
+import { nowUtcIso } from "~/lib/date-time";
 
 /**
  * Pyroxene Owned Resources
@@ -74,10 +74,11 @@ export async function createPyroxeneOwnedResource(
   env: Env,
   userId: number,
   resources: { pyroxene: number; oneTimeTicket: number; tenTimeTicket: number },
+  options: { uid?: string; inputAt?: string } = {},
 ): Promise<void> {
   const db = drizzle(env.DB);
-  const uid = nanoid(8);
-  const inputAt = new Date().toISOString();
+  const uid = options.uid ?? nanoid(8);
+  const inputAt = options.inputAt ?? new Date().toISOString();
   const { pyroxene, oneTimeTicket, tenTimeTicket } = resources;
   await db.insert(pyroxeneOwnedResourcesTable).values({ uid, userId, inputAt, pyroxene, oneTimeTicket, tenTimeTicket });
 }
@@ -127,6 +128,16 @@ export async function upsertCollectedSource(env: Env, userId: number, sourceKey:
     .onConflictDoUpdate({
       target: [pyroxeneCollectedSourcesTable.userId, pyroxeneCollectedSourcesTable.sourceKey],
       set: { collectedAt },
+    });
+}
+
+export async function ensureCollectedSource(env: Env, userId: number, sourceKey: string): Promise<void> {
+  const db = drizzle(env.DB);
+  await db
+    .insert(pyroxeneCollectedSourcesTable)
+    .values({ uid: nanoid(8), userId, sourceKey, collectedAt: nowUtcIso() })
+    .onConflictDoNothing({
+      target: [pyroxeneCollectedSourcesTable.userId, pyroxeneCollectedSourcesTable.sourceKey],
     });
 }
 
@@ -220,6 +231,7 @@ export async function getPyroxeneTimelineItems(env: Env, userId: number): Promis
 type CreateBuyPyroxeneOptions = {
   repeatType?: PyroxeneTimelineRepeatType;
   monthlyCount?: number;
+  uid?: string;
 };
 
 function normalizeMonthlyCount(monthlyCount: number | undefined): number {
@@ -236,7 +248,7 @@ export async function createBuyPyroxene(
   quantity: number,
   options: CreateBuyPyroxeneOptions = {},
 ): Promise<void> {
-  const uid = nanoid(8);
+  const uid = options.uid ?? nanoid(8);
   const eventAt = normalizePyroxeneTimelineEventAt(date);
   const repeatType = options.repeatType ?? "fixed_days";
   const normalizedMonthlyCount = normalizeMonthlyCount(options.monthlyCount);
@@ -274,8 +286,8 @@ export async function createPyroxeneMonthlyPackage(
   startDate: Date | string,
   packageType: PyroxeneMonthlyPackageType,
   autoRepurchase = false,
+  uid = nanoid(8),
 ): Promise<void> {
-  const uid = nanoid(8);
   const eventAt = normalizePyroxeneTimelineEventAt(startDate);
 
   const {
@@ -324,8 +336,8 @@ export async function createPyroxeneApPackage(
   userId: number,
   startDate: Date | string,
   autoRepurchase = false,
+  uid = nanoid(8),
 ): Promise<void> {
-  const uid = nanoid(8);
   const eventAt = normalizePyroxeneTimelineEventAt(startDate);
   const autoRepurchaseValue = autoRepurchase ? 1 : 0;
 
@@ -345,15 +357,19 @@ export async function createPyroxeneApPackage(
   });
 }
 
-export async function createAttendance(env: Env, userId: number, startDate: Date | string): Promise<void> {
+export async function createAttendance(
+  env: Env,
+  userId: number,
+  startDate: Date | string,
+  uid = nanoid(8),
+): Promise<void> {
   const db = drizzle(env.DB);
-  await db
+  const deleteExisting = db
     .delete(pyroxeneTimelineItemsTable)
     .where(and(eq(pyroxeneTimelineItemsTable.userId, userId), eq(pyroxeneTimelineItemsTable.source, "attendance")));
 
-  const uid = nanoid(8);
   const startAt = dayjs(normalizePyroxeneTimelineEventAt(startDate));
-  await db.insert(pyroxeneTimelineItemsTable).values(
+  const insertReplacement = db.insert(pyroxeneTimelineItemsTable).values(
     PYROXENE_ATTENDANCE_CONFIG.map(({ day, pyroxene }) => ({
       uid: `${uid}::${day}`,
       userId,
@@ -367,6 +383,7 @@ export async function createAttendance(env: Env, userId: number, startDate: Date
       repeatCount: null,
     })),
   );
+  await db.batch([deleteExisting, insertReplacement]);
 }
 
 export async function createOtherPyroxeneGain(
@@ -377,10 +394,11 @@ export async function createOtherPyroxeneGain(
   oneTimeTicket: number,
   tenTimeTicket: number,
   description: string,
+  uid = nanoid(8),
 ): Promise<void> {
   const db = drizzle(env.DB);
   await db.insert(pyroxeneTimelineItemsTable).values({
-    uid: nanoid(8),
+    uid,
     userId,
     eventAt: normalizePyroxeneTimelineEventAt(date),
     source: "other",

--- a/app/routes/more._index.tsx
+++ b/app/routes/more._index.tsx
@@ -61,6 +61,7 @@ export default function MoreIndexPage() {
     upcomingEvent,
     hasOngoingRaid,
     hasUnconsumedCoupons,
+    isSignedIn: currentUser !== null,
   }).flatMap((section) =>
     section.items
       .filter(

--- a/app/routes/utils.pyroxene.tsx
+++ b/app/routes/utils.pyroxene.tsx
@@ -1,5 +1,5 @@
 import { CalendarIcon, ChartBarIcon, PlusIcon } from "@heroicons/react/24/outline";
-import { ArrowPathIcon, LockClosedIcon } from "@heroicons/react/24/solid";
+import { ArrowPathIcon } from "@heroicons/react/24/solid";
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
   type ActionFunctionArgs,
@@ -13,10 +13,19 @@ import {
   PyroxenePlannerOptionsPanel,
   PyroxenePlannerSourcePanel,
   PyroxeneSchedule,
+  useGuestPyroxenePlanner,
   usePyroxeneScheduleItems,
 } from "~/components/features/futures";
-import { ErrorPage } from "~/components/features/layout";
 import Page from "~/components/features/layout/Page";
+import { Button, Callout } from "~/components/primitives";
+import { useSignIn } from "~/contexts/SignInProvider";
+import {
+  createGuestRecord,
+  type GuestPyroxeneRecord,
+  guestPyroxeneRecordToTimelineItems,
+  guestPyroxeneTimelineItems,
+  hasGuestPyroxenePlannerData,
+} from "~/domain/guest-pyroxene-planner";
 import { defaultPyroxenePlannerOptions, type PyroxenePlannerOptions } from "~/domain/pyroxene-planner";
 import {
   createOptimisticApPackageTimelineItems,
@@ -49,6 +58,7 @@ import {
   upsertPyroxeneEventData,
   upsertPyroxenePlannerOptions,
 } from "~/models/pyroxene-planner";
+import { getRecruitedStudents } from "~/models/recruited-student";
 import {
   deleteRecruitmentResult,
   getRecruitmentResultsByRecruitmentGroupUids,
@@ -80,6 +90,7 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
       calcOptions: defaultPyroxenePlannerOptions,
       eventData: [],
       recruitmentResultCompletions: [],
+      recruitedStudentUids: [],
       collectedSourceKeys: [],
     };
   }
@@ -96,6 +107,7 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
     eventData,
     timelineItems,
     recruitmentResults,
+    recruitedStudents,
     collectedSources,
   ] = await Promise.all([
     getUserFavoritedStudents(env, currentUser.id, undefined, { ctx }),
@@ -104,6 +116,7 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
     getAllPyroxeneEventData(env, currentUser.id),
     getPyroxeneTimelineItems(env, currentUser.id),
     getRecruitmentResultsByRecruitmentGroupUids(env, currentUser.id, recruitmentGroupUids),
+    getRecruitedStudents(env, currentUser.id),
     getCollectedSourceKeys(env, currentUser.id),
   ]);
 
@@ -133,6 +146,7 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
       );
       return content ? [{ eventUid: content.uid, recruitmentGroupUid: result.recruitmentGroupUid }] : [];
     }),
+    recruitedStudentUids: recruitedStudents.map(({ studentUid }) => studentUid),
     collectedSourceKeys: [...collectedSources],
   };
 };
@@ -207,7 +221,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
           const content = (await getPyroxenePlannerContents(publicReadEnv, false, ctx)).find(
             (content) => content.kind === "event" && content.uid === eventUid,
           );
-          if (!content || content.kind !== "event" || !content.recruitmentGroupUid) {
+          if (content?.kind !== "event" || !content.recruitmentGroupUid) {
             throw new Error(`Cannot resolve recruitment group for pyroxene completion: eventUid=${eventUid}`);
           }
 
@@ -335,7 +349,9 @@ export const meta: MetaFunction = () => {
 
 export default function PyroxenePlanner() {
   const loaderData = useLoaderData<typeof loader>();
-  const { signedIn, contents, favoritedStudents } = loaderData;
+  const { signedIn, contents } = loaderData;
+  const { showSignIn } = useSignIn();
+  const guestPlanner = useGuestPyroxenePlanner();
 
   const [initialDate, setInitialDate] = useState<Date | null>(
     loaderData.latestResources.inputAt ? new Date(loaderData.latestResources.inputAt) : null,
@@ -351,8 +367,9 @@ export default function PyroxenePlanner() {
   const [localCollectedSourceKeys, setLocalCollectedSourceKeys] = useState<string[]>(
     loaderData.collectedSourceKeys ?? [],
   );
-
+  const [localFavoritedStudents, setLocalFavoritedStudents] = useState(loaderData.favoritedStudents ?? []);
   const fetcher = useFetcher<typeof action>();
+  const favoriteFetcher = useFetcher();
   const timelineSaveInFlight = useRef(false);
 
   // Sync from loader data after server revalidation
@@ -378,8 +395,32 @@ export default function PyroxenePlanner() {
   }, [loaderData.collectedSourceKeys]);
 
   useEffect(() => {
-    setOptions(loaderData.calcOptions);
-  }, [loaderData.calcOptions]);
+    setLocalFavoritedStudents(loaderData.favoritedStudents ?? []);
+  }, [loaderData.favoritedStudents]);
+
+  useEffect(() => {
+    if (signedIn || !guestPlanner.snapshot || guestPlanner.snapshot.status === "corrupt") return;
+    const data = guestPlanner.snapshot.envelope.data;
+    setInitialDate(data.resources ? new Date(data.resources.inputAt) : null);
+    setInitialResources(data.resources ?? { pyroxene: 0, oneTimeTicket: 0, tenTimeTicket: 0 });
+    setLocalTimelineItems(guestPyroxeneTimelineItems(data));
+    setLocalEventData(
+      Object.entries(data.eventTrials).map(([eventUid, expectedTrials]) => ({
+        uid: `guest-${eventUid}`,
+        userId: 0,
+        eventUid,
+        completed: false,
+        expectedTrials,
+      })),
+    );
+    setLocalCollectedSourceKeys(data.collectedSourceKeys);
+    setLocalFavoritedStudents(data.favoriteStudents);
+    setOptions(data.options);
+  }, [guestPlanner.snapshot, signedIn]);
+
+  useEffect(() => {
+    if (signedIn) setOptions(loaderData.calcOptions);
+  }, [loaderData.calcOptions, signedIn]);
 
   useEffect(() => {
     if (fetcher.state === "idle") {
@@ -393,11 +434,12 @@ export default function PyroxenePlanner() {
     collectedSourceKeys: string[] = [],
   ) => {
     setInitialResources(resources);
-    setInitialDate(new Date());
+    const inputAt = new Date();
+    setInitialDate(inputAt);
     if (collectedSourceKeys.length > 0) {
       setLocalCollectedSourceKeys((prev) => [...new Set([...prev, ...collectedSourceKeys])]);
     }
-    if (eventUid) {
+    if (eventUid && signedIn) {
       const content = contents.find((content) => content.kind === "event" && content.uid === eventUid);
       if (content?.kind === "event" && content.recruitmentGroupUid) {
         const recruitmentGroupUid = content.recruitmentGroupUid;
@@ -408,6 +450,14 @@ export default function PyroxenePlanner() {
           return [...prev, { eventUid, recruitmentGroupUid }];
         });
       }
+    }
+    if (!signedIn) {
+      void guestPlanner.update((data) => ({
+        ...data,
+        resources: { ...resources, inputAt: inputAt.toISOString() },
+        collectedSourceKeys: [...new Set([...data.collectedSourceKeys, ...collectedSourceKeys])],
+      }));
+      return;
     }
     fetcher.submit(
       {
@@ -425,6 +475,15 @@ export default function PyroxenePlanner() {
       }
       return prev.filter((key) => key !== sourceKey);
     });
+    if (!signedIn) {
+      void guestPlanner.update((data) => ({
+        ...data,
+        collectedSourceKeys: collected
+          ? [...new Set([...data.collectedSourceKeys, sourceKey])]
+          : data.collectedSourceKeys.filter((key) => key !== sourceKey),
+      }));
+      return;
+    }
     fetcher.submit(
       { collectedSource: { sourceKey } },
       { method: collected ? "POST" : "DELETE", encType: "application/json" },
@@ -448,10 +507,20 @@ export default function PyroxenePlanner() {
         },
       ];
     });
+    if (!signedIn) {
+      void guestPlanner.update((current) => {
+        const eventTrials = { ...current.eventTrials };
+        if (data.expectedTrials === null || data.expectedTrials === undefined) delete eventTrials[eventUid];
+        else eventTrials[eventUid] = data.expectedTrials;
+        return { ...current, eventTrials };
+      });
+      return;
+    }
     fetcher.submit({ eventData: { eventUid, ...data } }, { method: "POST", encType: "application/json" });
   };
 
   const handleDeletePickupComplete = (eventUid: string) => {
+    if (!signedIn) return;
     const recruitmentResultCompletion = localRecruitmentResultCompletions.find(
       (completion) => completion.eventUid === eventUid,
     );
@@ -465,7 +534,53 @@ export default function PyroxenePlanner() {
   const handleDeleteItem = (itemUid: string) => {
     const baseUid = extractPyroxeneTimelineBaseUid(itemUid);
     setLocalTimelineItems((prev) => prev.filter((item) => !item.uid.startsWith(baseUid)));
+    if (!signedIn) {
+      void guestPlanner.update((data) => ({
+        ...data,
+        records: data.records.filter((record) => record.recordId !== baseUid),
+      }));
+      return;
+    }
     fetcher.submit({ deleteData: { itemUid } }, { method: "DELETE", encType: "application/json" });
+  };
+
+  const handleFavoriteChange = (contentUid: string, studentUid: string, favorited: boolean) => {
+    setLocalFavoritedStudents((current) => {
+      const withoutTarget = current.filter(
+        (favorite) => !(favorite.contentUid === contentUid && favorite.studentUid === studentUid),
+      );
+      return favorited ? [...withoutTarget, { contentUid, studentUid }] : withoutTarget;
+    });
+    if (!signedIn) {
+      void guestPlanner.update((data) => {
+        const withoutTarget = data.favoriteStudents.filter(
+          (favorite) => !(favorite.contentUid === contentUid && favorite.studentUid === studentUid),
+        );
+        return {
+          ...data,
+          favoriteStudents: favorited ? [...withoutTarget, { contentUid, studentUid }] : withoutTarget,
+        };
+      });
+      return;
+    }
+    favoriteFetcher.submit(
+      { favorite: { contentUid, studentUid, favorited } },
+      { action: "/api/contents", method: "POST", encType: "application/json" },
+    );
+  };
+
+  const saveGuestRecord = (record: GuestPyroxeneRecord, replaceAttendance = false) => {
+    setLocalTimelineItems((prev) => {
+      const current = replaceAttendance ? prev.filter((item) => item.source !== "attendance") : prev;
+      return [...current, ...guestPyroxeneRecordToTimelineItems(record)];
+    });
+    void guestPlanner.update((data) => ({
+      ...data,
+      records: [
+        ...(replaceAttendance ? data.records.filter((item) => item.kind !== "attendance") : data.records),
+        record,
+      ],
+    }));
   };
 
   const handleSaveBuy = (
@@ -477,6 +592,13 @@ export default function PyroxenePlanner() {
       return;
     }
     timelineSaveInFlight.current = true;
+    if (!signedIn) {
+      saveGuestRecord(
+        createGuestRecord({ kind: "buy", quantity, date: date.toISOString(), ...options }) as GuestPyroxeneRecord,
+      );
+      timelineSaveInFlight.current = false;
+      return;
+    }
     setLocalTimelineItems((prev) => [...prev, ...createOptimisticBuyTimelineItems(quantity, date, options)]);
     fetcher.submit(
       { createData: { buy: { quantity, date: date.toISOString(), ...options } } },
@@ -493,6 +615,19 @@ export default function PyroxenePlanner() {
       return;
     }
     timelineSaveInFlight.current = true;
+    if (!signedIn) {
+      saveGuestRecord(
+        createGuestRecord({
+          kind: "monthlyPackage",
+          startDate: startDate.toISOString(),
+          packageType,
+          autoRepurchase,
+        }) as GuestPyroxeneRecord,
+      );
+      ensureTimelineSourcesVisible(["package_onetime"]);
+      timelineSaveInFlight.current = false;
+      return;
+    }
     setLocalTimelineItems((prev) => [
       ...prev,
       ...createOptimisticMonthlyPackageTimelineItems(startDate, packageType, autoRepurchase),
@@ -512,6 +647,18 @@ export default function PyroxenePlanner() {
       return;
     }
     timelineSaveInFlight.current = true;
+    if (!signedIn) {
+      saveGuestRecord(
+        createGuestRecord({
+          kind: "apPackage",
+          startDate: startDate.toISOString(),
+          autoRepurchase,
+        }) as GuestPyroxeneRecord,
+      );
+      ensureTimelineSourcesVisible(["package_ap"]);
+      timelineSaveInFlight.current = false;
+      return;
+    }
     setLocalTimelineItems((prev) => [...prev, ...createOptimisticApPackageTimelineItems(startDate, autoRepurchase)]);
     const nextOptions = ensureTimelineSourcesVisible(["package_ap"]);
     fetcher.submit(
@@ -525,6 +672,14 @@ export default function PyroxenePlanner() {
       return;
     }
     timelineSaveInFlight.current = true;
+    if (!signedIn) {
+      saveGuestRecord(
+        createGuestRecord({ kind: "attendance", startDate: startDate.toISOString() }) as GuestPyroxeneRecord,
+        true,
+      );
+      timelineSaveInFlight.current = false;
+      return;
+    }
     setLocalTimelineItems((prev) => {
       const withoutAttendance = prev.filter((item) => item.source !== "attendance");
       return [...withoutAttendance, ...createOptimisticAttendanceTimelineItems(startDate)];
@@ -540,6 +695,13 @@ export default function PyroxenePlanner() {
       return;
     }
     timelineSaveInFlight.current = true;
+    if (!signedIn) {
+      saveGuestRecord(
+        createGuestRecord({ kind: "other", resources, description, date: date.toISOString() }) as GuestPyroxeneRecord,
+      );
+      timelineSaveInFlight.current = false;
+      return;
+    }
     setLocalTimelineItems((prev) => [...prev, ...createOptimisticOtherTimelineItems(resources, description, date)]);
     fetcher.submit(
       { createData: { other: { resources, description, date: date.toISOString() } } },
@@ -574,6 +736,9 @@ export default function PyroxenePlanner() {
       },
     };
     setOptions(nextOptions);
+    if (!signedIn) {
+      void guestPlanner.update((data) => ({ ...data, options: nextOptions, optionsChanged: true }));
+    }
     return nextOptions;
   };
 
@@ -583,6 +748,10 @@ export default function PyroxenePlanner() {
       clearTimeout(optionsSaveTimer.current);
     }
     optionsSaveTimer.current = setTimeout(() => {
+      if (!signedIn) {
+        void guestPlanner.update((data) => ({ ...data, options: newOptions, optionsChanged: true }));
+        return;
+      }
       fetcher.submit({ calcOptions: newOptions }, { method: "POST", encType: "application/json" });
     }, 500);
   };
@@ -605,9 +774,11 @@ export default function PyroxenePlanner() {
     return map;
   }, [localEventData, localRecruitmentResultCompletions]);
 
-  const scheduleItems = usePyroxeneScheduleItems(contents, favoritedStudents, localTimelineItems);
+  const scheduleItems = usePyroxeneScheduleItems(contents, localFavoritedStudents, localTimelineItems);
 
-  const isSaving = fetcher.state === "submitting" || fetcher.state === "loading";
+  const isSaving = Boolean(signedIn) && (fetcher.state === "submitting" || fetcher.state === "loading");
+  const guestDataStatus = guestPlanner.snapshot?.status;
+  const hasGuestData = guestPlanner.snapshot ? hasGuestPyroxenePlannerData(guestPlanner.snapshot.envelope.data) : false;
 
   return (
     <>
@@ -635,7 +806,6 @@ export default function PyroxenePlanner() {
             title: "수급/소비 계획",
             Icon: PlusIcon,
             description: "청휘석 수급/소비처를 등록해주세요",
-            disabled: !signedIn,
             children: (
               <PyroxenePlannerSourcePanel
                 options={options}
@@ -655,13 +825,47 @@ export default function PyroxenePlanner() {
             title: "플래너 설정",
             Icon: ChartBarIcon,
             description: "시뮬레이션 조건을 선택해주세요",
-            disabled: !signedIn,
-            collapsible: signedIn,
+            collapsible: true,
             children: <PyroxenePlannerOptionsPanel options={options} onOptionsChange={handleOptionsChange} />,
           },
         ]}
       >
-        {signedIn ? (
+        <div className="space-y-4">
+          <div className="space-y-3">
+            {signedIn && hasGuestData ? (
+              <Callout
+                tone="info"
+                title="비로그인 상태에서 입력한 데이터가 있어요"
+                description="계정에 저장된 내용과 비교 후 최근 데이터를 선택해주세요."
+              >
+                <div className="mt-2">
+                  <Button text="내용 확인" to="/utils/pyroxene/import" size="sm" variant="primary" />
+                </div>
+              </Callout>
+            ) : !signedIn && guestDataStatus === "memory" ? (
+              <Callout
+                tone="warning"
+                title="이 브라우저에 저장하지 못했어요"
+                description="현재 탭에서는 계속 사용할 수 있지만, 탭을 닫으면 입력한 내용이 사라져요."
+              />
+            ) : !signedIn && guestDataStatus === "corrupt" ? (
+              <Callout tone="destructive" title="저장된 데이터를 불러오지 못했어요">
+                <div className="mt-2">
+                  <Button text="저장된 데이터 초기화" size="sm" variant="danger-subtle" onClick={guestPlanner.reset} />
+                </div>
+              </Callout>
+            ) : !signedIn ? (
+              <Callout
+                tone="info"
+                title="로그인 후 더 많은 정보를 관리할 수 있어요"
+                description="정보를 안전하게 저장하고 필요할 때마다 불러와 사용해보세요."
+              >
+                <div className="mt-2">
+                  <Button text="로그인하기" size="sm" variant="primary" onClick={showSignIn} />
+                </div>
+              </Callout>
+            ) : null}
+          </div>
           <PyroxeneSchedule
             initialDate={initialDate}
             initialResources={initialResources}
@@ -669,6 +873,7 @@ export default function PyroxenePlanner() {
             scheduleItems={scheduleItems}
             options={options}
             collectedSourceKeys={localCollectedSourceKeys}
+            recruitedStudentUids={loaderData.recruitedStudentUids}
             onPickupComplete={(eventUid, resources, collectedSourceKeys) =>
               handleSaveOwnedResources(eventUid, resources, collectedSourceKeys)
             }
@@ -676,10 +881,10 @@ export default function PyroxenePlanner() {
             onDeleteItem={(itemUid) => handleDeleteItem(itemUid)}
             onUpdateEventData={handleUpdateEventData}
             onCollectedSourceChange={handleCollectedSourceChange}
+            allowPickupCompletion={Boolean(signedIn)}
+            onFavoriteChange={handleFavoriteChange}
           />
-        ) : (
-          <ErrorPage Icon={LockClosedIcon} message="로그인 후 이용할 수 있어요" showButtons={false} />
-        )}
+        </div>
       </Page>
     </>
   );

--- a/app/routes/utils.pyroxene_.import.tsx
+++ b/app/routes/utils.pyroxene_.import.tsx
@@ -1,0 +1,849 @@
+import { ArrowPathIcon, CheckCircleIcon } from "@heroicons/react/20/solid";
+import dayjs from "dayjs";
+import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import {
+  type ActionFunctionArgs,
+  data,
+  type LoaderFunctionArgs,
+  type MetaFunction,
+  redirect,
+  useFetcher,
+  useLoaderData,
+} from "react-router";
+import { getActiveSensei } from "~/auth/authenticator.server";
+import { useGuestPyroxenePlanner } from "~/components/features/futures";
+import Page from "~/components/features/layout/Page";
+import { Button, Callout, Checkbox, ResourceCard, SectionCard } from "~/components/primitives";
+import {
+  clearVerifiedGuestPyroxeneImport,
+  type GuestPyroxeneFavorite,
+  type GuestPyroxenePlannerEnvelope,
+  type GuestPyroxeneRecord,
+  guestPyroxeneRecordFingerprint,
+  parseGuestPyroxenePlanner,
+  pyroxeneTimelineItemFingerprint,
+  type VerifiedGuestPyroxeneImport,
+} from "~/domain/guest-pyroxene-planner";
+import type { PyroxenePlannerOptions } from "~/domain/pyroxene-planner";
+import { extractPyroxeneTimelineBaseUid, PYROXENE_RESOURCE_UIDS } from "~/domain/pyroxene-sources";
+import type { PickupResources } from "~/domain/pyroxene-timeline";
+import { ResourceTypeEnum } from "~/graphql/graphql";
+import { withD1Session } from "~/lib/d1-session";
+import { cn } from "~/lib/utils";
+import { favoriteStudent, getUserFavoritedStudents } from "~/models/favorite-students";
+import {
+  type GuestImportItemType,
+  hasGuestImportReceipt,
+  importGuestRecord,
+  importGuestResources,
+  markGuestImportReceipt,
+} from "~/models/guest-pyroxene-import";
+import {
+  ensureCollectedSource,
+  getAllPyroxeneEventData,
+  getCollectedSourceKeys,
+  getLatestPyroxeneOwnedResource,
+  getPyroxenePlannerOptions,
+  getPyroxeneTimelineItems,
+  upsertPyroxeneEventData,
+  upsertPyroxenePlannerOptions,
+} from "~/models/pyroxene-planner";
+import { getPyroxenePlannerContents } from "~/views/pyroxene";
+
+type ImportSelection = {
+  resources: boolean;
+  options: boolean;
+  recordIds: string[];
+  sourceKeys: string[];
+  eventUids: string[];
+  favorites: GuestPyroxeneFavorite[];
+};
+
+type VerifiedItems = VerifiedGuestPyroxeneImport;
+
+type ImportActionResult = {
+  success: boolean;
+  verified: VerifiedItems;
+  failedLabels: string[];
+};
+
+const emptyVerified = (): VerifiedItems => ({
+  resources: false,
+  options: false,
+  recordIds: [],
+  sourceKeys: [],
+  eventUids: [],
+  favorites: [],
+});
+
+function verifiedItemCount(items: VerifiedItems): number {
+  return (
+    Number(items.resources) +
+    Number(items.options) +
+    items.recordIds.length +
+    items.sourceKeys.length +
+    items.eventUids.length +
+    items.favorites.length
+  );
+}
+
+function getDiscardedItems(guest: GuestPyroxenePlannerEnvelope["data"], selection: ImportSelection): VerifiedItems {
+  const selectedRecordIds = new Set(selection.recordIds);
+  const selectedSourceKeys = new Set(selection.sourceKeys);
+  const selectedEventUids = new Set(selection.eventUids);
+  const selectedFavoriteKeys = new Set(selection.favorites.map(favoriteKey));
+
+  return {
+    resources: Boolean(guest.resources && !selection.resources),
+    options: guest.optionsChanged && !selection.options,
+    recordIds: guest.records
+      .filter((record) => !selectedRecordIds.has(record.recordId))
+      .map((record) => record.recordId),
+    sourceKeys: guest.collectedSourceKeys.filter((key) => !selectedSourceKeys.has(key)),
+    eventUids: Object.keys(guest.eventTrials).filter((uid) => !selectedEventUids.has(uid)),
+    favorites: guest.favoriteStudents.filter((favorite) => !selectedFavoriteKeys.has(favoriteKey(favorite))),
+  };
+}
+
+export const meta: MetaFunction = () => [{ title: "데이터 가져오기 | 몰루로그" }];
+
+export const loader = async ({ context, request }: LoaderFunctionArgs) => {
+  const { env, ctx } = context.cloudflare;
+  const user = await getActiveSensei(env, request);
+  if (!user) return redirect("/unauthorized");
+
+  const publicReadEnv = withD1Session(env, "first-unconstrained");
+  const [contents, resources, options, records, eventData, sources, favorites] = await Promise.all([
+    getPyroxenePlannerContents(publicReadEnv, false, ctx),
+    getLatestPyroxeneOwnedResource(env, user.id),
+    getPyroxenePlannerOptions(env, user.id),
+    getPyroxeneTimelineItems(env, user.id),
+    getAllPyroxeneEventData(env, user.id),
+    getCollectedSourceKeys(env, user.id),
+    getUserFavoritedStudents(env, user.id, undefined, { ctx }),
+  ]);
+
+  return {
+    contents,
+    resources,
+    options,
+    records,
+    eventData,
+    sourceKeys: [...sources],
+    favorites: favorites.map(({ contentId, studentId }) => ({ contentUid: contentId, studentUid: studentId })),
+  };
+};
+
+function favoriteKey(favorite: GuestPyroxeneFavorite): string {
+  return `${favorite.contentUid}\u0000${favorite.studentUid}`;
+}
+
+export const action = async ({ context, request }: ActionFunctionArgs) => {
+  const { env, ctx } = context.cloudflare;
+  const user = await getActiveSensei(env, request);
+  if (!user)
+    return data<ImportActionResult>(
+      { success: false, verified: emptyVerified(), failedLabels: ["로그인이 필요해요"] },
+      { status: 401 },
+    );
+
+  const body = await request.json<{ envelope?: unknown; selection?: ImportSelection }>();
+  const envelope = body.envelope ? parseGuestPyroxenePlanner(JSON.stringify(body.envelope)) : null;
+  const selection = body.selection;
+  if (
+    !envelope ||
+    !selection ||
+    typeof selection.resources !== "boolean" ||
+    typeof selection.options !== "boolean" ||
+    !Array.isArray(selection.recordIds) ||
+    !selection.recordIds.every((value) => typeof value === "string") ||
+    !Array.isArray(selection.sourceKeys) ||
+    !selection.sourceKeys.every((value) => typeof value === "string") ||
+    !Array.isArray(selection.eventUids) ||
+    !selection.eventUids.every((value) => typeof value === "string") ||
+    !Array.isArray(selection.favorites) ||
+    !selection.favorites.every(
+      (value) =>
+        typeof value === "object" &&
+        value !== null &&
+        typeof value.contentUid === "string" &&
+        typeof value.studentUid === "string",
+    )
+  ) {
+    return data<ImportActionResult>(
+      { success: false, verified: emptyVerified(), failedLabels: ["가져올 데이터를 확인하지 못했어요"] },
+      { status: 400 },
+    );
+  }
+
+  const { datasetId } = envelope;
+  const guest = envelope.data;
+  const selectedRecordIds = new Set(selection.recordIds);
+  const selectedSourceKeys = new Set(selection.sourceKeys);
+  const selectedEventUids = new Set(selection.eventUids);
+  const selectedFavoriteKeys = new Set(selection.favorites.map(favoriteKey));
+  if (
+    [...selectedRecordIds].some((id) => !guest.records.some((record) => record.recordId === id)) ||
+    [...selectedSourceKeys].some((key) => !guest.collectedSourceKeys.includes(key)) ||
+    [...selectedEventUids].some((uid) => !(uid in guest.eventTrials)) ||
+    [...selectedFavoriteKeys].some((key) => !guest.favoriteStudents.some((favorite) => favoriteKey(favorite) === key))
+  ) {
+    return data<ImportActionResult>(
+      { success: false, verified: emptyVerified(), failedLabels: ["선택한 항목이 원본 데이터와 일치하지 않아요"] },
+      { status: 400 },
+    );
+  }
+
+  const verified = emptyVerified();
+  const failedLabels: string[] = [];
+  const importItem = async (
+    type: GuestImportItemType,
+    key: string,
+    label: string,
+    operation: () => Promise<void>,
+    onVerified: () => void,
+  ) => {
+    try {
+      if (!(await hasGuestImportReceipt(env, user.id, datasetId, type, key))) {
+        await operation();
+        await markGuestImportReceipt(env, user.id, datasetId, type, key);
+      }
+      if (await hasGuestImportReceipt(env, user.id, datasetId, type, key)) onVerified();
+      else failedLabels.push(label);
+    } catch {
+      failedLabels.push(label);
+    }
+  };
+
+  if (selection.resources && guest.resources) {
+    const guestResources = guest.resources;
+    await importItem(
+      "resources",
+      "current",
+      "보유 재화",
+      () => importGuestResources(env, user.id, datasetId, guestResources),
+      () => {
+        verified.resources = true;
+      },
+    );
+  }
+  if (selection.options && guest.optionsChanged) {
+    await importItem(
+      "options",
+      "current",
+      "플래너 설정",
+      () => upsertPyroxenePlannerOptions(env, user.id, guest.options),
+      () => {
+        verified.options = true;
+      },
+    );
+  }
+  for (const record of guest.records.filter((item) => selectedRecordIds.has(item.recordId))) {
+    await importItem(
+      "record",
+      record.recordId,
+      describeRecord(record),
+      () => importGuestRecord(env, user.id, datasetId, record),
+      () => {
+        verified.recordIds.push(record.recordId);
+      },
+    );
+  }
+  for (const sourceKey of guest.collectedSourceKeys.filter((key) => selectedSourceKeys.has(key))) {
+    await importItem(
+      "source",
+      sourceKey,
+      "수령한 보상",
+      () => ensureCollectedSource(env, user.id, sourceKey),
+      () => {
+        verified.sourceKeys.push(sourceKey);
+      },
+    );
+  }
+  for (const [eventUid, expectedTrials] of Object.entries(guest.eventTrials).filter(([uid]) =>
+    selectedEventUids.has(uid),
+  )) {
+    await importItem(
+      "event",
+      eventUid,
+      "모집 목표",
+      () => upsertPyroxeneEventData(env, user.id, eventUid, { expectedTrials }),
+      () => {
+        verified.eventUids.push(eventUid);
+      },
+    );
+  }
+  for (const favorite of guest.favoriteStudents.filter((item) => selectedFavoriteKeys.has(favoriteKey(item)))) {
+    await importItem(
+      "favorite",
+      favoriteKey(favorite),
+      "관심 학생",
+      () => favoriteStudent(env, user.id, favorite.studentUid, favorite.contentUid, { ctx }),
+      () => {
+        verified.favorites.push(favorite);
+      },
+    );
+  }
+
+  return { success: failedLabels.length === 0, verified, failedLabels } satisfies ImportActionResult;
+};
+
+function describeRecord(record: GuestPyroxeneRecord): string {
+  return `${recordName(record)} · ${recordDate(record)}`;
+}
+
+function recordName(record: GuestPyroxeneRecord): string {
+  switch (record.kind) {
+    case "buy":
+      return "청휘석 구매";
+    case "monthlyPackage":
+      return record.packageType === "full" ? "월정액" : "반정액";
+    case "apPackage":
+      return "AP 패키지";
+    case "attendance":
+      return "출석 시작일";
+    case "other":
+      return record.description || "기타 수급";
+  }
+}
+
+function recordDate(record: GuestPyroxeneRecord): string {
+  switch (record.kind) {
+    case "buy":
+    case "other":
+      return dayjs(record.date).format("MM/DD");
+    case "monthlyPackage":
+    case "apPackage":
+    case "attendance":
+      return dayjs(record.startDate).format("MM/DD");
+  }
+}
+
+export default function GuestPyroxeneImportPage() {
+  const account = useLoaderData<typeof loader>();
+  const guestPlanner = useGuestPyroxenePlanner();
+  const fetcher = useFetcher<ImportActionResult>();
+  const [selection, setSelection] = useState<ImportSelection | null>(null);
+  const initializedDatasetId = useRef<string | null>(null);
+  const processedResult = useRef<ImportActionResult | null>(null);
+  const submittedEnvelope = useRef<GuestPyroxenePlannerEnvelope | null>(null);
+  const submittedDiscardedItems = useRef<VerifiedItems>(emptyVerified());
+
+  const envelope =
+    guestPlanner.snapshot?.status === "ready" || guestPlanner.snapshot?.status === "memory"
+      ? guestPlanner.snapshot.envelope
+      : null;
+
+  const accountRecordFingerprints = useMemo(() => {
+    const grouped = new Map<string, typeof account.records>();
+    for (const item of account.records) {
+      const baseUid = extractPyroxeneTimelineBaseUid(item.uid);
+      grouped.set(baseUid, [...(grouped.get(baseUid) ?? []), item]);
+    }
+    return new Set([...grouped.values()].map((items) => items.map(pyroxeneTimelineItemFingerprint).sort().join("|")));
+  }, [account.records]);
+  const accountSourceKeys = useMemo(() => new Set(account.sourceKeys), [account.sourceKeys]);
+  const accountFavoriteKeys = useMemo(() => new Set(account.favorites.map(favoriteKey)), [account.favorites]);
+
+  const sourceGroups = useMemo(() => {
+    const sourceKeys = envelope?.data.collectedSourceKeys ?? [];
+    return {
+      missing: sourceKeys.filter((key) => !accountSourceKeys.has(key)),
+      existing: sourceKeys.filter((key) => accountSourceKeys.has(key)),
+    };
+  }, [accountSourceKeys, envelope]);
+
+  const contentLabels = useMemo(() => {
+    const eventNames = new Map<string, string>();
+    const favoriteNames = new Map<string, string>();
+    for (const content of account.contents) {
+      if (content.kind !== "event") continue;
+      eventNames.set(content.uid, content.name);
+      for (const recruitment of content.recruitments) {
+        if (!recruitment.student) continue;
+        const contentUid = recruitment.sourceContentUid ?? content.uid;
+        favoriteNames.set(
+          favoriteKey({ contentUid, studentUid: recruitment.student.uid }),
+          `${recruitment.student.name} · ${content.name}`,
+        );
+      }
+    }
+    return { eventNames, favoriteNames };
+  }, [account.contents]);
+
+  useEffect(() => {
+    if (!envelope || initializedDatasetId.current === envelope.datasetId) return;
+    initializedDatasetId.current = envelope.datasetId;
+    const accountEventUids = new Set(account.eventData.map((item) => item.eventUid));
+    setSelection({
+      resources: Boolean(envelope.data.resources && !account.resources),
+      options: false,
+      recordIds: envelope.data.records
+        .filter(
+          (record) => record.kind !== "attendance" || !account.records.some((item) => item.source === "attendance"),
+        )
+        .filter((record) => !accountRecordFingerprints.has(guestPyroxeneRecordFingerprint(record)))
+        .map((record) => record.recordId),
+      sourceKeys: envelope.data.collectedSourceKeys.filter((key) => !accountSourceKeys.has(key)),
+      eventUids: Object.keys(envelope.data.eventTrials).filter((uid) => !accountEventUids.has(uid)),
+      favorites: envelope.data.favoriteStudents.filter((favorite) => !accountFavoriteKeys.has(favoriteKey(favorite))),
+    });
+  }, [
+    account.eventData,
+    account.records,
+    account.resources,
+    accountFavoriteKeys,
+    accountRecordFingerprints,
+    accountSourceKeys,
+    envelope,
+  ]);
+
+  useEffect(() => {
+    const result = fetcher.data;
+    if (!result || result === processedResult.current) return;
+    processedResult.current = result;
+    const submitted = submittedEnvelope.current;
+    if (!submitted) return;
+    const verifiedFavoriteKeys = new Set(result.verified.favorites.map(favoriteKey));
+    setSelection((current) =>
+      current
+        ? {
+            resources: result.verified.resources ? false : current.resources,
+            options: result.verified.options ? false : current.options,
+            recordIds: current.recordIds.filter((id) => !result.verified.recordIds.includes(id)),
+            sourceKeys: current.sourceKeys.filter((key) => !result.verified.sourceKeys.includes(key)),
+            eventUids: current.eventUids.filter((uid) => !result.verified.eventUids.includes(uid)),
+            favorites: current.favorites.filter((favorite) => !verifiedFavoriteKeys.has(favoriteKey(favorite))),
+          }
+        : current,
+    );
+    void guestPlanner.update((current) => {
+      const imported = clearVerifiedGuestPyroxeneImport(current, submitted.data, result.verified);
+      return clearVerifiedGuestPyroxeneImport(imported, submitted.data, submittedDiscardedItems.current);
+    });
+  }, [fetcher.data, guestPlanner.update]);
+
+  const toggleList = <T extends string>(values: T[], value: T, checked: boolean) =>
+    checked ? [...new Set([...values, value])] : values.filter((item) => item !== value);
+  const toggleGroup = (values: string[], group: string[], checked: boolean) =>
+    checked ? [...new Set([...values, ...group])] : values.filter((item) => !group.includes(item));
+  const isSubmitting = fetcher.state !== "idle";
+  const selectedCount = selection
+    ? Number(selection.resources) +
+      Number(selection.options) +
+      selection.recordIds.length +
+      selection.sourceKeys.length +
+      selection.eventUids.length +
+      selection.favorites.length
+    : 0;
+  const discardedItems = envelope && selection ? getDiscardedItems(envelope.data, selection) : emptyVerified();
+  const discardedCount = verifiedItemCount(discardedItems);
+  const submittedDiscardedCount = verifiedItemCount(submittedDiscardedItems.current);
+  const importedCount = fetcher.data ? verifiedItemCount(fetcher.data.verified) : 0;
+
+  return (
+    <Page
+      title="데이터 가져오기"
+      description="비로그인 시 등록한 데이터와 계정에 저장된 데이터를 비교해 저장할 내용을 선택해주세요."
+      backward={{ title: "청휘석 플래너", to: "/utils/pyroxene" }}
+      contentWidth="full"
+    >
+      <div className="space-y-5 lg:max-w-4xl">
+        {!envelope || !selection ? (
+          <Callout
+            title="가져올 데이터를 찾지 못했어요"
+            description="이 브라우저에서 비로그인 시 플래너에 등록한 데이터가 없어요."
+          />
+        ) : (
+          <>
+            {envelope.data.resources && (
+              <SectionCard
+                title="현재 보유 재화"
+                description={
+                  account.resources ? "앞으로 사용할 값을 선택해주세요." : "계정에 저장된 보유 재화가 없어요."
+                }
+              >
+                <ImportSourceComparison
+                  name="resources"
+                  selected={selection.resources ? "guest" : "account"}
+                  onChange={(source) => setSelection({ ...selection, resources: source === "guest" })}
+                  guest={
+                    <ResourceSourceSummary
+                      resources={envelope.data.resources}
+                      inputAt={envelope.data.resources.inputAt}
+                    />
+                  }
+                  account={
+                    account.resources ? (
+                      <ResourceSourceSummary resources={account.resources} inputAt={account.resources.inputAt} />
+                    ) : (
+                      <p className="text-sm text-muted-foreground">저장된 보유 재화가 없어요.</p>
+                    )
+                  }
+                />
+              </SectionCard>
+            )}
+
+            {envelope.data.records.length > 0 && (
+              <SectionCard
+                title="수급/소비 계획"
+                description="계정에 추가할 계획을 선택해주세요. 선택하지 않은 계획은 저장할 때 이 브라우저에서 삭제해요."
+              >
+                <div className="space-y-3">
+                  {envelope.data.records.map((record) => {
+                    const exact = accountRecordFingerprints.has(guestPyroxeneRecordFingerprint(record));
+                    const attendanceConflict =
+                      record.kind === "attendance" && account.records.some((item) => item.source === "attendance");
+                    return (
+                      <ImportCheckbox
+                        key={record.recordId}
+                        checked={selection.recordIds.includes(record.recordId)}
+                        onChange={(checked) =>
+                          setSelection({
+                            ...selection,
+                            recordIds: toggleList(selection.recordIds, record.recordId, checked),
+                          })
+                        }
+                        title={describeRecord(record)}
+                        description={
+                          exact
+                            ? "같은 내용이 계정에 저장되어 있어요. 한 번 더 추가하려면 선택해주세요."
+                            : attendanceConflict
+                              ? "선택하면 계정에 저장된 출석 계획이 이 날짜로 바뀌어요."
+                              : "계정에 추가"
+                        }
+                      />
+                    );
+                  })}
+                </div>
+              </SectionCard>
+            )}
+
+            {envelope.data.optionsChanged && (
+              <SectionCard title="플래너 설정" description="앞으로 사용할 설정을 선택해주세요.">
+                <ImportSourceComparison
+                  name="options"
+                  selected={selection.options ? "guest" : "account"}
+                  onChange={(source) => setSelection({ ...selection, options: source === "guest" })}
+                  guest={<PlannerOptionsSummary options={envelope.data.options} />}
+                  account={<PlannerOptionsSummary options={account.options} />}
+                />
+              </SectionCard>
+            )}
+
+            {(envelope.data.favoriteStudents.length > 0 || Object.keys(envelope.data.eventTrials).length > 0) && (
+              <SectionCard title="관심 학생과 모집 설정" description="계정에 없는 항목은 기본으로 선택했어요.">
+                <div className="space-y-3">
+                  {envelope.data.favoriteStudents.map((favorite) => {
+                    const key = favoriteKey(favorite);
+                    const checked = selection.favorites.some((item) => favoriteKey(item) === key);
+                    const existsInAccount = accountFavoriteKeys.has(key);
+                    return (
+                      <ImportCheckbox
+                        key={key}
+                        checked={checked}
+                        onChange={(next) =>
+                          setSelection({
+                            ...selection,
+                            favorites: next
+                              ? [...selection.favorites, favorite]
+                              : selection.favorites.filter((item) => favoriteKey(item) !== key),
+                          })
+                        }
+                        title={contentLabels.favoriteNames.get(key) ?? "관심 학생"}
+                        description={
+                          existsInAccount ? "이미 계정의 관심 학생으로 저장되어 있어요." : "계정의 관심 학생에 추가"
+                        }
+                      />
+                    );
+                  })}
+                  {Object.keys(envelope.data.eventTrials).map((eventUid) => (
+                    <ImportCheckbox
+                      key={eventUid}
+                      checked={selection.eventUids.includes(eventUid)}
+                      onChange={(checked) =>
+                        setSelection({ ...selection, eventUids: toggleList(selection.eventUids, eventUid, checked) })
+                      }
+                      title={`${contentLabels.eventNames.get(eventUid) ?? "모집"} · ${envelope.data.eventTrials[eventUid]}회`}
+                      description={
+                        account.eventData.some((item) => item.eventUid === eventUid)
+                          ? "계정에 모집 목표가 저장되어 있어요. 선택하면 비로그인 시 등록한 값으로 바뀌어요."
+                          : "계정에 추가"
+                      }
+                    />
+                  ))}
+                </div>
+              </SectionCard>
+            )}
+
+            {envelope.data.collectedSourceKeys.length > 0 && (
+              <SectionCard title="수령한 보상" description="계정에 없는 기록은 기본으로 선택했어요.">
+                <div className="space-y-3">
+                  {sourceGroups.missing.length > 0 && (
+                    <ImportCheckbox
+                      checked={sourceGroups.missing.every((key) => selection.sourceKeys.includes(key))}
+                      onChange={(checked) =>
+                        setSelection({
+                          ...selection,
+                          sourceKeys: toggleGroup(selection.sourceKeys, sourceGroups.missing, checked),
+                        })
+                      }
+                      title={`새로 가져올 수령 기록 ${sourceGroups.missing.length}건`}
+                      description="계정의 수령 기록에 추가"
+                    />
+                  )}
+                  {sourceGroups.existing.length > 0 && (
+                    <ImportCheckbox
+                      checked={sourceGroups.existing.every((key) => selection.sourceKeys.includes(key))}
+                      onChange={(checked) =>
+                        setSelection({
+                          ...selection,
+                          sourceKeys: toggleGroup(selection.sourceKeys, sourceGroups.existing, checked),
+                        })
+                      }
+                      title={`계정에 이미 저장된 수령 기록 ${sourceGroups.existing.length}건`}
+                      description="이미 계정에 저장되어 있어요."
+                    />
+                  )}
+                </div>
+              </SectionCard>
+            )}
+
+            {fetcher.data && (
+              <Callout
+                tone={fetcher.data.failedLabels.length ? "warning" : "success"}
+                Icon={CheckCircleIcon}
+                title={
+                  fetcher.data.failedLabels.length
+                    ? "일부 항목을 가져오지 못했어요"
+                    : submittedDiscardedCount > 0
+                      ? "선택한 내용을 저장했어요"
+                      : "선택한 항목을 가져왔어요"
+                }
+                description={
+                  fetcher.data.failedLabels.length
+                    ? `${fetcher.data.failedLabels.join(", ")}은 이 브라우저에 남겨뒀어요. 다시 시도할 수 있어요.${submittedDiscardedCount > 0 ? ` 선택하지 않은 항목 ${submittedDiscardedCount}개는 삭제했어요.` : ""}`
+                    : submittedDiscardedCount > 0
+                      ? importedCount > 0
+                        ? `선택한 항목은 계정에 가져오고, 선택하지 않은 항목 ${submittedDiscardedCount}개는 이 브라우저에서 삭제했어요.`
+                        : `선택하지 않은 항목 ${submittedDiscardedCount}개를 이 브라우저에서 삭제했어요.`
+                      : "가져온 항목만 이 브라우저에서 정리했어요."
+                }
+              />
+            )}
+
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-sm text-muted-foreground">
+                {selectedCount}개 항목 선택
+                {discardedCount > 0 && ` · 삭제할 항목 ${discardedCount}개`}
+              </p>
+              <div className="flex flex-col-reverse gap-2 sm:flex-row">
+                <Button text="플래너로 돌아가기" to="/utils/pyroxene" variant="secondary" />
+                <Button
+                  variant="primary"
+                  disabled={(selectedCount === 0 && discardedCount === 0) || isSubmitting}
+                  onClick={() => {
+                    submittedEnvelope.current = envelope;
+                    submittedDiscardedItems.current = discardedItems;
+                    fetcher.submit({ envelope, selection }, { method: "POST", encType: "application/json" });
+                  }}
+                >
+                  {isSubmitting && <ArrowPathIcon className="size-4 animate-spin" />}
+                  {isSubmitting ? "저장하는 중..." : "선택 내용 저장"}
+                </Button>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </Page>
+  );
+}
+
+const IMPORT_SOURCE_LABELS = {
+  guest: "비로그인 시 등록한 값",
+  account: "계정에 저장된 값",
+} as const;
+
+function ImportSourceComparison({
+  name,
+  selected,
+  onChange,
+  guest,
+  account,
+}: {
+  name: string;
+  selected: "guest" | "account";
+  onChange: (source: "guest" | "account") => void;
+  guest: ReactNode;
+  account: ReactNode;
+}) {
+  return (
+    <fieldset>
+      <legend className="sr-only">{name === "resources" ? "현재 보유 재화" : "플래너 설정"} 선택</legend>
+      <div className="grid gap-3 md:grid-cols-2">
+        <ImportSourceOption
+          name={name}
+          source="guest"
+          selected={selected === "guest"}
+          onSelect={() => onChange("guest")}
+        >
+          {guest}
+        </ImportSourceOption>
+        <ImportSourceOption
+          name={name}
+          source="account"
+          selected={selected === "account"}
+          onSelect={() => onChange("account")}
+        >
+          {account}
+        </ImportSourceOption>
+      </div>
+    </fieldset>
+  );
+}
+
+function ImportSourceOption({
+  name,
+  source,
+  selected,
+  onSelect,
+  children,
+}: {
+  name: string;
+  source: keyof typeof IMPORT_SOURCE_LABELS;
+  selected: boolean;
+  onSelect: () => void;
+  children: ReactNode;
+}) {
+  const label = IMPORT_SOURCE_LABELS[source];
+  return (
+    <label
+      className={cn(
+        "flex cursor-pointer flex-col gap-3 rounded-lg border p-4 transition-colors",
+        selected ? "border-primary bg-primary/5 ring-1 ring-primary/30" : "border-border bg-card hover:bg-muted/50",
+      )}
+    >
+      <span className="flex items-center gap-2 font-medium text-foreground">
+        <input
+          type="radio"
+          name={`pyroxene-import-${name}`}
+          value={source}
+          checked={selected}
+          onChange={onSelect}
+          className="size-4 border-input text-primary focus:ring-2 focus:ring-ring/30"
+        />
+        {label}
+      </span>
+      {children}
+    </label>
+  );
+}
+
+function ResourceSourceSummary({ resources, inputAt }: { resources: PickupResources; inputAt: Date | string }) {
+  const items = [
+    {
+      resourceType: ResourceTypeEnum.Currency,
+      itemUid: PYROXENE_RESOURCE_UIDS.pyroxene,
+      label: "청휘석",
+      value: resources.pyroxene,
+      unit: "개",
+    },
+    {
+      resourceType: ResourceTypeEnum.Item,
+      itemUid: PYROXENE_RESOURCE_UIDS.tenTimeTicket,
+      label: "10회 모집 티켓",
+      value: resources.tenTimeTicket,
+      unit: "장",
+    },
+    {
+      resourceType: ResourceTypeEnum.Item,
+      itemUid: PYROXENE_RESOURCE_UIDS.oneTimeTicket,
+      label: "1회 모집 티켓",
+      value: resources.oneTimeTicket,
+      unit: "장",
+    },
+  ];
+
+  return (
+    <span className="space-y-3">
+      <span className="space-y-2">
+        {items.map((item) => (
+          <span key={item.itemUid} className="flex items-center gap-2.5">
+            <ResourceCard resourceType={item.resourceType} itemUid={item.itemUid} name={item.label} size="sm" />
+            <span className="min-w-0 flex-1 text-sm text-muted-foreground">{item.label}</span>
+            <span className="shrink-0 text-sm font-semibold tabular-nums text-foreground">
+              {item.value.toLocaleString()}
+              {item.unit}
+            </span>
+          </span>
+        ))}
+      </span>
+      <span className="mt-2 block text-sm text-muted-foreground">{dayjs(inputAt).format("MM/DD HH:mm")} 입력</span>
+    </span>
+  );
+}
+
+function PlannerOptionsSummary({ options }: { options: PyroxenePlannerOptions }) {
+  const pickupChanceLabels: Record<PyroxenePlannerOptions["event"]["pickupChance"], string> = {
+    average: "평균 (천장 미반영)",
+    average_pity: "평균 (천장 반영)",
+    ceil: "천장",
+  };
+  const raidTierLabels: Record<PyroxenePlannerOptions["raid"]["tier"], string> = {
+    platinum: "플래티넘",
+    gold: "골드",
+    silver: "실버",
+    bronze: "브론즈",
+  };
+  const tacticalLevelLabels: Record<PyroxenePlannerOptions["tactical"]["level"], string> = {
+    in10: "10위 내",
+    in100: "100위 내",
+    in200: "200위 내",
+    over200: "200위 밖",
+  };
+
+  return (
+    <span className="space-y-1 text-sm">
+      <span className="block font-medium text-foreground">
+        모집 목표 · {pickupChanceLabels[options.event.pickupChance]}
+      </span>
+      <span className="block text-muted-foreground">
+        총력전 {raidTierLabels[options.raid.tier]} · 전술대회 {tacticalLevelLabels[options.tactical.level]}
+      </span>
+      <span className="block text-muted-foreground">
+        AP 충전 {options.consumption.apChargeCount}회 · 타임라인 {options.timeline.display.length}개 표시
+      </span>
+    </span>
+  );
+}
+
+function ImportCheckbox({
+  checked,
+  onChange,
+  title,
+  description,
+}: {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  title: string;
+  description: string;
+}) {
+  return (
+    <Checkbox
+      checked={checked}
+      onChange={onChange}
+      className={cn(
+        "w-full items-start rounded-lg border px-4 py-3 transition-colors",
+        checked ? "border-primary/50 bg-primary/5" : "border-border bg-card hover:bg-muted/50",
+      )}
+      aria-label={title}
+      label={
+        <span className="min-w-0">
+          <span className="block text-sm font-medium text-foreground">{title}</span>
+          <span className="mt-0.5 block text-sm text-muted-foreground">{description}</span>
+        </span>
+      }
+    />
+  );
+}

--- a/db/migrations/20260719000100_create_pyroxene_guest_import_items.sql
+++ b/db/migrations/20260719000100_create_pyroxene_guest_import_items.sql
@@ -1,0 +1,11 @@
+create table pyroxene_guest_import_items (
+  id integer primary key autoincrement,
+  userId integer not null,
+  datasetId text not null,
+  itemType text not null,
+  itemKey text not null,
+  importedAt text not null default current_timestamp
+);
+
+create unique index pyroxene_guest_import_items_user_dataset_item
+  on pyroxene_guest_import_items (userId, datasetId, itemType, itemKey);

--- a/test/app/components/features/layout/navigation-menu.test.ts
+++ b/test/app/components/features/layout/navigation-menu.test.ts
@@ -1,20 +1,26 @@
 import { describe, expect, it } from "@jest/globals";
 import { getNavigationSections } from "~/components/features/layout/navigation-menu";
 
-function getRaidMenuItem(hasOngoingRaid: boolean) {
+function getMenuItems({ hasOngoingRaid = false, isSignedIn = false } = {}) {
   return getNavigationSections({
     pathname: "/",
     upcomingEvent: null,
     hasOngoingRaid,
     hasUnconsumedCoupons: false,
-  })
-    .flatMap((section) => section.items)
-    .find((item) => item.to === "/raids");
+    isSignedIn,
+  }).flatMap((section) => section.items);
 }
 
 describe("getNavigationSections", () => {
   it("labels the raid menu only while a raid is ongoing", () => {
-    expect(getRaidMenuItem(true)?.badgeLabel).toBe("진행중");
-    expect(getRaidMenuItem(false)?.badgeLabel).toBeUndefined();
+    expect(getMenuItems({ hasOngoingRaid: true }).find((item) => item.to === "/raids")?.badgeLabel).toBe("진행중");
+    expect(getMenuItems().find((item) => item.to === "/raids")?.badgeLabel).toBeUndefined();
+  });
+
+  it("labels guest access to the pyroxene planner only while signed out", () => {
+    expect(getMenuItems().find((item) => item.to === "/utils/pyroxene")?.badgeLabel).toBe("로그인 없이 사용");
+    expect(
+      getMenuItems({ isSignedIn: true }).find((item) => item.to === "/utils/pyroxene")?.badgeLabel,
+    ).toBeUndefined();
   });
 });

--- a/test/app/domain/guest-pyroxene-planner.test.ts
+++ b/test/app/domain/guest-pyroxene-planner.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  clearVerifiedGuestPyroxeneImport,
+  createEmptyGuestPyroxenePlanner,
+  type GuestPyroxeneRecord,
+  guestPyroxeneRecordToTimelineItems,
+  hasGuestPyroxenePlannerData,
+  parseGuestPyroxenePlanner,
+} from "~/domain/guest-pyroxene-planner";
+
+describe("guest pyroxene planner", () => {
+  it("빈 데이터는 가져오기 대상으로 판단하지 않는다", () => {
+    const envelope = createEmptyGuestPyroxenePlanner();
+
+    expect(hasGuestPyroxenePlannerData(envelope.data)).toBe(false);
+    expect(parseGuestPyroxenePlanner(JSON.stringify(envelope))).toEqual(envelope);
+  });
+
+  it("사용자 입력이 하나라도 있으면 가져오기 대상으로 판단한다", () => {
+    const envelope = createEmptyGuestPyroxenePlanner();
+    envelope.data.resources = {
+      inputAt: "2026-07-19T01:00:00.000Z",
+      pyroxene: 12_000,
+      oneTimeTicket: 2,
+      tenTimeTicket: 3,
+    };
+
+    expect(hasGuestPyroxenePlannerData(envelope.data)).toBe(true);
+  });
+
+  it("손상됐거나 제한을 벗어난 데이터는 거부한다", () => {
+    const envelope = createEmptyGuestPyroxenePlanner();
+    envelope.data.resources = {
+      inputAt: "2026-07-19T01:00:00.000Z",
+      pyroxene: -1,
+      oneTimeTicket: 0,
+      tenTimeTicket: 0,
+    };
+
+    expect(parseGuestPyroxenePlanner("not-json")).toBeNull();
+    expect(parseGuestPyroxenePlanner(JSON.stringify(envelope))).toBeNull();
+  });
+
+  it("일부 항목만 조용히 버리지 않고 전체를 손상 상태로 처리한다", () => {
+    const envelope = createEmptyGuestPyroxenePlanner();
+    envelope.data.favoriteStudents = [{ contentUid: "event", studentUid: "student" }];
+    const parsed = JSON.parse(JSON.stringify(envelope)) as Record<string, unknown> & {
+      data: { favoriteStudents: unknown[]; options: { event: { pickupChance: string } } };
+    };
+    parsed.data.favoriteStudents.push({ contentUid: "event" });
+
+    expect(parseGuestPyroxenePlanner(JSON.stringify(parsed))).toBeNull();
+
+    parsed.data.favoriteStudents.pop();
+    parsed.data.options.event.pickupChance = "unknown";
+    expect(parseGuestPyroxenePlanner(JSON.stringify(parsed))).toBeNull();
+  });
+
+  it("stable id에 와일드카드나 빈 문자열이 들어간 데이터는 거부한다", () => {
+    const envelope = createEmptyGuestPyroxenePlanner();
+    envelope.datasetId = "unsafe%id";
+    expect(parseGuestPyroxenePlanner(JSON.stringify(envelope))).toBeNull();
+
+    envelope.datasetId = "safe-dataset-id1";
+    envelope.data.records = [
+      {
+        kind: "attendance",
+        recordId: "",
+        createdAt: "2026-07-19T01:00:00.000Z",
+        startDate: "2026-07-19T01:00:00.000Z",
+      },
+    ];
+    expect(parseGuestPyroxenePlanner(JSON.stringify(envelope))).toBeNull();
+  });
+
+  it("가져오기를 요청한 뒤 수정된 로컬 값은 이전 응답으로 지우지 않는다", () => {
+    const submitted = createEmptyGuestPyroxenePlanner().data;
+    submitted.resources = {
+      inputAt: "2026-07-19T01:00:00.000Z",
+      pyroxene: 12_000,
+      oneTimeTicket: 0,
+      tenTimeTicket: 0,
+    };
+    submitted.optionsChanged = true;
+    submitted.eventTrials = { event: 200 };
+
+    const current = structuredClone(submitted);
+    current.resources = {
+      inputAt: "2026-07-19T02:00:00.000Z",
+      pyroxene: 13_000,
+      oneTimeTicket: 0,
+      tenTimeTicket: 0,
+    };
+    current.options = { ...current.options, consumption: { apChargeCount: 3 } };
+    current.eventTrials.event = 300;
+
+    const next = clearVerifiedGuestPyroxeneImport(current, submitted, {
+      resources: true,
+      options: true,
+      recordIds: [],
+      sourceKeys: [],
+      eventUids: ["event"],
+      favorites: [],
+    });
+
+    expect(next.resources).toEqual(current.resources);
+    expect(next.options).toEqual(current.options);
+    expect(next.optionsChanged).toBe(true);
+    expect(next.eventTrials).toEqual({ event: 300 });
+  });
+
+  it("서버에서 확인된 항목만 로컬 데이터에서 정리한다", () => {
+    const envelope = createEmptyGuestPyroxenePlanner();
+    envelope.data.resources = {
+      inputAt: "2026-07-19T01:00:00.000Z",
+      pyroxene: 12_000,
+      oneTimeTicket: 0,
+      tenTimeTicket: 0,
+    };
+    envelope.data.eventTrials = { imported: 200, failed: 300 };
+    envelope.data.collectedSourceKeys = ["imported", "failed"];
+
+    const next = clearVerifiedGuestPyroxeneImport(envelope.data, envelope.data, {
+      resources: true,
+      options: false,
+      recordIds: [],
+      sourceKeys: ["imported"],
+      eventUids: ["imported"],
+      favorites: [],
+    });
+
+    expect(next.resources).toBeNull();
+    expect(next.eventTrials).toEqual({ failed: 300 });
+    expect(next.collectedSourceKeys).toEqual(["failed"]);
+  });
+
+  it("논리 레코드의 stable id를 계산 항목 uid로 사용한다", () => {
+    const record: GuestPyroxeneRecord = {
+      kind: "monthlyPackage",
+      recordId: "stable-record-id",
+      createdAt: "2026-07-19T01:00:00.000Z",
+      startDate: "2026-07-19T01:00:00.000Z",
+      packageType: "full",
+      autoRepurchase: false,
+    };
+
+    expect(guestPyroxeneRecordToTimelineItems(record).map((item) => item.uid)).toEqual([
+      "stable-record-id::onetime",
+      "stable-record-id::daily",
+    ]);
+  });
+});

--- a/test/app/domain/pyroxene-schedule.test.ts
+++ b/test/app/domain/pyroxene-schedule.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "@jest/globals";
-import { buildPyroxeneScheduleItems, type PyroxeneScheduleContent } from "~/domain/pyroxene-schedule";
+import {
+  buildPyroxeneDisplayTimeline,
+  buildPyroxeneScheduleItems,
+  type PyroxeneScheduleContent,
+  type PyroxeneScheduleItem,
+} from "~/domain/pyroxene-schedule";
 import { RecruitmentTypeEnum } from "~/graphql/graphql";
 
 function recruitment(
@@ -67,5 +72,38 @@ describe("buildPyroxeneScheduleItems favorited resolution", () => {
     );
 
     expect(favoritedByStudentUid).toEqual({ a: true, b: false, c: true, d: false });
+  });
+});
+
+describe("buildPyroxeneDisplayTimeline", () => {
+  const resources = { pyroxene: 0, oneTimeTicket: 0, tenTimeTicket: 0 };
+
+  function eventItem(uid: string, since: string, until: string): PyroxeneScheduleItem {
+    return {
+      event: {
+        uid,
+        name: uid,
+        since,
+        until,
+        earnablePyroxene: null,
+        tags: [],
+        recruitments: [{ ...recruitment(`${uid}-student`), favorited: false }],
+      },
+    };
+  }
+
+  it("shows ongoing and upcoming recruitments without an owned-resource baseline", () => {
+    const displayTimeline = buildPyroxeneDisplayTimeline(
+      [],
+      [
+        eventItem("ongoing", "2026-07-14T02:00:00.000Z", "2026-07-21T02:00:00.000Z"),
+        eventItem("upcoming", "2026-07-22T02:00:00.000Z", "2026-08-05T02:00:00.000Z"),
+        eventItem("finished", "2026-07-01T02:00:00.000Z", "2026-07-10T02:00:00.000Z"),
+      ],
+      new Date("2026-07-19T02:00:00.000Z"),
+      resources,
+    );
+
+    expect(displayTimeline.map(({ source }) => source.event?.uid)).toEqual(["ongoing", "upcoming"]);
   });
 });


### PR DESCRIPTION
## Summary

Allow signed-out users to use the pyroxene planner and keep their inputs in the current browser.

This also adds an explicit review flow after sign-in, allowing users to compare guest data with account data, import selected items, and discard items they chose not to keep.

## Changes

- Open the pyroxene planner's inputs, calculations, and recruitment schedule to signed-out users.
- Store versioned guest planner data in `localStorage` with validation, migration boundaries, and cross-tab updates.
- Allow users to select favorite students directly from the planner while keeping recruited-student information account-only.
- Separate display-only recruitment events from events included in pyroxene consumption calculations.
- Add planner callouts for sign-in and remaining guest data.
- Add `/utils/pyroxene/import` to compare browser data with account data before saving.
- Compare owned resources with resource cards and support selective handling of plans, settings, favorite students, recruitment targets, and collected rewards.
- Treat saving as the final decision: import selected items, remove unselected browser data, and preserve only failed imports for retry.
- Add idempotent guest import receipts and per-item verification.
- Standardize visible planner dates to `MM/DD`.
- Add regression coverage for guest dataset validation, verified cleanup, and display-only recruitment schedules.

The D1 migration `20260719000100_create_pyroxene_guest_import_items.sql` must be applied before deploying the import flow.

## Verification

- [x] I verified the related behavior myself.
- [ ] I ran `pnpm typecheck`, `pnpm exec biome check .`, and relevant tests when needed.
  - `mise exec -- pnpm run typecheck`: passed
  - `mise exec -- pnpm test --runInBand`: passed (113 suites, 687 tests)
  - `mise exec -- pnpm run prod:build`: passed
  - Biome checks for all 21 changed TypeScript files: passed
  - `git diff --check`: passed
- [x] (If AI tools were used) The generated content was reviewed by a person.

## Related issues

None.
