### PR TITLE
feat: run cache refresh as an observable workflow

### DIFF
--- a/app/domain/cache-refresh.ts
+++ b/app/domain/cache-refresh.ts
@@ -1,0 +1,100 @@
+export const SOURCE_CACHE_REFRESH_TASK_NAMES = [
+  "syncYoutubeCommunityPosts",
+  "syncRawStudents",
+  "warmRecruitmentCache",
+  "warmRaidCache",
+  "getMainStories",
+  "getAllStudentsFavoriteItems",
+  "syncAllTimelineContentsMeta",
+  "syncEventContentsList",
+  "warmStudentSkillItems",
+  "warmStudentGearData",
+  "warmActiveUpcomingEventContent",
+  "getItemCatalogResources",
+  "getCampaignFarmingStages",
+] as const;
+
+export const ROUTE_CACHE_REFRESH_TASK_NAMES = [
+  "getEventList",
+  "getIndexContents",
+  "getFutureContents",
+  "getNavigationBarContentsRaw",
+] as const;
+
+export const CACHE_REFRESH_TASK_NAMES = [
+  ...SOURCE_CACHE_REFRESH_TASK_NAMES,
+  ...ROUTE_CACHE_REFRESH_TASK_NAMES,
+] as const;
+
+export type CacheRefreshTaskName = (typeof CACHE_REFRESH_TASK_NAMES)[number];
+export type CacheRefreshJobStatus = "queued" | "running" | "completed" | "partial_failure" | "failed";
+export type CacheRefreshTaskStatus = "pending" | "succeeded" | "failed" | "skipped";
+
+export type CacheRefreshTaskResult = {
+  status: CacheRefreshTaskStatus;
+  durationMs: number | null;
+  error: string | null;
+};
+
+export type CacheRefreshTaskResults = Record<CacheRefreshTaskName, CacheRefreshTaskResult>;
+
+export type CacheRefreshJob = {
+  uid: string;
+  requestedBy: number;
+  status: CacheRefreshJobStatus;
+  currentTask: CacheRefreshTaskName | null;
+  completedCount: number;
+  totalCount: number;
+  taskResults: CacheRefreshTaskResults;
+  startedAt: string | null;
+  finishedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type CacheRefreshWorkflowParams = {
+  requestedBy: number;
+};
+
+export type CacheRefreshWorkflowOutput = {
+  status: Extract<CacheRefreshJobStatus, "completed" | "partial_failure">;
+  taskResults: CacheRefreshTaskResults;
+};
+
+export const CACHE_REFRESH_TASK_LABELS: Record<CacheRefreshTaskName, string> = {
+  syncYoutubeCommunityPosts: "YouTube 커뮤니티 동기화",
+  syncRawStudents: "학생 원본 데이터",
+  warmRecruitmentCache: "모집 캐시",
+  warmRaidCache: "총력전 캐시",
+  getMainStories: "메인 스토리",
+  getAllStudentsFavoriteItems: "학생 선물 데이터",
+  syncAllTimelineContentsMeta: "타임라인 메타데이터",
+  syncEventContentsList: "이벤트 콘텐츠 목록",
+  warmStudentSkillItems: "학생 스킬 재료",
+  warmStudentGearData: "학생 장비 데이터",
+  warmActiveUpcomingEventContent: "진행·예정 이벤트",
+  getItemCatalogResources: "아이템 카탈로그",
+  getCampaignFarmingStages: "캠페인 파밍 스테이지",
+  getEventList: "이벤트 목록 화면",
+  getIndexContents: "홈 화면",
+  getFutureContents: "미래시 화면",
+  getNavigationBarContentsRaw: "내비게이션",
+};
+
+export function createPendingCacheRefreshTaskResults(): CacheRefreshTaskResults {
+  return Object.fromEntries(
+    CACHE_REFRESH_TASK_NAMES.map((name) => [name, { status: "pending", durationMs: null, error: null }]),
+  ) as CacheRefreshTaskResults;
+}
+
+export function isCacheRefreshJobActive(status: CacheRefreshJobStatus): boolean {
+  return status === "queued" || status === "running";
+}
+
+export function isCacheRefreshTaskName(value: string): value is CacheRefreshTaskName {
+  return CACHE_REFRESH_TASK_NAMES.includes(value as CacheRefreshTaskName);
+}
+
+export function countCompletedCacheRefreshTasks(results: CacheRefreshTaskResults): number {
+  return CACHE_REFRESH_TASK_NAMES.filter((name) => results[name].status !== "pending").length;
+}

--- a/app/jobs/cache-refresh-control.server.ts
+++ b/app/jobs/cache-refresh-control.server.ts
@@ -6,12 +6,13 @@ import {
   completeCacheRefreshJob,
   createCacheRefreshJob,
   failCacheRefreshJob,
+  failStaleCacheRefreshJob,
   getActiveCacheRefreshJob,
   getCacheRefreshJob,
   getLatestCacheRefreshJob,
 } from "~/models/cache-refresh-job";
 
-type CacheRefreshControlEnv = Pick<Env, "CACHE_REFRESH_WORKFLOW" | "DB"> & Env;
+const CACHE_REFRESH_JOB_STALE_AFTER_HOURS = 24;
 
 export type StartCacheRefreshResult = {
   job: CacheRefreshJob;
@@ -30,8 +31,30 @@ function isWorkflowOutput(value: unknown): value is CacheRefreshWorkflowOutput {
   );
 }
 
+async function recoverStaleCacheRefreshJob(
+  env: Env,
+  job: CacheRefreshJob,
+  logger: ReturnType<typeof getLogger>,
+): Promise<CacheRefreshJob> {
+  try {
+    const released = await failStaleCacheRefreshJob(env, job.uid, CACHE_REFRESH_JOB_STALE_AFTER_HOURS);
+    if (released) {
+      logger.warn("Released stale cache refresh job after reconciliation repeatedly failed", {
+        staleAfterHours: CACHE_REFRESH_JOB_STALE_AFTER_HOURS,
+      });
+      return (await getCacheRefreshJob(env, job.uid)) ?? job;
+    }
+  } catch (error) {
+    logger.error("Failed to release stale cache refresh job", error, {
+      staleAfterHours: CACHE_REFRESH_JOB_STALE_AFTER_HOURS,
+    });
+  }
+
+  return job;
+}
+
 async function reconcileCacheRefreshJob(
-  env: CacheRefreshControlEnv,
+  env: Env,
   ctx: ExecutionContext,
   job: CacheRefreshJob,
 ): Promise<CacheRefreshJob> {
@@ -53,17 +76,19 @@ async function reconcileCacheRefreshJob(
     } else if (workflowStatus.status === "errored" || workflowStatus.status === "terminated") {
       logger.error("Cache refresh workflow stopped", workflowStatus.error, { workflowStatus: workflowStatus.status });
       await failCacheRefreshJob(env, job.uid);
+    } else if (workflowStatus.status === "unknown") {
+      return recoverStaleCacheRefreshJob(env, job, logger);
     }
   } catch (error) {
     logger.error("Failed to reconcile cache refresh workflow status", error);
-    return job;
+    return recoverStaleCacheRefreshJob(env, job, logger);
   }
 
   return (await getCacheRefreshJob(env, job.uid)) ?? job;
 }
 
 export async function startCacheRefresh(
-  env: CacheRefreshControlEnv,
+  env: Env,
   ctx: ExecutionContext,
   requestedBy: number,
 ): Promise<StartCacheRefreshResult> {
@@ -106,7 +131,7 @@ export async function startCacheRefresh(
 }
 
 export async function getCacheRefreshStatus(
-  env: CacheRefreshControlEnv,
+  env: Env,
   ctx: ExecutionContext,
   uid?: string | null,
 ): Promise<CacheRefreshJob | null> {

--- a/app/jobs/cache-refresh-control.server.ts
+++ b/app/jobs/cache-refresh-control.server.ts
@@ -1,0 +1,115 @@
+import type { CacheRefreshJob, CacheRefreshWorkflowOutput, CacheRefreshWorkflowParams } from "~/domain/cache-refresh";
+import { isCacheRefreshJobActive } from "~/domain/cache-refresh";
+import { isUniqueConstraintError } from "~/lib/db";
+import { getLogger } from "~/lib/observability.server";
+import {
+  completeCacheRefreshJob,
+  createCacheRefreshJob,
+  failCacheRefreshJob,
+  getActiveCacheRefreshJob,
+  getCacheRefreshJob,
+  getLatestCacheRefreshJob,
+} from "~/models/cache-refresh-job";
+
+type CacheRefreshControlEnv = Pick<Env, "CACHE_REFRESH_WORKFLOW" | "DB"> & Env;
+
+export type StartCacheRefreshResult = {
+  job: CacheRefreshJob;
+  created: boolean;
+};
+
+function isWorkflowOutput(value: unknown): value is CacheRefreshWorkflowOutput {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const output = value as Partial<CacheRefreshWorkflowOutput>;
+  return (
+    (output.status === "completed" || output.status === "partial_failure") &&
+    Boolean(output.taskResults) &&
+    typeof output.taskResults === "object"
+  );
+}
+
+async function reconcileCacheRefreshJob(
+  env: CacheRefreshControlEnv,
+  ctx: ExecutionContext,
+  job: CacheRefreshJob,
+): Promise<CacheRefreshJob> {
+  if (!isCacheRefreshJobActive(job.status)) {
+    return job;
+  }
+
+  const logger = getLogger(env, ctx, { job: "cache-refresh", jobUid: job.uid });
+  try {
+    const workflowInstance = await env.CACHE_REFRESH_WORKFLOW.get(job.uid);
+    const workflowStatus = await workflowInstance.status();
+    if (workflowStatus.status === "complete") {
+      if (isWorkflowOutput(workflowStatus.output)) {
+        await completeCacheRefreshJob(env, job.uid, workflowStatus.output.status, workflowStatus.output.taskResults);
+      } else {
+        logger.error("Cache refresh workflow completed without a valid output");
+        await failCacheRefreshJob(env, job.uid);
+      }
+    } else if (workflowStatus.status === "errored" || workflowStatus.status === "terminated") {
+      logger.error("Cache refresh workflow stopped", workflowStatus.error, { workflowStatus: workflowStatus.status });
+      await failCacheRefreshJob(env, job.uid);
+    }
+  } catch (error) {
+    logger.error("Failed to reconcile cache refresh workflow status", error);
+    return job;
+  }
+
+  return (await getCacheRefreshJob(env, job.uid)) ?? job;
+}
+
+export async function startCacheRefresh(
+  env: CacheRefreshControlEnv,
+  ctx: ExecutionContext,
+  requestedBy: number,
+): Promise<StartCacheRefreshResult> {
+  const active = await getActiveCacheRefreshJob(env);
+  if (active) {
+    const reconciled = await reconcileCacheRefreshJob(env, ctx, active);
+    if (isCacheRefreshJobActive(reconciled.status)) {
+      return { job: reconciled, created: false };
+    }
+  }
+
+  const uid = crypto.randomUUID();
+  let job: CacheRefreshJob;
+  try {
+    job = await createCacheRefreshJob(env, { uid, requestedBy });
+  } catch (error) {
+    const unique = error instanceof Error ? isUniqueConstraintError(error) : null;
+    if (unique?.table === "cache_refresh_jobs" && unique.column === "activeSlot") {
+      const racedJob = await getActiveCacheRefreshJob(env);
+      if (racedJob) {
+        return { job: racedJob, created: false };
+      }
+    }
+    throw error;
+  }
+
+  try {
+    await env.CACHE_REFRESH_WORKFLOW.create({
+      id: uid,
+      params: { requestedBy } satisfies CacheRefreshWorkflowParams,
+      retention: { successRetention: "7 days", errorRetention: "7 days" },
+    });
+  } catch (error) {
+    await failCacheRefreshJob(env, uid);
+    getLogger(env, ctx, { job: "cache-refresh", jobUid: uid }).error("Failed to create cache refresh workflow", error);
+    throw error;
+  }
+
+  return { job, created: true };
+}
+
+export async function getCacheRefreshStatus(
+  env: CacheRefreshControlEnv,
+  ctx: ExecutionContext,
+  uid?: string | null,
+): Promise<CacheRefreshJob | null> {
+  const job = uid ? await getCacheRefreshJob(env, uid) : await getLatestCacheRefreshJob(env);
+  return job ? reconcileCacheRefreshJob(env, ctx, job) : null;
+}

--- a/app/jobs/cache-refresh-workflow.server.ts
+++ b/app/jobs/cache-refresh-workflow.server.ts
@@ -1,0 +1,126 @@
+import type { WorkflowEvent, WorkflowStep, WorkflowStepConfig } from "cloudflare:workers";
+import {
+  type CacheRefreshJobStatus,
+  type CacheRefreshTaskName,
+  type CacheRefreshTaskResult,
+  type CacheRefreshTaskResults,
+  type CacheRefreshWorkflowOutput,
+  type CacheRefreshWorkflowParams,
+  createPendingCacheRefreshTaskResults,
+  ROUTE_CACHE_REFRESH_TASK_NAMES,
+  SOURCE_CACHE_REFRESH_TASK_NAMES,
+} from "~/domain/cache-refresh";
+import { getLogger } from "~/lib/observability.server";
+import {
+  completeCacheRefreshJob,
+  markCacheRefreshJobRunning,
+  markCacheRefreshTaskRunning,
+  recordCacheRefreshTaskResult,
+  recordSkippedCacheRefreshTasks,
+} from "~/models/cache-refresh-job";
+import { runCacheRefreshTask } from "./cache-refresh";
+
+const STATUS_STEP_CONFIG: WorkflowStepConfig = {
+  retries: { limit: 3, delay: "1 second", backoff: "linear" },
+  timeout: "30 seconds",
+};
+
+const TASK_STEP_CONFIG: WorkflowStepConfig = {
+  retries: { limit: 0, delay: 0 },
+  timeout: "5 minutes",
+};
+
+const SAFE_TASK_ERROR = "작업을 완료하지 못했어요. 로그에서 job ID를 확인해주세요.";
+
+async function runStatusStep(
+  step: WorkflowStep,
+  name: string,
+  logger: ReturnType<typeof getLogger>,
+  operation: () => Promise<void>,
+): Promise<void> {
+  try {
+    await step.do(name, STATUS_STEP_CONFIG, async () => {
+      await operation();
+      return true;
+    });
+  } catch (error) {
+    logger.error("Failed to persist cache refresh progress", error, { workflowStep: name });
+  }
+}
+
+async function runTaskStep(
+  env: Env,
+  ctx: ExecutionContext,
+  step: WorkflowStep,
+  jobUid: string,
+  taskName: CacheRefreshTaskName,
+  logger: ReturnType<typeof getLogger>,
+): Promise<CacheRefreshTaskResult> {
+  await runStatusStep(step, `status running ${taskName}`, logger, () =>
+    markCacheRefreshTaskRunning(env, jobUid, taskName),
+  );
+
+  let result: CacheRefreshTaskResult;
+  try {
+    result = await step.do(`refresh ${taskName}`, TASK_STEP_CONFIG, () =>
+      runCacheRefreshTask(env, ctx, jobUid, taskName),
+    );
+  } catch (error) {
+    logger.error("Cache refresh workflow task step failed", error, { taskName });
+    result = { status: "failed", durationMs: null, error: SAFE_TASK_ERROR };
+  }
+
+  await runStatusStep(step, `status result ${taskName}`, logger, () =>
+    recordCacheRefreshTaskResult(env, jobUid, taskName, result).then(() => undefined),
+  );
+  return result;
+}
+
+export async function runCacheRefreshWorkflow(
+  env: Env,
+  ctx: ExecutionContext,
+  event: Readonly<WorkflowEvent<CacheRefreshWorkflowParams>>,
+  step: WorkflowStep,
+): Promise<CacheRefreshWorkflowOutput> {
+  const jobUid = event.instanceId;
+  const logger = getLogger(env, ctx, { job: "cache-refresh", jobUid, requestedBy: event.payload.requestedBy });
+  let taskResults: CacheRefreshTaskResults = createPendingCacheRefreshTaskResults();
+
+  await runStatusStep(step, "status job running", logger, () => markCacheRefreshJobRunning(env, jobUid));
+
+  let sourceFailed = false;
+  for (const taskName of SOURCE_CACHE_REFRESH_TASK_NAMES) {
+    const result = await runTaskStep(env, ctx, step, jobUid, taskName, logger);
+    taskResults = { ...taskResults, [taskName]: result };
+    sourceFailed ||= result.status === "failed";
+  }
+
+  if (sourceFailed) {
+    for (const taskName of ROUTE_CACHE_REFRESH_TASK_NAMES) {
+      taskResults = {
+        ...taskResults,
+        [taskName]: { status: "skipped", durationMs: null, error: null },
+      };
+    }
+    await runStatusStep(step, "status route tasks skipped", logger, () =>
+      recordSkippedCacheRefreshTasks(env, jobUid, ROUTE_CACHE_REFRESH_TASK_NAMES).then(() => undefined),
+    );
+  } else {
+    for (const taskName of ROUTE_CACHE_REFRESH_TASK_NAMES) {
+      const result = await runTaskStep(env, ctx, step, jobUid, taskName, logger);
+      taskResults = { ...taskResults, [taskName]: result };
+    }
+  }
+
+  const status: Extract<CacheRefreshJobStatus, "completed" | "partial_failure"> = Object.values(taskResults).some(
+    (result) => result.status === "failed",
+  )
+    ? "partial_failure"
+    : "completed";
+
+  await runStatusStep(step, "status job complete", logger, () =>
+    completeCacheRefreshJob(env, jobUid, status, taskResults),
+  );
+  logger.info("Cache refresh workflow completed", { status });
+  return { status, taskResults };
+}

--- a/app/jobs/cache-refresh.ts
+++ b/app/jobs/cache-refresh.ts
@@ -1,0 +1,100 @@
+import type { CacheRefreshTaskName, CacheRefreshTaskResult } from "~/domain/cache-refresh";
+import { getLogger } from "~/lib/observability.server";
+import { syncEventContentsList } from "~/models/event-content";
+import { getStudentGearData } from "~/models/growth-resource";
+import { getItemCatalogResources } from "~/models/item-catalog";
+import { getMainStories } from "~/models/main-story";
+import { warmRaidCache } from "~/models/raid";
+import { warmRecruitmentCache } from "~/models/recruitment";
+import { getAllStudentsFavoriteItems } from "~/models/resource";
+import { getCampaignFarmingStages } from "~/models/stage";
+import { getAllStudents, getStudentSkillItemsBatch, syncRawStudents } from "~/models/student";
+import { syncAllTimelineContentsMeta } from "~/models/timeline-content.server";
+import { syncYoutubeCommunityPosts } from "~/models/youtube";
+import { getEventList, warmActiveUpcomingEventContent } from "~/views/events";
+import { getFutureContents } from "~/views/futures";
+import { getIndexContents } from "~/views/home";
+import { getNavigationBarContentsRaw } from "~/views/navigation";
+
+const SAFE_TASK_ERROR = "작업을 완료하지 못했어요. 로그에서 job ID를 확인해주세요.";
+
+async function executeCacheRefreshTask(env: Env, ctx: ExecutionContext, name: CacheRefreshTaskName): Promise<void> {
+  switch (name) {
+    case "syncYoutubeCommunityPosts":
+      await syncYoutubeCommunityPosts(env);
+      return;
+    case "syncRawStudents":
+      await syncRawStudents(env);
+      return;
+    case "warmRecruitmentCache":
+      await warmRecruitmentCache(env);
+      return;
+    case "warmRaidCache":
+      await warmRaidCache(env);
+      return;
+    case "getMainStories":
+      await getMainStories(env, true);
+      return;
+    case "getAllStudentsFavoriteItems":
+      await getAllStudentsFavoriteItems(env, true);
+      return;
+    case "syncAllTimelineContentsMeta":
+      await syncAllTimelineContentsMeta(env, true, { ctx });
+      return;
+    case "syncEventContentsList":
+      await syncEventContentsList(env);
+      return;
+    case "warmStudentSkillItems": {
+      const studentUids = (await getAllStudents(env, true)).map((student) => student.uid);
+      await getStudentSkillItemsBatch(env, studentUids, true);
+      return;
+    }
+    case "warmStudentGearData": {
+      const studentUids = (await getAllStudents(env, true)).map((student) => student.uid);
+      await getStudentGearData(env, studentUids, true);
+      return;
+    }
+    case "warmActiveUpcomingEventContent":
+      await warmActiveUpcomingEventContent(env, true, ctx);
+      return;
+    case "getItemCatalogResources":
+      await getItemCatalogResources(env, true);
+      return;
+    case "getCampaignFarmingStages":
+      await getCampaignFarmingStages(env, true);
+      return;
+    case "getEventList":
+      await getEventList(env, undefined, true, ctx);
+      return;
+    case "getIndexContents":
+      await getIndexContents(env, true, ctx);
+      return;
+    case "getFutureContents":
+      await getFutureContents(env, true, ctx);
+      return;
+    case "getNavigationBarContentsRaw":
+      await getNavigationBarContentsRaw(env, true, ctx);
+      return;
+  }
+}
+
+export async function runCacheRefreshTask(
+  env: Env,
+  ctx: ExecutionContext,
+  jobUid: string,
+  name: CacheRefreshTaskName,
+): Promise<CacheRefreshTaskResult> {
+  const startedAt = Date.now();
+  const logger = getLogger(env, ctx, { job: "cache-refresh", jobUid, taskName: name });
+
+  try {
+    await executeCacheRefreshTask(env, ctx, name);
+    const durationMs = Date.now() - startedAt;
+    logger.info("Cache refresh task completed", { durationMs });
+    return { status: "succeeded", durationMs, error: null };
+  } catch (error) {
+    const durationMs = Date.now() - startedAt;
+    logger.error("Cache refresh task failed", error, { durationMs });
+    return { status: "failed", durationMs, error: SAFE_TASK_ERROR };
+  }
+}

--- a/app/lib/require-admin.server.ts
+++ b/app/lib/require-admin.server.ts
@@ -1,0 +1,14 @@
+import { redirect } from "react-router";
+import { getActiveSensei } from "~/auth/authenticator.server";
+import type { Sensei } from "~/models/sensei";
+
+export async function requireAdmin(env: Env, request: Request, ctx: ExecutionContext): Promise<Sensei | Response> {
+  const currentUser = await getActiveSensei(env, request, ctx);
+  if (!currentUser) {
+    return redirect("/unauthorized");
+  }
+  if (currentUser.role !== "admin") {
+    return new Response(null, { status: 403 });
+  }
+  return currentUser;
+}

--- a/app/models/cache-refresh-job.ts
+++ b/app/models/cache-refresh-job.ts
@@ -1,0 +1,253 @@
+import { desc, eq, sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+import { int, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import {
+  CACHE_REFRESH_TASK_NAMES,
+  type CacheRefreshJob,
+  type CacheRefreshJobStatus,
+  type CacheRefreshTaskName,
+  type CacheRefreshTaskResult,
+  type CacheRefreshTaskResults,
+  countCompletedCacheRefreshTasks,
+  createPendingCacheRefreshTaskResults,
+  isCacheRefreshTaskName,
+} from "~/domain/cache-refresh";
+
+export const cacheRefreshJobsTable = sqliteTable("cache_refresh_jobs", {
+  uid: text().primaryKey(),
+  requestedBy: int().notNull(),
+  status: text().notNull(),
+  activeSlot: int(),
+  currentTask: text(),
+  completedCount: int().notNull().default(0),
+  totalCount: int().notNull(),
+  taskResults: text().notNull(),
+  startedAt: text(),
+  finishedAt: text(),
+  createdAt: text().notNull().default(sql`current_timestamp`),
+  updatedAt: text().notNull().default(sql`current_timestamp`),
+});
+
+const JOB_STATUSES = ["queued", "running", "completed", "partial_failure", "failed"] as const;
+const TASK_STATUSES = ["pending", "succeeded", "failed", "skipped"] as const;
+
+function parseJobStatus(value: string): CacheRefreshJobStatus {
+  if (JOB_STATUSES.includes(value as CacheRefreshJobStatus)) {
+    return value as CacheRefreshJobStatus;
+  }
+  throw new Error(`Invalid cache refresh job status: ${value}`);
+}
+
+function parseTaskResult(value: unknown, name: CacheRefreshTaskName): CacheRefreshTaskResult {
+  if (!value || typeof value !== "object") {
+    throw new Error(`Invalid cache refresh task result: ${name}`);
+  }
+
+  const candidate = value as Record<string, unknown>;
+  if (!TASK_STATUSES.includes(candidate.status as CacheRefreshTaskResult["status"])) {
+    throw new Error(`Invalid cache refresh task status: ${name}`);
+  }
+  if (candidate.durationMs !== null && typeof candidate.durationMs !== "number") {
+    throw new Error(`Invalid cache refresh task duration: ${name}`);
+  }
+  if (candidate.error !== null && typeof candidate.error !== "string") {
+    throw new Error(`Invalid cache refresh task error: ${name}`);
+  }
+
+  return {
+    status: candidate.status as CacheRefreshTaskResult["status"],
+    durationMs: candidate.durationMs as number | null,
+    error: candidate.error as string | null,
+  };
+}
+
+export function parseCacheRefreshTaskResults(value: string): CacheRefreshTaskResults {
+  const parsed = JSON.parse(value) as unknown;
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error("Invalid cache refresh task results");
+  }
+
+  const candidate = parsed as Record<string, unknown>;
+  return Object.fromEntries(
+    CACHE_REFRESH_TASK_NAMES.map((name) => [name, parseTaskResult(candidate[name], name)]),
+  ) as CacheRefreshTaskResults;
+}
+
+function toCacheRefreshJob(row: typeof cacheRefreshJobsTable.$inferSelect): CacheRefreshJob {
+  if (row.currentTask !== null && !isCacheRefreshTaskName(row.currentTask)) {
+    throw new Error(`Invalid current cache refresh task: ${row.currentTask}`);
+  }
+
+  return {
+    uid: row.uid,
+    requestedBy: row.requestedBy,
+    status: parseJobStatus(row.status),
+    currentTask: row.currentTask,
+    completedCount: row.completedCount,
+    totalCount: row.totalCount,
+    taskResults: parseCacheRefreshTaskResults(row.taskResults),
+    startedAt: row.startedAt,
+    finishedAt: row.finishedAt,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+async function getCacheRefreshJobRow(env: Pick<Env, "DB">, uid: string) {
+  const [row] = await drizzle(env.DB)
+    .select()
+    .from(cacheRefreshJobsTable)
+    .where(eq(cacheRefreshJobsTable.uid, uid))
+    .limit(1);
+  return row ?? null;
+}
+
+export async function createCacheRefreshJob(
+  env: Pick<Env, "DB">,
+  input: { uid: string; requestedBy: number },
+): Promise<CacheRefreshJob> {
+  const taskResults = createPendingCacheRefreshTaskResults();
+  await drizzle(env.DB)
+    .insert(cacheRefreshJobsTable)
+    .values({
+      uid: input.uid,
+      requestedBy: input.requestedBy,
+      status: "queued",
+      activeSlot: 1,
+      totalCount: CACHE_REFRESH_TASK_NAMES.length,
+      taskResults: JSON.stringify(taskResults),
+    });
+
+  const created = await getCacheRefreshJobRow(env, input.uid);
+  if (!created) {
+    throw new Error("Created cache refresh job was not found");
+  }
+  return toCacheRefreshJob(created);
+}
+
+export async function getCacheRefreshJob(env: Pick<Env, "DB">, uid: string): Promise<CacheRefreshJob | null> {
+  const row = await getCacheRefreshJobRow(env, uid);
+  return row ? toCacheRefreshJob(row) : null;
+}
+
+export async function getActiveCacheRefreshJob(env: Pick<Env, "DB">): Promise<CacheRefreshJob | null> {
+  const [row] = await drizzle(env.DB)
+    .select()
+    .from(cacheRefreshJobsTable)
+    .where(eq(cacheRefreshJobsTable.activeSlot, 1))
+    .limit(1);
+  return row ? toCacheRefreshJob(row) : null;
+}
+
+export async function getLatestCacheRefreshJob(env: Pick<Env, "DB">): Promise<CacheRefreshJob | null> {
+  const [row] = await drizzle(env.DB)
+    .select()
+    .from(cacheRefreshJobsTable)
+    .orderBy(desc(cacheRefreshJobsTable.createdAt))
+    .limit(1);
+  return row ? toCacheRefreshJob(row) : null;
+}
+
+export async function markCacheRefreshJobRunning(env: Pick<Env, "DB">, uid: string): Promise<void> {
+  await drizzle(env.DB)
+    .update(cacheRefreshJobsTable)
+    .set({
+      status: "running",
+      startedAt: sql`coalesce(${cacheRefreshJobsTable.startedAt}, current_timestamp)`,
+      updatedAt: sql`current_timestamp`,
+    })
+    .where(eq(cacheRefreshJobsTable.uid, uid));
+}
+
+export async function markCacheRefreshTaskRunning(
+  env: Pick<Env, "DB">,
+  uid: string,
+  taskName: CacheRefreshTaskName,
+): Promise<void> {
+  await drizzle(env.DB)
+    .update(cacheRefreshJobsTable)
+    .set({ currentTask: taskName, updatedAt: sql`current_timestamp` })
+    .where(eq(cacheRefreshJobsTable.uid, uid));
+}
+
+export async function recordCacheRefreshTaskResult(
+  env: Pick<Env, "DB">,
+  uid: string,
+  taskName: CacheRefreshTaskName,
+  result: CacheRefreshTaskResult,
+): Promise<CacheRefreshTaskResults> {
+  const job = await getCacheRefreshJob(env, uid);
+  if (!job) {
+    throw new Error(`Cache refresh job not found: ${uid}`);
+  }
+
+  const taskResults = { ...job.taskResults, [taskName]: result };
+  await drizzle(env.DB)
+    .update(cacheRefreshJobsTable)
+    .set({
+      taskResults: JSON.stringify(taskResults),
+      completedCount: countCompletedCacheRefreshTasks(taskResults),
+      updatedAt: sql`current_timestamp`,
+    })
+    .where(eq(cacheRefreshJobsTable.uid, uid));
+  return taskResults;
+}
+
+export async function recordSkippedCacheRefreshTasks(
+  env: Pick<Env, "DB">,
+  uid: string,
+  taskNames: readonly CacheRefreshTaskName[],
+): Promise<CacheRefreshTaskResults> {
+  const job = await getCacheRefreshJob(env, uid);
+  if (!job) {
+    throw new Error(`Cache refresh job not found: ${uid}`);
+  }
+
+  const taskResults = { ...job.taskResults };
+  for (const taskName of taskNames) {
+    taskResults[taskName] = { status: "skipped", durationMs: null, error: null };
+  }
+
+  await drizzle(env.DB)
+    .update(cacheRefreshJobsTable)
+    .set({
+      taskResults: JSON.stringify(taskResults),
+      completedCount: countCompletedCacheRefreshTasks(taskResults),
+      updatedAt: sql`current_timestamp`,
+    })
+    .where(eq(cacheRefreshJobsTable.uid, uid));
+  return taskResults;
+}
+
+export async function completeCacheRefreshJob(
+  env: Pick<Env, "DB">,
+  uid: string,
+  status: Extract<CacheRefreshJobStatus, "completed" | "partial_failure">,
+  taskResults: CacheRefreshTaskResults,
+): Promise<void> {
+  await drizzle(env.DB)
+    .update(cacheRefreshJobsTable)
+    .set({
+      status,
+      activeSlot: null,
+      currentTask: null,
+      completedCount: countCompletedCacheRefreshTasks(taskResults),
+      taskResults: JSON.stringify(taskResults),
+      finishedAt: sql`current_timestamp`,
+      updatedAt: sql`current_timestamp`,
+    })
+    .where(eq(cacheRefreshJobsTable.uid, uid));
+}
+
+export async function failCacheRefreshJob(env: Pick<Env, "DB">, uid: string): Promise<void> {
+  await drizzle(env.DB)
+    .update(cacheRefreshJobsTable)
+    .set({
+      status: "failed",
+      activeSlot: null,
+      currentTask: null,
+      finishedAt: sql`current_timestamp`,
+      updatedAt: sql`current_timestamp`,
+    })
+    .where(eq(cacheRefreshJobsTable.uid, uid));
+}

--- a/app/models/cache-refresh-job.ts
+++ b/app/models/cache-refresh-job.ts
@@ -251,3 +251,25 @@ export async function failCacheRefreshJob(env: Pick<Env, "DB">, uid: string): Pr
     })
     .where(eq(cacheRefreshJobsTable.uid, uid));
 }
+
+export async function failStaleCacheRefreshJob(
+  env: Pick<Env, "DB">,
+  uid: string,
+  staleAfterHours: number,
+): Promise<boolean> {
+  const result = await env.DB.prepare(
+    `update cache_refresh_jobs
+       set status = 'failed',
+           activeSlot = null,
+           currentTask = null,
+           finishedAt = current_timestamp,
+           updatedAt = current_timestamp
+     where uid = ?1
+       and activeSlot = 1
+       and updatedAt <= datetime('now', ?2)`,
+  )
+    .bind(uid, `-${staleAfterHours} hours`)
+    .run();
+
+  return result.meta.changes > 0;
+}

--- a/app/routes/[__manage]._components/CacheRefreshPanel.tsx
+++ b/app/routes/[__manage]._components/CacheRefreshPanel.tsx
@@ -1,0 +1,207 @@
+import {
+  ArrowPathIcon,
+  CheckCircleIcon,
+  ClockIcon,
+  ExclamationTriangleIcon,
+  MinusCircleIcon,
+} from "@heroicons/react/24/outline";
+import { useEffect, useState } from "react";
+import { useFetcher } from "react-router";
+import { Button, Callout, Progress } from "~/components/primitives";
+import {
+  CACHE_REFRESH_TASK_LABELS,
+  CACHE_REFRESH_TASK_NAMES,
+  type CacheRefreshJob,
+  type CacheRefreshTaskName,
+  type CacheRefreshTaskResult,
+  isCacheRefreshJobActive,
+} from "~/domain/cache-refresh";
+import { formatInstant } from "~/lib/date-time";
+import type { action, loader } from "../[__manage]";
+
+function formatDuration(durationMs: number | null): string | null {
+  if (durationMs === null) {
+    return null;
+  }
+  if (durationMs < 1000) {
+    return `${durationMs}ms`;
+  }
+  return `${(durationMs / 1000).toFixed(1)}초`;
+}
+
+function formatDate(value: string): string {
+  return formatInstant(value, { timeZone: "Asia/Seoul", format: "YYYY. M. D. A h:mm:ss" });
+}
+
+function getTaskIcon(job: CacheRefreshJob, name: CacheRefreshTaskName, result: CacheRefreshTaskResult) {
+  if (result.status === "succeeded") {
+    return <CheckCircleIcon className="size-5 shrink-0 text-green-500" />;
+  }
+  if (result.status === "failed") {
+    return <ExclamationTriangleIcon className="size-5 shrink-0 text-destructive" />;
+  }
+  if (result.status === "skipped") {
+    return <MinusCircleIcon className="size-5 shrink-0 text-muted-foreground" />;
+  }
+  if (job.currentTask === name) {
+    return <ArrowPathIcon className="size-5 shrink-0 animate-spin text-primary" />;
+  }
+  return <ClockIcon className="size-5 shrink-0 text-muted-foreground/60" />;
+}
+
+function getStatusText(job: CacheRefreshJob): string {
+  switch (job.status) {
+    case "queued":
+      return "실행 대기 중";
+    case "running":
+      return "캐시를 갱신하고 있어요.";
+    case "completed":
+      return "모든 캐시 갱신을 완료했어요.";
+    case "partial_failure":
+      return "일부 캐시를 갱신하지 못했어요.";
+    case "failed":
+      return "캐시 갱신 작업을 완료하지 못했어요.";
+  }
+}
+
+function JobResultCallout({ job }: { job: CacheRefreshJob }) {
+  if (job.status === "completed") {
+    return (
+      <Callout
+        Icon={CheckCircleIcon}
+        tone="success"
+        title="Cache refresh 완료"
+        description={job.finishedAt ? `${formatDate(job.finishedAt)}에 완료했습니다.` : "모든 작업을 완료했습니다."}
+      />
+    );
+  }
+  if (job.status === "partial_failure" || job.status === "failed") {
+    return (
+      <Callout
+        Icon={ExclamationTriangleIcon}
+        tone={job.status === "failed" ? "destructive" : "warning"}
+        title={job.status === "failed" ? "Cache refresh 실패" : "Cache refresh 일부 실패"}
+        description={`상세 로그를 확인할 때 job ID ${job.uid}를 사용해주세요.`}
+      />
+    );
+  }
+  return null;
+}
+
+export function CacheRefreshPanel({
+  initialJob,
+  initialError,
+}: {
+  initialJob: CacheRefreshJob | null;
+  initialError: string | null;
+}) {
+  const startFetcher = useFetcher<typeof action>();
+  const statusFetcher = useFetcher<typeof loader>();
+  const actionJob =
+    startFetcher.data?.intent === "cache.refresh" && "job" in startFetcher.data ? startFetcher.data.job : null;
+  const [trackedJobUid, setTrackedJobUid] = useState(initialJob?.uid ?? null);
+  const desiredJobUid = actionJob?.uid ?? trackedJobUid;
+  const polledJob = statusFetcher.data?.job?.uid === desiredJobUid ? statusFetcher.data.job : null;
+  const job = polledJob ?? actionJob ?? (initialJob?.uid === desiredJobUid ? initialJob : null);
+  const isActive = job ? isCacheRefreshJobActive(job.status) : false;
+  const isStarting = startFetcher.state !== "idle";
+  const actionError = startFetcher.data && "error" in startFetcher.data ? startFetcher.data.error : null;
+  const statusError = statusFetcher.data ? statusFetcher.data.error : initialError;
+
+  useEffect(() => {
+    if (actionJob) {
+      setTrackedJobUid(actionJob.uid);
+    }
+  }, [actionJob]);
+
+  useEffect(() => {
+    if (!job || !isActive || statusFetcher.state !== "idle") {
+      return;
+    }
+
+    const delayMs = document.visibilityState === "hidden" ? 8000 : 2000;
+    const timer = window.setTimeout(() => {
+      statusFetcher.load(`/__manage?jobId=${encodeURIComponent(job.uid)}`);
+    }, delayMs);
+    return () => window.clearTimeout(timer);
+  }, [isActive, job, statusFetcher.load, statusFetcher.state]);
+
+  const ratio = job && job.totalCount > 0 ? job.completedCount / job.totalCount : 0;
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-lg bg-card p-5 shadow-lg shadow-black/5 dark:shadow-md dark:shadow-black/20 md:p-6">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h2 className="text-base font-semibold">Cache refresh</h2>
+            <p className="mt-1 text-sm text-muted-foreground">BAQL 기반 캐시를 background job으로 다시 생성합니다.</p>
+          </div>
+          <startFetcher.Form method="post">
+            <Button
+              type="submit"
+              name="intent"
+              value="cache.refresh"
+              variant="primary"
+              icon={ArrowPathIcon}
+              text={isStarting ? "Starting..." : isActive ? "Refresh in progress" : "Refresh cache"}
+              disabled={isStarting || isActive}
+            />
+          </startFetcher.Form>
+        </div>
+      </section>
+
+      {(actionError || statusError) && (
+        <Callout
+          Icon={ExclamationTriangleIcon}
+          tone="destructive"
+          title="진행 상태를 불러오지 못했어요."
+          description={actionError ?? statusError ?? undefined}
+        />
+      )}
+
+      {job && (
+        <section className="rounded-lg bg-card p-5 shadow-lg shadow-black/5 dark:shadow-md dark:shadow-black/20 md:p-6">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <h2 className="text-base font-semibold">{getStatusText(job)}</h2>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {formatDate(job.startedAt ?? job.createdAt)} · job ID {job.uid}
+              </p>
+            </div>
+            <span className="rounded-full bg-muted px-3 py-1 text-xs font-medium text-muted-foreground">
+              {job.completedCount} / {job.totalCount}
+            </span>
+          </div>
+
+          <div className="mt-4">
+            <Progress
+              ratio={ratio}
+              color={job.status === "failed" || job.status === "partial_failure" ? "orange" : "blue"}
+            />
+          </div>
+
+          <div className="mt-5 divide-y divide-border rounded-md border border-border">
+            {CACHE_REFRESH_TASK_NAMES.map((name) => {
+              const result = job.taskResults[name];
+              return (
+                <div key={name} className="flex items-center justify-between gap-3 px-3 py-3 text-sm">
+                  <div className="flex min-w-0 items-center gap-3">
+                    {getTaskIcon(job, name, result)}
+                    <span className={result.status === "skipped" ? "truncate text-muted-foreground" : "truncate"}>
+                      {CACHE_REFRESH_TASK_LABELS[name]}
+                    </span>
+                  </div>
+                  <span className="shrink-0 text-xs text-muted-foreground">
+                    {formatDuration(result.durationMs) ?? (result.status === "skipped" ? "건너뜀" : "")}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </section>
+      )}
+
+      {job && <JobResultCallout job={job} />}
+    </div>
+  );
+}

--- a/app/routes/[__manage].tsx
+++ b/app/routes/[__manage].tsx
@@ -1,130 +1,12 @@
-import { ArrowPathIcon, CheckCircleIcon, ExclamationTriangleIcon } from "@heroicons/react/24/outline";
 import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from "react-router";
-import { data, Form, redirect, useActionData, useNavigation } from "react-router";
-import { getActiveSensei } from "~/auth/authenticator.server";
-import { Button, Callout, Title } from "~/components/primitives";
-import { mapWithConcurrencyLimit } from "~/lib/concurrency";
-import { syncEventContentsList } from "~/models/event-content";
-import { getStudentGearData } from "~/models/growth-resource";
-import { getItemCatalogResources } from "~/models/item-catalog";
-import { getMainStories } from "~/models/main-story";
-import { warmRaidCache } from "~/models/raid";
-import { warmRecruitmentCache } from "~/models/recruitment";
-import { getAllStudentsFavoriteItems } from "~/models/resource";
-import type { Sensei } from "~/models/sensei";
-import { getCampaignFarmingStages } from "~/models/stage";
-import { getAllStudents, getStudentSkillItemsBatch, syncRawStudents } from "~/models/student";
-import { syncAllTimelineContentsMeta } from "~/models/timeline-content.server";
-import { syncYoutubeCommunityPosts } from "~/models/youtube";
-import { getEventList, warmActiveUpcomingEventContent } from "~/views/events";
-import { getFutureContents } from "~/views/futures";
-import { getIndexContents } from "~/views/home";
-import { getNavigationBarContentsRaw } from "~/views/navigation";
+import { data, useLoaderData } from "react-router";
+import { Title } from "~/components/primitives";
+import { getCacheRefreshStatus, startCacheRefresh } from "~/jobs/cache-refresh-control.server";
+import { getLogger } from "~/lib/observability.server";
+import { requireAdmin } from "~/lib/require-admin.server";
+import { CacheRefreshPanel } from "./[__manage]._components/CacheRefreshPanel";
 
-type RefreshTaskName =
-  | "syncYoutubeCommunityPosts"
-  | "syncRawStudents"
-  | "warmRecruitmentCache"
-  | "warmRaidCache"
-  | "getMainStories"
-  | "getAllStudentsFavoriteItems"
-  | "syncAllTimelineContentsMeta"
-  | "syncEventContentsList"
-  | "warmStudentSkillItems"
-  | "warmStudentGearData"
-  | "warmActiveUpcomingEventContent"
-  | "getItemCatalogResources"
-  | "getCampaignFarmingStages"
-  | "getEventList"
-  | "getIndexContents"
-  | "getFutureContents"
-  | "getNavigationBarContentsRaw";
-
-type RefreshTaskResult = {
-  name: RefreshTaskName;
-  duration: number;
-  error: unknown | null;
-};
-
-type RefreshResult = {
-  ok: boolean;
-  ranAt: string;
-  durations: Partial<Record<RefreshTaskName, number>>;
-  errors?: Partial<Record<RefreshTaskName, string>>;
-};
-
-type ManageActionData = { intent: "cache.refresh"; result: RefreshResult } | { intent: "unknown"; error: string };
-
-const SOURCE_REFRESH_CONCURRENCY = 1;
-
-async function requireAdmin(env: Env, request: Request, ctx: ExecutionContext): Promise<Sensei | Response> {
-  const currentUser = await getActiveSensei(env, request, ctx);
-  if (!currentUser) {
-    return redirect("/unauthorized");
-  }
-  if (currentUser.role !== "admin") {
-    return new Response(null, { status: 403 });
-  }
-  return currentUser;
-}
-
-async function runRefreshTask(name: RefreshTaskName, fn: () => Promise<unknown>): Promise<RefreshTaskResult> {
-  const startedAt = Date.now();
-  try {
-    await fn();
-    return { name, duration: Date.now() - startedAt, error: null };
-  } catch (error) {
-    return { name, duration: Date.now() - startedAt, error };
-  }
-}
-
-async function refreshCache(env: Env, ctx: ExecutionContext): Promise<RefreshResult> {
-  const getStudentUids = () => getAllStudents(env, true).then((students) => students.map((student) => student.uid));
-  const sourceTasks: Array<[RefreshTaskName, () => Promise<unknown>]> = [
-    ["syncYoutubeCommunityPosts", () => syncYoutubeCommunityPosts(env)],
-    ["syncRawStudents", () => syncRawStudents(env)],
-    ["warmRecruitmentCache", () => warmRecruitmentCache(env)],
-    ["warmRaidCache", () => warmRaidCache(env)],
-    ["getMainStories", () => getMainStories(env, true)],
-    ["getAllStudentsFavoriteItems", () => getAllStudentsFavoriteItems(env, true)],
-    ["syncAllTimelineContentsMeta", () => syncAllTimelineContentsMeta(env, true, { ctx })],
-    ["syncEventContentsList", () => syncEventContentsList(env)],
-    ["warmStudentSkillItems", async () => getStudentSkillItemsBatch(env, await getStudentUids(), true)],
-    ["warmStudentGearData", async () => getStudentGearData(env, await getStudentUids(), true)],
-    ["warmActiveUpcomingEventContent", () => warmActiveUpcomingEventContent(env, true, ctx)],
-    ["getItemCatalogResources", () => getItemCatalogResources(env, true)],
-    ["getCampaignFarmingStages", () => getCampaignFarmingStages(env, true)],
-  ];
-  const routeTasks: Array<[RefreshTaskName, () => Promise<unknown>]> = [
-    ["getEventList", () => getEventList(env, undefined, true, ctx)],
-    ["getIndexContents", () => getIndexContents(env, true, ctx)],
-    ["getFutureContents", () => getFutureContents(env, true, ctx)],
-    ["getNavigationBarContentsRaw", () => getNavigationBarContentsRaw(env, true, ctx)],
-  ];
-
-  const sourceResults = await mapWithConcurrencyLimit(sourceTasks, SOURCE_REFRESH_CONCURRENCY, ([name, fn]) =>
-    runRefreshTask(name, fn),
-  );
-  const routeResults = sourceResults.some((result) => result.error)
-    ? []
-    : await Promise.all(routeTasks.map(([name, fn]) => runRefreshTask(name, fn)));
-  const results = [...sourceResults, ...routeResults];
-  const durations: Partial<Record<RefreshTaskName, number>> = {};
-  const errors: Partial<Record<RefreshTaskName, string>> = {};
-  for (const result of results) {
-    durations[result.name] = result.duration;
-    if (result.error) {
-      errors[result.name] = result.error instanceof Error ? result.error.message : String(result.error);
-    }
-  }
-
-  return {
-    ok: Object.keys(errors).length === 0,
-    ranAt: new Date().toISOString(),
-    durations,
-    ...(Object.keys(errors).length > 0 ? { errors } : {}),
-  };
-}
+const SAFE_STATUS_ERROR = "잠시 후 다시 시도해주세요. 문제가 계속되면 서버 로그를 확인해주세요.";
 
 export async function loader({ request, context }: LoaderFunctionArgs) {
   const { env, ctx } = context.cloudflare;
@@ -133,7 +15,16 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
     return guard;
   }
 
-  return data({});
+  const jobUid = new URL(request.url).searchParams.get("jobId");
+  try {
+    return data({ job: await getCacheRefreshStatus(env, ctx, jobUid), error: null });
+  } catch (error) {
+    getLogger(env, ctx, { route: "/__manage", operation: "cache-refresh-status", jobUid }).error(
+      "Failed to load cache refresh status",
+      error,
+    );
+    return data({ job: null, error: SAFE_STATUS_ERROR }, { status: 503 });
+  }
 }
 
 export async function action({ request, context }: ActionFunctionArgs) {
@@ -145,87 +36,31 @@ export async function action({ request, context }: ActionFunctionArgs) {
 
   const formData = await request.formData();
   const intent = String(formData.get("intent") ?? "");
-  if (intent === "cache.refresh") {
-    return data<ManageActionData>({ intent, result: await refreshCache(env, ctx) });
+  if (intent !== "cache.refresh") {
+    return data({ intent: "unknown" as const, error: `Unsupported intent: ${intent}` }, { status: 400 });
   }
-  return data<ManageActionData>({ intent: "unknown", error: `Unsupported intent: ${intent}` }, { status: 400 });
+
+  try {
+    const result = await startCacheRefresh(env, ctx, guard.id);
+    return data({ intent, ...result }, { status: result.created ? 202 : 200 });
+  } catch (error) {
+    getLogger(env, ctx, { route: "/__manage", operation: "cache-refresh-start", requestedBy: guard.id }).error(
+      "Failed to start cache refresh",
+      error,
+    );
+    return data({ intent, error: SAFE_STATUS_ERROR }, { status: 503 });
+  }
 }
 
 export const meta: MetaFunction = () => [{ title: "관리 | 몰루로그" }, { name: "robots", content: "noindex,nofollow" }];
 
 export default function ManagePage() {
-  const actionData = useActionData<typeof action>();
-  const navigation = useNavigation();
-  const submittingIntent = navigation.formData?.get("intent");
-  const isRefreshing = navigation.state === "submitting" && submittingIntent === "cache.refresh";
+  const loaderData = useLoaderData<typeof loader>();
 
   return (
     <div className="max-w-3xl">
       <Title text="관리" description="캐시 및 데이터 이관 작업" />
-
-      <div className="space-y-6">
-        <section className="rounded-lg border border-border bg-card p-5 md:p-6">
-          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-            <div>
-              <h2 className="text-base font-semibold">Cache refresh</h2>
-              <p className="mt-1 text-sm text-muted-foreground">BAQL 기반 캐시를 다시 생성합니다.</p>
-            </div>
-            <Form method="post">
-              <Button
-                type="submit"
-                name="intent"
-                value="cache.refresh"
-                variant="primary"
-                icon={ArrowPathIcon}
-                text={isRefreshing ? "Refreshing..." : "Refresh cache"}
-                disabled={isRefreshing}
-              />
-            </Form>
-          </div>
-        </section>
-
-        {actionData && <ActionResult data={actionData} />}
-      </div>
+      <CacheRefreshPanel initialJob={loaderData.job} initialError={loaderData.error} />
     </div>
-  );
-}
-
-function ActionResult({ data }: { data: ManageActionData }) {
-  if (data.intent === "unknown") {
-    return (
-      <Callout
-        Icon={ExclamationTriangleIcon}
-        tone="destructive"
-        title="요청을 처리하지 못했어요."
-        description={data.error}
-      />
-    );
-  }
-
-  return (
-    <Callout
-      Icon={data.result.ok ? CheckCircleIcon : ExclamationTriangleIcon}
-      tone={data.result.ok ? "success" : "warning"}
-      title={data.result.ok ? "Cache refresh 완료" : "Cache refresh 일부 실패"}
-      description={`Ran at ${data.result.ranAt}`}
-    >
-      <dl className="mt-3 grid gap-2 text-xs text-muted-foreground md:grid-cols-2">
-        {Object.entries(data.result.durations).map(([name, duration]) => (
-          <div key={name} className="flex items-center justify-between gap-3 rounded-md bg-background/60 px-3 py-2">
-            <dt className="truncate font-medium">{name}</dt>
-            <dd>{duration}ms</dd>
-          </div>
-        ))}
-      </dl>
-      {data.result.errors && (
-        <div className="mt-3 space-y-2 text-xs">
-          {Object.entries(data.result.errors).map(([name, message]) => (
-            <p key={name} className="rounded-md bg-background/60 px-3 py-2 text-destructive">
-              {name}: {message}
-            </p>
-          ))}
-        </div>
-      )}
-    </Callout>
   );
 }

--- a/db/migrations/20260723000100_create_cache_refresh_jobs.sql
+++ b/db/migrations/20260723000100_create_cache_refresh_jobs.sql
@@ -1,0 +1,20 @@
+create table cache_refresh_jobs (
+  uid text primary key not null,
+  requestedBy integer not null,
+  status text not null,
+  activeSlot integer,
+  currentTask text,
+  completedCount integer not null default 0,
+  totalCount integer not null,
+  taskResults text not null,
+  startedAt text,
+  finishedAt text,
+  createdAt text not null default current_timestamp,
+  updatedAt text not null default current_timestamp
+);
+
+create unique index cache_refresh_jobs_active_slot
+  on cache_refresh_jobs (activeSlot);
+
+create index cache_refresh_jobs_created_at
+  on cache_refresh_jobs (createdAt desc);

--- a/env.d.ts
+++ b/env.d.ts
@@ -3,6 +3,7 @@ interface Env {
   KV_SESSION: KVNamespace;
   DB: D1Database;
   HYPERDRIVE: Hyperdrive;
+  CACHE_REFRESH_WORKFLOW: Workflow<{ requestedBy: number }>;
   EVENTS?: Queue;
   HOST: string;
   CONNECT_API_URL?: string;

--- a/test/app/domain/cache-refresh.test.ts
+++ b/test/app/domain/cache-refresh.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  CACHE_REFRESH_TASK_NAMES,
+  countCompletedCacheRefreshTasks,
+  createPendingCacheRefreshTaskResults,
+} from "~/domain/cache-refresh";
+
+describe("cache refresh domain", () => {
+  it("creates a pending result for every refresh task", () => {
+    const results = createPendingCacheRefreshTaskResults();
+
+    expect(Object.keys(results)).toEqual(CACHE_REFRESH_TASK_NAMES);
+    expect(countCompletedCacheRefreshTasks(results)).toBe(0);
+  });
+
+  it("counts succeeded, failed, and skipped tasks as completed", () => {
+    const results = createPendingCacheRefreshTaskResults();
+    results.syncYoutubeCommunityPosts = { status: "succeeded", durationMs: 10, error: null };
+    results.syncRawStudents = { status: "failed", durationMs: 20, error: "failed" };
+    results.warmRecruitmentCache = { status: "skipped", durationMs: null, error: null };
+
+    expect(countCompletedCacheRefreshTasks(results)).toBe(3);
+  });
+});

--- a/test/app/jobs/cache-refresh-control.test.ts
+++ b/test/app/jobs/cache-refresh-control.test.ts
@@ -1,0 +1,215 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import {
+  CACHE_REFRESH_TASK_NAMES,
+  type CacheRefreshJob,
+  type CacheRefreshWorkflowOutput,
+  createPendingCacheRefreshTaskResults,
+} from "~/domain/cache-refresh";
+import {
+  completeCacheRefreshJob,
+  createCacheRefreshJob,
+  failCacheRefreshJob,
+  failStaleCacheRefreshJob,
+  getActiveCacheRefreshJob,
+  getCacheRefreshJob,
+  getLatestCacheRefreshJob,
+} from "~/models/cache-refresh-job";
+
+jest.mock("~/lib/observability.server", () => ({
+  getLogger: jest.fn(() => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  })),
+}));
+
+jest.mock("~/models/cache-refresh-job", () => ({
+  completeCacheRefreshJob: jest.fn(),
+  createCacheRefreshJob: jest.fn(),
+  failCacheRefreshJob: jest.fn(),
+  failStaleCacheRefreshJob: jest.fn(),
+  getActiveCacheRefreshJob: jest.fn(),
+  getCacheRefreshJob: jest.fn(),
+  getLatestCacheRefreshJob: jest.fn(),
+}));
+
+import { getCacheRefreshStatus, startCacheRefresh } from "~/jobs/cache-refresh-control.server";
+
+const mockedCompleteCacheRefreshJob = completeCacheRefreshJob as jest.MockedFunction<typeof completeCacheRefreshJob>;
+const mockedCreateCacheRefreshJob = createCacheRefreshJob as jest.MockedFunction<typeof createCacheRefreshJob>;
+const mockedFailCacheRefreshJob = failCacheRefreshJob as jest.MockedFunction<typeof failCacheRefreshJob>;
+const mockedFailStaleCacheRefreshJob = failStaleCacheRefreshJob as jest.MockedFunction<typeof failStaleCacheRefreshJob>;
+const mockedGetActiveCacheRefreshJob = getActiveCacheRefreshJob as jest.MockedFunction<typeof getActiveCacheRefreshJob>;
+const mockedGetCacheRefreshJob = getCacheRefreshJob as jest.MockedFunction<typeof getCacheRefreshJob>;
+const mockedGetLatestCacheRefreshJob = getLatestCacheRefreshJob as jest.MockedFunction<typeof getLatestCacheRefreshJob>;
+
+function makeJob(status: CacheRefreshJob["status"], uid = "job-uid"): CacheRefreshJob {
+  return {
+    uid,
+    requestedBy: 1,
+    status,
+    currentTask: null,
+    completedCount: 0,
+    totalCount: CACHE_REFRESH_TASK_NAMES.length,
+    taskResults: createPendingCacheRefreshTaskResults(),
+    startedAt: status === "queued" ? null : "2026-07-23 00:00:00",
+    finishedAt:
+      status === "completed" || status === "partial_failure" || status === "failed" ? "2026-07-23 01:00:00" : null,
+    createdAt: "2026-07-23 00:00:00",
+    updatedAt: "2026-07-23 00:30:00",
+  };
+}
+
+function createEnv(workflowStatus: unknown = { status: "running" }) {
+  const status = jest.fn(async () => workflowStatus);
+  const get = jest.fn(async (_uid: string) => ({ status }));
+  const create = jest.fn(async (_options: unknown) => undefined);
+  const env = { CACHE_REFRESH_WORKFLOW: { create, get } } as unknown as Env;
+  return { env, create, get, status };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedGetActiveCacheRefreshJob.mockResolvedValue(null);
+  mockedGetCacheRefreshJob.mockResolvedValue(null);
+  mockedGetLatestCacheRefreshJob.mockResolvedValue(null);
+  mockedCreateCacheRefreshJob.mockImplementation(async (_env, input) => makeJob("queued", input.uid));
+  mockedCompleteCacheRefreshJob.mockResolvedValue();
+  mockedFailCacheRefreshJob.mockResolvedValue();
+  mockedFailStaleCacheRefreshJob.mockResolvedValue(false);
+});
+
+describe("cache refresh control", () => {
+  it("creates a D1 job and starts a workflow instance", async () => {
+    const { env, create } = createEnv();
+
+    const result = await startCacheRefresh(env, {} as ExecutionContext, 7);
+
+    expect(result.created).toBe(true);
+    expect(mockedCreateCacheRefreshJob).toHaveBeenCalledWith(expect.anything(), {
+      uid: result.job.uid,
+      requestedBy: 7,
+    });
+    expect(create).toHaveBeenCalledWith({
+      id: result.job.uid,
+      params: { requestedBy: 7 },
+      retention: { successRetention: "7 days", errorRetention: "7 days" },
+    });
+  });
+
+  it("returns an existing running job instead of starting a duplicate", async () => {
+    const active = makeJob("running");
+    mockedGetActiveCacheRefreshJob.mockResolvedValue(active);
+    mockedGetCacheRefreshJob.mockResolvedValue(active);
+    const { env, create } = createEnv();
+
+    await expect(startCacheRefresh(env, {} as ExecutionContext, 7)).resolves.toEqual({
+      job: active,
+      created: false,
+    });
+    expect(create).not.toHaveBeenCalled();
+    expect(mockedCreateCacheRefreshJob).not.toHaveBeenCalled();
+  });
+
+  it("persists a completed workflow output during reconciliation", async () => {
+    const active = makeJob("running");
+    const completed = makeJob("completed");
+    const output: CacheRefreshWorkflowOutput = {
+      status: "completed",
+      taskResults: createPendingCacheRefreshTaskResults(),
+    };
+    mockedGetCacheRefreshJob.mockResolvedValueOnce(active).mockResolvedValueOnce(completed);
+    const { env } = createEnv({ status: "complete", output });
+
+    await expect(getCacheRefreshStatus(env, {} as ExecutionContext, active.uid)).resolves.toEqual(completed);
+    expect(mockedCompleteCacheRefreshJob).toHaveBeenCalledWith(
+      expect.anything(),
+      active.uid,
+      output.status,
+      output.taskResults,
+    );
+  });
+
+  it.each(["errored", "terminated"] as const)("fails a job when its workflow is %s", async (status) => {
+    const active = makeJob("running");
+    const failed = makeJob("failed");
+    mockedGetCacheRefreshJob.mockResolvedValueOnce(active).mockResolvedValueOnce(failed);
+    const { env } = createEnv({ status, error: { name: "Error", message: "stopped" } });
+
+    await expect(getCacheRefreshStatus(env, {} as ExecutionContext, active.uid)).resolves.toEqual(failed);
+    expect(mockedFailCacheRefreshJob).toHaveBeenCalledWith(expect.anything(), active.uid);
+  });
+
+  it("fails a completed workflow with an invalid output", async () => {
+    const active = makeJob("running");
+    const failed = makeJob("failed");
+    mockedGetCacheRefreshJob.mockResolvedValueOnce(active).mockResolvedValueOnce(failed);
+    const { env } = createEnv({ status: "complete", output: null });
+
+    await expect(getCacheRefreshStatus(env, {} as ExecutionContext, active.uid)).resolves.toEqual(failed);
+    expect(mockedFailCacheRefreshJob).toHaveBeenCalledWith(expect.anything(), active.uid);
+  });
+
+  it("keeps a recent job active when workflow status is temporarily unavailable", async () => {
+    const active = makeJob("running");
+    mockedGetActiveCacheRefreshJob.mockResolvedValue(active);
+    const { env, get, create } = createEnv();
+    get.mockRejectedValue(new Error("workflow API unavailable"));
+
+    await expect(startCacheRefresh(env, {} as ExecutionContext, 7)).resolves.toEqual({
+      job: active,
+      created: false,
+    });
+    expect(mockedFailStaleCacheRefreshJob).toHaveBeenCalledWith(expect.anything(), active.uid, 24);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("applies stale recovery when workflow status is unknown", async () => {
+    const active = makeJob("running");
+    mockedGetCacheRefreshJob.mockResolvedValue(active);
+    const { env } = createEnv({ status: "unknown" });
+
+    await expect(getCacheRefreshStatus(env, {} as ExecutionContext, active.uid)).resolves.toEqual(active);
+    expect(mockedFailStaleCacheRefreshJob).toHaveBeenCalledWith(expect.anything(), active.uid, 24);
+  });
+
+  it("releases a stale job when workflow status remains unavailable", async () => {
+    const active = makeJob("running", "stale-job");
+    const failed = makeJob("failed", active.uid);
+    mockedGetActiveCacheRefreshJob.mockResolvedValue(active);
+    mockedFailStaleCacheRefreshJob.mockResolvedValue(true);
+    mockedGetCacheRefreshJob.mockResolvedValue(failed);
+    const { env, get, create } = createEnv();
+    get.mockRejectedValue(new Error("workflow instance not found"));
+
+    const result = await startCacheRefresh(env, {} as ExecutionContext, 7);
+
+    expect(mockedFailStaleCacheRefreshJob).toHaveBeenCalledWith(expect.anything(), active.uid, 24);
+    expect(result.created).toBe(true);
+    expect(result.job.uid).not.toBe(active.uid);
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns the raced active job after a unique constraint conflict", async () => {
+    const raced = makeJob("queued", "raced-job");
+    mockedGetActiveCacheRefreshJob.mockResolvedValueOnce(null).mockResolvedValueOnce(raced);
+    mockedCreateCacheRefreshJob.mockRejectedValue(new Error("UNIQUE constraint failed: cache_refresh_jobs.activeSlot"));
+    const { env, create } = createEnv();
+
+    await expect(startCacheRefresh(env, {} as ExecutionContext, 7)).resolves.toEqual({
+      job: raced,
+      created: false,
+    });
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("fails the D1 job when workflow creation fails", async () => {
+    const { env, create } = createEnv();
+    create.mockRejectedValue(new Error("workflow create failed"));
+
+    await expect(startCacheRefresh(env, {} as ExecutionContext, 7)).rejects.toThrow("workflow create failed");
+    const createdUid = mockedCreateCacheRefreshJob.mock.calls[0][1].uid;
+    expect(mockedFailCacheRefreshJob).toHaveBeenCalledWith(expect.anything(), createdUid);
+  });
+});

--- a/test/app/jobs/cache-refresh-workflow.test.ts
+++ b/test/app/jobs/cache-refresh-workflow.test.ts
@@ -1,0 +1,120 @@
+import type { WorkflowEvent, WorkflowStep } from "cloudflare:workers";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import {
+  CACHE_REFRESH_TASK_NAMES,
+  createPendingCacheRefreshTaskResults,
+  ROUTE_CACHE_REFRESH_TASK_NAMES,
+  SOURCE_CACHE_REFRESH_TASK_NAMES,
+} from "~/domain/cache-refresh";
+import { runCacheRefreshTask } from "~/jobs/cache-refresh";
+import {
+  completeCacheRefreshJob,
+  markCacheRefreshJobRunning,
+  markCacheRefreshTaskRunning,
+  recordCacheRefreshTaskResult,
+  recordSkippedCacheRefreshTasks,
+} from "~/models/cache-refresh-job";
+
+jest.mock("~/jobs/cache-refresh", () => ({
+  runCacheRefreshTask: jest.fn(),
+}));
+
+jest.mock("~/models/cache-refresh-job", () => ({
+  completeCacheRefreshJob: jest.fn(),
+  markCacheRefreshJobRunning: jest.fn(),
+  markCacheRefreshTaskRunning: jest.fn(),
+  recordCacheRefreshTaskResult: jest.fn(),
+  recordSkippedCacheRefreshTasks: jest.fn(),
+}));
+
+import { runCacheRefreshWorkflow } from "~/jobs/cache-refresh-workflow.server";
+
+const mockedRunCacheRefreshTask = runCacheRefreshTask as jest.MockedFunction<typeof runCacheRefreshTask>;
+const mockedCompleteCacheRefreshJob = completeCacheRefreshJob as jest.MockedFunction<typeof completeCacheRefreshJob>;
+const mockedMarkCacheRefreshJobRunning = markCacheRefreshJobRunning as jest.MockedFunction<
+  typeof markCacheRefreshJobRunning
+>;
+const mockedMarkCacheRefreshTaskRunning = markCacheRefreshTaskRunning as jest.MockedFunction<
+  typeof markCacheRefreshTaskRunning
+>;
+const mockedRecordCacheRefreshTaskResult = recordCacheRefreshTaskResult as jest.MockedFunction<
+  typeof recordCacheRefreshTaskResult
+>;
+const mockedRecordSkippedCacheRefreshTasks = recordSkippedCacheRefreshTasks as jest.MockedFunction<
+  typeof recordSkippedCacheRefreshTasks
+>;
+
+function createStep(): WorkflowStep {
+  return {
+    do: jest.fn(async (...args: unknown[]) => {
+      const callback = (typeof args[1] === "function" ? args[1] : args[2]) as () => Promise<unknown>;
+      return callback();
+    }),
+  } as unknown as WorkflowStep;
+}
+
+function createEvent(): WorkflowEvent<{ requestedBy: number }> {
+  return {
+    payload: { requestedBy: 1 },
+    timestamp: new Date("2026-07-23T00:00:00Z"),
+    instanceId: "job-uid",
+    workflowName: "cache-refresh",
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedRunCacheRefreshTask.mockResolvedValue({ status: "succeeded", durationMs: 10, error: null });
+  mockedMarkCacheRefreshJobRunning.mockResolvedValue();
+  mockedMarkCacheRefreshTaskRunning.mockResolvedValue();
+  mockedRecordCacheRefreshTaskResult.mockResolvedValue(createPendingCacheRefreshTaskResults());
+  mockedRecordSkippedCacheRefreshTasks.mockResolvedValue(createPendingCacheRefreshTaskResults());
+  mockedCompleteCacheRefreshJob.mockResolvedValue();
+});
+
+describe("cache refresh workflow", () => {
+  it("runs all source and route cache tasks and records completion", async () => {
+    const output = await runCacheRefreshWorkflow({} as Env, {} as ExecutionContext, createEvent(), createStep());
+
+    expect(mockedRunCacheRefreshTask.mock.calls.map((call) => call[3])).toEqual(CACHE_REFRESH_TASK_NAMES);
+    expect(mockedMarkCacheRefreshTaskRunning).toHaveBeenCalledTimes(CACHE_REFRESH_TASK_NAMES.length);
+    expect(mockedRecordCacheRefreshTaskResult).toHaveBeenCalledTimes(CACHE_REFRESH_TASK_NAMES.length);
+    expect(mockedCompleteCacheRefreshJob).toHaveBeenCalledWith(
+      expect.anything(),
+      "job-uid",
+      "completed",
+      expect.anything(),
+    );
+    expect(output.status).toBe("completed");
+  });
+
+  it("finishes source tasks, skips route tasks, and reports partial failure", async () => {
+    mockedRunCacheRefreshTask.mockImplementation(async (_env, _ctx, _jobUid, taskName) =>
+      taskName === "warmRaidCache"
+        ? { status: "failed", durationMs: 20, error: "safe error" }
+        : { status: "succeeded", durationMs: 10, error: null },
+    );
+
+    const output = await runCacheRefreshWorkflow({} as Env, {} as ExecutionContext, createEvent(), createStep());
+
+    expect(mockedRunCacheRefreshTask.mock.calls.map((call) => call[3])).toEqual(SOURCE_CACHE_REFRESH_TASK_NAMES);
+    expect(mockedRecordSkippedCacheRefreshTasks).toHaveBeenCalledWith(
+      expect.anything(),
+      "job-uid",
+      ROUTE_CACHE_REFRESH_TASK_NAMES,
+    );
+    for (const taskName of ROUTE_CACHE_REFRESH_TASK_NAMES) {
+      expect(output.taskResults[taskName].status).toBe("skipped");
+    }
+    expect(output.status).toBe("partial_failure");
+  });
+
+  it("continues cache work when a D1 progress update fails", async () => {
+    mockedMarkCacheRefreshTaskRunning.mockRejectedValue(new Error("D1 unavailable"));
+
+    const output = await runCacheRefreshWorkflow({} as Env, {} as ExecutionContext, createEvent(), createStep());
+
+    expect(mockedRunCacheRefreshTask).toHaveBeenCalledTimes(CACHE_REFRESH_TASK_NAMES.length);
+    expect(output.status).toBe("completed");
+  });
+});

--- a/test/app/models/cache-refresh-job.test.ts
+++ b/test/app/models/cache-refresh-job.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "@jest/globals";
+import { describe, expect, it, jest } from "@jest/globals";
 import { CACHE_REFRESH_TASK_NAMES, createPendingCacheRefreshTaskResults } from "~/domain/cache-refresh";
-import { parseCacheRefreshTaskResults } from "~/models/cache-refresh-job";
+import { failStaleCacheRefreshJob, parseCacheRefreshTaskResults } from "~/models/cache-refresh-job";
 
 describe("cache refresh job model", () => {
   it("parses a complete task result payload", () => {
@@ -15,5 +15,15 @@ describe("cache refresh job model", () => {
     delete results[CACHE_REFRESH_TASK_NAMES[0]];
 
     expect(() => parseCacheRefreshTaskResults(JSON.stringify(results))).toThrow("Invalid cache refresh task result");
+  });
+
+  it("releases only jobs older than the stale threshold", async () => {
+    const run = jest.fn(async () => ({ meta: { changes: 1 } }));
+    const bind = jest.fn((_uid: string, _staleAge: string) => ({ run }));
+    const prepare = jest.fn((_query: string) => ({ bind }));
+    const env = { DB: { prepare } } as unknown as Pick<Env, "DB">;
+
+    await expect(failStaleCacheRefreshJob(env, "job-uid", 24)).resolves.toBe(true);
+    expect(bind).toHaveBeenCalledWith("job-uid", "-24 hours");
   });
 });

--- a/test/app/models/cache-refresh-job.test.ts
+++ b/test/app/models/cache-refresh-job.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "@jest/globals";
+import { CACHE_REFRESH_TASK_NAMES, createPendingCacheRefreshTaskResults } from "~/domain/cache-refresh";
+import { parseCacheRefreshTaskResults } from "~/models/cache-refresh-job";
+
+describe("cache refresh job model", () => {
+  it("parses a complete task result payload", () => {
+    const results = createPendingCacheRefreshTaskResults();
+    results.syncRawStudents = { status: "succeeded", durationMs: 1200, error: null };
+
+    expect(parseCacheRefreshTaskResults(JSON.stringify(results))).toEqual(results);
+  });
+
+  it("rejects payloads that omit a known task", () => {
+    const results = createPendingCacheRefreshTaskResults() as Record<string, unknown>;
+    delete results[CACHE_REFRESH_TASK_NAMES[0]];
+
+    expect(() => parseCacheRefreshTaskResults(JSON.stringify(results))).toThrow("Invalid cache refresh task result");
+  });
+});

--- a/test/app/routes/__manage.test.ts
+++ b/test/app/routes/__manage.test.ts
@@ -1,21 +1,8 @@
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import { getActiveSensei } from "~/auth/authenticator.server";
-import { syncEventContentsList } from "~/models/event-content";
-import { getStudentGearData } from "~/models/growth-resource";
-import { getItemCatalogResources } from "~/models/item-catalog";
-import { getMainStories } from "~/models/main-story";
-import { warmRaidCache } from "~/models/raid";
-import { warmRecruitmentCache } from "~/models/recruitment";
-import { getAllStudentsFavoriteItems } from "~/models/resource";
+import { CACHE_REFRESH_TASK_NAMES, createPendingCacheRefreshTaskResults } from "~/domain/cache-refresh";
+import { getCacheRefreshStatus, startCacheRefresh } from "~/jobs/cache-refresh-control.server";
 import type { Sensei } from "~/models/sensei";
-import { getCampaignFarmingStages } from "~/models/stage";
-import { getAllStudents, getStudentSkillItemsBatch, syncRawStudents } from "~/models/student";
-import { syncAllTimelineContentsMeta } from "~/models/timeline-content.server";
-import { syncYoutubeCommunityPosts } from "~/models/youtube";
-import { getEventList, warmActiveUpcomingEventContent } from "~/views/events";
-import { getFutureContents } from "~/views/futures";
-import { getIndexContents } from "~/views/home";
-import { getNavigationBarContentsRaw } from "~/views/navigation";
 
 function makeSensei(overrides: Partial<Sensei>): Sensei {
   return {
@@ -31,117 +18,36 @@ function makeSensei(overrides: Partial<Sensei>): Sensei {
   };
 }
 
+function makeJob(status: "queued" | "running" | "completed" = "queued") {
+  return {
+    uid: "job-uid",
+    requestedBy: 1,
+    status,
+    currentTask: null,
+    completedCount: status === "completed" ? CACHE_REFRESH_TASK_NAMES.length : 0,
+    totalCount: CACHE_REFRESH_TASK_NAMES.length,
+    taskResults: createPendingCacheRefreshTaskResults(),
+    startedAt: null,
+    finishedAt: null,
+    createdAt: "2026-07-23 00:00:00",
+    updatedAt: "2026-07-23 00:00:00",
+  } as const;
+}
+
 jest.mock("~/auth/authenticator.server", () => ({
   getActiveSensei: jest.fn(),
 }));
 
-jest.mock("~/models/main-story", () => ({
-  getMainStories: jest.fn(),
-}));
-
-jest.mock("~/models/resource", () => ({
-  getAllStudentsFavoriteItems: jest.fn(),
-}));
-
-jest.mock("~/models/student", () => ({
-  getAllStudents: jest.fn(),
-  getStudentSkillItemsBatch: jest.fn(),
-  syncRawStudents: jest.fn(),
-}));
-
-jest.mock("~/models/timeline-content.server", () => ({
-  syncAllTimelineContentsMeta: jest.fn(),
-}));
-
-jest.mock("~/models/youtube", () => ({
-  syncYoutubeCommunityPosts: jest.fn(),
-}));
-
-jest.mock("~/views/futures", () => ({
-  getFutureContents: jest.fn(),
-}));
-
-jest.mock("~/views/home", () => ({
-  getIndexContents: jest.fn(),
-}));
-
-jest.mock("~/views/navigation", () => ({
-  getNavigationBarContentsRaw: jest.fn(),
-}));
-
-jest.mock("~/models/event-content", () => ({
-  syncEventContentsList: jest.fn(),
-}));
-
-jest.mock("~/views/events", () => ({
-  getEventList: jest.fn(),
-  warmActiveUpcomingEventContent: jest.fn(),
-}));
-
-jest.mock("~/models/item-catalog", () => ({
-  getItemCatalogResources: jest.fn(),
-}));
-
-jest.mock("~/models/stage", () => ({
-  getCampaignFarmingStages: jest.fn(),
-}));
-
-jest.mock("~/models/growth-resource", () => ({
-  getStudentGearData: jest.fn(),
-}));
-
-jest.mock("~/models/recruitment", () => ({
-  warmRecruitmentCache: jest.fn(),
-}));
-
-jest.mock("~/models/raid", () => ({
-  warmRaidCache: jest.fn(),
+jest.mock("~/jobs/cache-refresh-control.server", () => ({
+  getCacheRefreshStatus: jest.fn(),
+  startCacheRefresh: jest.fn(),
 }));
 
 import { action, loader } from "../../../app/routes/[__manage]";
 
 const mockedGetActiveSensei = getActiveSensei as jest.MockedFunction<typeof getActiveSensei>;
-const mockedSyncRawStudents = syncRawStudents as jest.MockedFunction<typeof syncRawStudents>;
-const mockedGetAllStudents = getAllStudents as jest.MockedFunction<typeof getAllStudents>;
-const mockedGetStudentSkillItemsBatch = getStudentSkillItemsBatch as jest.MockedFunction<
-  typeof getStudentSkillItemsBatch
->;
-const mockedSyncYoutubeCommunityPosts = syncYoutubeCommunityPosts as jest.MockedFunction<
-  typeof syncYoutubeCommunityPosts
->;
-const mockedGetFutureContents = getFutureContents as jest.MockedFunction<typeof getFutureContents>;
-const mockedGetIndexContents = getIndexContents as jest.MockedFunction<typeof getIndexContents>;
-const mockedGetNavigationBarContentsRaw = getNavigationBarContentsRaw as jest.MockedFunction<
-  typeof getNavigationBarContentsRaw
->;
-const mockedGetEventList = getEventList as jest.MockedFunction<typeof getEventList>;
-const mockedSyncEventContentsList = syncEventContentsList as jest.MockedFunction<typeof syncEventContentsList>;
-const mockedWarmActiveUpcomingEventContent = warmActiveUpcomingEventContent as jest.MockedFunction<
-  typeof warmActiveUpcomingEventContent
->;
-const mockedGetMainStories = getMainStories as jest.MockedFunction<typeof getMainStories>;
-const mockedGetAllStudentsFavoriteItems = getAllStudentsFavoriteItems as jest.MockedFunction<
-  typeof getAllStudentsFavoriteItems
->;
-const mockedSyncAllTimelineContentsMeta = syncAllTimelineContentsMeta as jest.MockedFunction<
-  typeof syncAllTimelineContentsMeta
->;
-const mockedGetItemCatalogResources = getItemCatalogResources as jest.MockedFunction<typeof getItemCatalogResources>;
-const mockedGetCampaignFarmingStages = getCampaignFarmingStages as jest.MockedFunction<typeof getCampaignFarmingStages>;
-const mockedGetStudentGearData = getStudentGearData as jest.MockedFunction<typeof getStudentGearData>;
-const mockedWarmRecruitmentCache = warmRecruitmentCache as jest.MockedFunction<typeof warmRecruitmentCache>;
-const mockedWarmRaidCache = warmRaidCache as jest.MockedFunction<typeof warmRaidCache>;
-
-type ManageActionResponse = {
-  intent: "cache.refresh" | "unknown";
-  result?: {
-    ok: boolean;
-    ranAt: string;
-    durations?: Record<string, number>;
-    errors?: Record<string, string>;
-  };
-  error?: string;
-};
+const mockedGetCacheRefreshStatus = getCacheRefreshStatus as jest.MockedFunction<typeof getCacheRefreshStatus>;
+const mockedStartCacheRefresh = startCacheRefresh as jest.MockedFunction<typeof startCacheRefresh>;
 
 type LoaderArgs = Parameters<typeof loader>[0];
 type ActionArgs = Parameters<typeof action>[0];
@@ -151,9 +57,9 @@ type DataResult<T> = {
   init: ResponseInit | null;
 };
 
-function createLoaderArgs(): LoaderArgs {
+function createLoaderArgs(url = "https://mollulog.net/__manage"): LoaderArgs {
   return {
-    request: new Request("https://mollulog.net/__manage", { method: "GET" }),
+    request: new Request(url, { method: "GET" }),
     context: { cloudflare: { env: {} as Env, ctx: {} as ExecutionContext } },
     params: {},
   } as unknown as LoaderArgs;
@@ -179,158 +85,79 @@ function dataStatus(result: DataResult<unknown>): number {
   return result.init?.status ?? 200;
 }
 
-function expectResponse(result: unknown): Response {
-  expect(result).toBeInstanceOf(Response);
-  return result as Response;
-}
-
 beforeEach(() => {
   jest.clearAllMocks();
-  mockedSyncYoutubeCommunityPosts.mockResolvedValue({ synced: 0 });
-  mockedSyncRawStudents.mockResolvedValue([]);
-  mockedGetAllStudents.mockResolvedValue([{ uid: "10000" }, { uid: "10001" }] as Awaited<
-    ReturnType<typeof getAllStudents>
-  >);
-  mockedGetStudentSkillItemsBatch.mockResolvedValue(new Map());
-  mockedGetStudentGearData.mockResolvedValue(new Map());
-  mockedWarmRecruitmentCache.mockResolvedValue([]);
-  mockedWarmRaidCache.mockResolvedValue([]);
-  mockedGetMainStories.mockResolvedValue([]);
-  mockedGetAllStudentsFavoriteItems.mockResolvedValue([]);
-  mockedSyncAllTimelineContentsMeta.mockResolvedValue([]);
-  mockedSyncEventContentsList.mockResolvedValue([]);
-  mockedWarmActiveUpcomingEventContent.mockResolvedValue();
-  mockedGetItemCatalogResources.mockResolvedValue([]);
-  mockedGetCampaignFarmingStages.mockResolvedValue([]);
-  mockedGetEventList.mockResolvedValue([]);
-  mockedGetIndexContents.mockResolvedValue({
-    mainEvent: null,
-    currentRaids: [],
-    currentRecruitments: [],
-    favoritedCounts: [],
-  });
-  mockedGetFutureContents.mockResolvedValue([]);
-  mockedGetNavigationBarContentsRaw.mockResolvedValue({
-    eventCandidates: [],
-    latestNewsTime: null,
-    raidActivePeriods: [],
-    couponActivePeriods: [],
-  });
+  mockedGetCacheRefreshStatus.mockResolvedValue(null);
 });
 
 describe("__manage route", () => {
-  it("allows admins to load the manage page", async () => {
+  it("loads the latest cache refresh job for admins", async () => {
     mockedGetActiveSensei.mockResolvedValue(makeSensei({ id: 1, role: "admin" }));
+    const job = makeJob("running");
+    mockedGetCacheRefreshStatus.mockResolvedValue(job);
 
-    const response = expectDataResult(await loader(createLoaderArgs()));
-
-    expect(dataStatus(response)).toBe(200);
-  });
-
-  it("runs refresh tasks for admins and returns task durations", async () => {
-    mockedGetActiveSensei.mockResolvedValue(makeSensei({ id: 1, role: "admin" }));
-
-    const response = expectDataResult<ManageActionResponse>(await action(createActionArgs("cache.refresh")));
-    const body = response.data;
-
-    expect(dataStatus(response)).toBe(200);
-    expect(body).toMatchObject({
-      intent: "cache.refresh",
-      result: {
-        ok: true,
-        durations: {
-          syncYoutubeCommunityPosts: expect.any(Number),
-          syncRawStudents: expect.any(Number),
-          warmRecruitmentCache: expect.any(Number),
-          warmRaidCache: expect.any(Number),
-          getMainStories: expect.any(Number),
-          getAllStudentsFavoriteItems: expect.any(Number),
-          syncAllTimelineContentsMeta: expect.any(Number),
-          syncEventContentsList: expect.any(Number),
-          warmStudentSkillItems: expect.any(Number),
-          warmStudentGearData: expect.any(Number),
-          warmActiveUpcomingEventContent: expect.any(Number),
-          getItemCatalogResources: expect.any(Number),
-          getCampaignFarmingStages: expect.any(Number),
-          getEventList: expect.any(Number),
-          getIndexContents: expect.any(Number),
-          getFutureContents: expect.any(Number),
-          getNavigationBarContentsRaw: expect.any(Number),
-        },
-      },
-    });
-    expect(body.result?.ranAt).toEqual(expect.any(String));
-    expect(mockedSyncYoutubeCommunityPosts).toHaveBeenCalledWith(expect.anything());
-    expect(mockedGetMainStories).toHaveBeenCalledWith(expect.anything(), true);
-    expect(mockedGetAllStudentsFavoriteItems).toHaveBeenCalledWith(expect.anything(), true);
-    expect(mockedSyncAllTimelineContentsMeta).toHaveBeenCalledWith(
-      expect.anything(),
-      true,
-      expect.objectContaining({ ctx: expect.anything() }),
-    );
-    expect(mockedSyncEventContentsList).toHaveBeenCalledWith(expect.anything());
-    expect(mockedGetAllStudents).toHaveBeenCalledWith(expect.anything(), true);
-    expect(mockedGetStudentSkillItemsBatch).toHaveBeenCalledWith(expect.anything(), ["10000", "10001"], true);
-    expect(mockedGetStudentGearData).toHaveBeenCalledWith(expect.anything(), ["10000", "10001"], true);
-    expect(mockedWarmActiveUpcomingEventContent).toHaveBeenCalledWith(expect.anything(), true, expect.anything());
-    expect(mockedGetItemCatalogResources).toHaveBeenCalledWith(expect.anything(), true);
-    expect(mockedGetCampaignFarmingStages).toHaveBeenCalledWith(expect.anything(), true);
-    expect(mockedGetEventList).toHaveBeenCalledWith(expect.anything(), undefined, true, expect.anything());
-    expect(mockedGetIndexContents).toHaveBeenCalledWith(expect.anything(), true, expect.anything());
-    expect(mockedGetFutureContents).toHaveBeenCalledWith(expect.anything(), true, expect.anything());
-    expect(mockedGetNavigationBarContentsRaw).toHaveBeenCalledWith(expect.anything(), true, expect.anything());
-    expect(mockedWarmRecruitmentCache).toHaveBeenCalledWith(expect.anything());
-    expect(mockedWarmRaidCache).toHaveBeenCalledWith(expect.anything());
-  });
-
-  it("captures elapsed duration and skips composite refresh when a leaf task fails", async () => {
-    mockedGetActiveSensei.mockResolvedValue(makeSensei({ id: 1, role: "admin" }));
-    mockedWarmRaidCache.mockImplementation(
-      () =>
-        new Promise((_resolve, reject) => {
-          setTimeout(() => reject(new Error("raid refresh failed")), 5);
-        }),
+    const response = expectDataResult<{ job: typeof job; error: null }>(
+      await loader(createLoaderArgs("https://mollulog.net/__manage?jobId=job-uid")),
     );
 
-    const response = expectDataResult<ManageActionResponse>(await action(createActionArgs("cache.refresh")));
-    const body = response.data;
-
     expect(dataStatus(response)).toBe(200);
-    expect(body.result?.ok).toBe(false);
-    expect(body.result?.errors).toEqual({ warmRaidCache: "raid refresh failed" });
-    expect(body.result?.durations?.warmRaidCache).toBeGreaterThan(0);
-    expect(mockedGetFutureContents).not.toHaveBeenCalled();
-    expect(mockedGetEventList).not.toHaveBeenCalled();
-    expect(mockedGetIndexContents).not.toHaveBeenCalled();
-    expect(mockedGetNavigationBarContentsRaw).not.toHaveBeenCalled();
+    expect(response.data).toEqual({ job, error: null });
+    expect(mockedGetCacheRefreshStatus).toHaveBeenCalledWith(expect.anything(), expect.anything(), "job-uid");
   });
 
-  it("rejects non-admin users from loader and action", async () => {
+  it("starts a workflow and responds before the refresh completes", async () => {
+    mockedGetActiveSensei.mockResolvedValue(makeSensei({ id: 1, role: "admin" }));
+    const job = makeJob();
+    mockedStartCacheRefresh.mockResolvedValue({ job, created: true });
+
+    const response = expectDataResult<{ intent: "cache.refresh"; job: typeof job; created: true }>(
+      await action(createActionArgs()),
+    );
+
+    expect(dataStatus(response)).toBe(202);
+    expect(response.data).toEqual({ intent: "cache.refresh", job, created: true });
+    expect(mockedStartCacheRefresh).toHaveBeenCalledWith(expect.anything(), expect.anything(), 1);
+  });
+
+  it("returns the active workflow instead of starting a duplicate", async () => {
+    mockedGetActiveSensei.mockResolvedValue(makeSensei({ id: 1, role: "admin" }));
+    const job = makeJob("running");
+    mockedStartCacheRefresh.mockResolvedValue({ job, created: false });
+
+    const response = expectDataResult<{ intent: "cache.refresh"; job: typeof job; created: false }>(
+      await action(createActionArgs()),
+    );
+
+    expect(dataStatus(response)).toBe(200);
+    expect(response.data).toEqual({ intent: "cache.refresh", job, created: false });
+  });
+
+  it("returns a safe error when starting the workflow fails", async () => {
+    mockedGetActiveSensei.mockResolvedValue(makeSensei({ id: 1, role: "admin" }));
+    mockedStartCacheRefresh.mockRejectedValue(new Error("internal workflow failure"));
+
+    const response = expectDataResult<{ error: string }>(await action(createActionArgs()));
+
+    expect(dataStatus(response)).toBe(503);
+    expect(response.data.error).not.toContain("internal workflow failure");
+  });
+
+  it("rejects non-admin and anonymous users", async () => {
     mockedGetActiveSensei.mockResolvedValue(makeSensei({ id: 2, role: "guest" }));
-
     await expect(loader(createLoaderArgs())).resolves.toHaveProperty("status", 403);
     await expect(action(createActionArgs())).resolves.toHaveProperty("status", 403);
-  });
 
-  it("redirects anonymous requests from loader and action", async () => {
     mockedGetActiveSensei.mockResolvedValue(null);
-
-    const loaderResponse = expectResponse(await loader(createLoaderArgs()));
-    const actionResponse = expectResponse(await action(createActionArgs()));
-
-    expect(loaderResponse.status).toBe(302);
-    expect(loaderResponse.headers.get("Location")).toBe("/unauthorized");
-    expect(actionResponse.status).toBe(302);
-    expect(actionResponse.headers.get("Location")).toBe("/unauthorized");
+    await expect(loader(createLoaderArgs())).resolves.toMatchObject({ status: 302 });
+    await expect(action(createActionArgs())).resolves.toMatchObject({ status: 302 });
   });
 
   it("returns 400 for unknown intents", async () => {
     mockedGetActiveSensei.mockResolvedValue(makeSensei({ id: 1, role: "admin" }));
 
-    const response = expectDataResult<ManageActionResponse>(await action(createActionArgs("unknown")));
-    const body = response.data;
+    const response = expectDataResult(await action(createActionArgs("unknown")));
 
     expect(dataStatus(response)).toBe(400);
-    expect(body).toEqual({ intent: "unknown", error: "Unsupported intent: unknown" });
+    expect(response.data).toEqual({ intent: "unknown", error: "Unsupported intent: unknown" });
   });
 });

--- a/workers/app.ts
+++ b/workers/app.ts
@@ -6,6 +6,8 @@ import { createRequestDiagnostics, type RequestDiagnostics } from "~/lib/request
 import { RUNTIME_TIMEOUTS } from "~/lib/runtime-timeouts";
 import { withD1Timeout } from "./d1-timeout";
 
+export { CacheRefreshWorkflow } from "./cache-refresh-workflow";
+
 type ObservabilityEnv = Env & {
   SERVER_BETTER_STACK_SOURCE_TOKEN?: string;
   SERVER_BETTER_STACK_SENTRY_DSN?: string;

--- a/workers/cache-refresh-workflow.ts
+++ b/workers/cache-refresh-workflow.ts
@@ -1,0 +1,11 @@
+import { WorkflowEntrypoint, type WorkflowEvent, type WorkflowStep } from "cloudflare:workers";
+import type { CacheRefreshWorkflowParams } from "~/domain/cache-refresh";
+import { runCacheRefreshWorkflow } from "~/jobs/cache-refresh-workflow.server";
+import { withD1Timeout } from "./d1-timeout";
+
+export class CacheRefreshWorkflow extends WorkflowEntrypoint<Env, CacheRefreshWorkflowParams> {
+  override run(event: Readonly<WorkflowEvent<CacheRefreshWorkflowParams>>, step: WorkflowStep) {
+    const env: Env = { ...this.env, DB: withD1Timeout(this.env.DB) };
+    return runCacheRefreshWorkflow(env, this.ctx, event, step);
+  }
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -47,6 +47,13 @@
   "hyperdrive": [
     { "binding": "HYPERDRIVE", "id": "0531527296514c808ba518ad5cbaa3d2" }
   ],
+  "workflows": [
+    {
+      "binding": "CACHE_REFRESH_WORKFLOW",
+      "name": "mollulog-cache-refresh-local",
+      "class_name": "CacheRefreshWorkflow"
+    }
+  ],
   "queues": {
     "producers": [
       { "binding": "EVENTS", "queue": "mollulog-events" }
@@ -93,6 +100,13 @@
       "hyperdrive": [
         { "binding": "HYPERDRIVE", "id": "0531527296514c808ba518ad5cbaa3d2" }
       ],
+      "workflows": [
+        {
+          "binding": "CACHE_REFRESH_WORKFLOW",
+          "name": "mollulog-cache-refresh-staging",
+          "class_name": "CacheRefreshWorkflow"
+        }
+      ],
       "queues": {
         "producers": [
           { "binding": "EVENTS", "queue": "mollulog-events-staging" }
@@ -129,6 +143,13 @@
       ],
       "hyperdrive": [
         { "binding": "HYPERDRIVE", "id": "0531527296514c808ba518ad5cbaa3d2" }
+      ],
+      "workflows": [
+        {
+          "binding": "CACHE_REFRESH_WORKFLOW",
+          "name": "mollulog-cache-refresh",
+          "class_name": "CacheRefreshWorkflow"
+        }
       ],
       "queues": {
         "producers": [


### PR DESCRIPTION
## Summary

Move the admin cache refresh out of the HTTP request lifecycle and into a Cloudflare Workflow so long-running refreshes no longer depend on a single request completing.

Persist job and task progress in D1 and show live progress on /__manage through polling, including completed, failed, and skipped tasks.

## Changes

- Add a Cloudflare Workflow entrypoint for the 17 existing cache refresh tasks.
- Return immediately after creating a refresh job instead of waiting for all cache work in the action.
- Store job status, per-task results, durations, and the active-job slot in D1.
- Prevent duplicate refresh jobs with a D1 unique index.
- Reconcile terminal Workflow state back into D1 when the management page reads job status.
- Release the active slot when reconciliation is unavailable or unknown and D1 progress has been stale for 24 hours.
- Add polling progress UI with active, completed, failed, and skipped states.
- Preserve the latest job status when the management page is reloaded.
- Keep raw task errors in server logs and expose only safe messages with a job ID.
- Add unit and route coverage for task state, Workflow orchestration, control and reconciliation branches, D1 parsing, and the management endpoints.

The D1 migration 20260723000100_create_cache_refresh_jobs.sql must be applied before deploying this workflow.

## Verification

- [x] I verified the related behavior myself.
- [ ] I ran pnpm typecheck, pnpm exec biome check ., and relevant tests when needed.
  - TypeScript typecheck: passed
  - Jest: passed (120 suites, 718 tests)
  - Production build: passed
  - Local D1 migrations and resulting schema: verified
  - Biome check for changed files: passed
  - git diff --check: passed
  - Repository-wide Biome check still reports 169 pre-existing diagnostics in unrelated files
- [ ] (If AI tools were used) The generated content was reviewed by a person.

## Related issues

None.