### PR TITLE
feat: add private profile visibility

### DIFF
--- a/app/components/features/profile/ProfileEditor.tsx
+++ b/app/components/features/profile/ProfileEditor.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ReactNode } from "react";
 import { StudentSelectForm } from "~/components/features/forms";
 import { Input, Textarea } from "~/components/primitives";
 
@@ -19,6 +20,7 @@ type Profile = {
 type ProfileEditorProps = {
   students: ProfileStudent[];
   initialData?: Partial<Profile>;
+  profileVisibilityField?: ReactNode;
   error?: {
     username?: string;
     friendCode?: string;
@@ -26,10 +28,37 @@ type ProfileEditorProps = {
   };
 };
 
-export default function ProfileEditor({ students, initialData, error }: ProfileEditorProps) {
+export default function ProfileEditor({ students, initialData, profileVisibilityField, error }: ProfileEditorProps) {
   const initialProfileStudentId = initialData?.profileStudentId
     ? students.find(({ uid }) => initialData.profileStudentId === uid)?.uid
     : undefined;
+
+  const profileStudentField = (
+    <StudentSelectForm
+      label="프로필 학생"
+      name="profileStudentId"
+      description="학생을 프로필 이미지로 설정할 수 있어요"
+      students={students}
+      initialStudentUids={initialProfileStudentId ? [initialProfileStudentId] : undefined}
+      placeholder="프로필 학생 선택"
+      searchPlaceholder="학생 이름으로 검색"
+      className="max-w-none"
+      containerClassName="mt-0 mb-0"
+    />
+  );
+
+  const friendCodeField = (
+    <Input
+      label="친구 코드"
+      type="text"
+      name="friendCode"
+      defaultValue={initialData?.friendCode ?? undefined}
+      description="8자리 영문자"
+      placeholder="[소셜] > [친구] > [ID 카드] 에서 확인"
+      error={error?.friendCode}
+      className={profileVisibilityField ? "max-w-none" : "max-w-none md:max-w-md"}
+    />
+  );
 
   return (
     <div className="space-y-6">
@@ -45,29 +74,17 @@ export default function ProfileEditor({ students, initialData, error }: ProfileE
           required
           className="max-w-none"
         />
-        <StudentSelectForm
-          label="프로필 학생"
-          name="profileStudentId"
-          description="학생을 프로필 이미지로 설정할 수 있어요"
-          students={students}
-          initialStudentUids={initialProfileStudentId ? [initialProfileStudentId] : undefined}
-          placeholder="프로필 학생 선택"
-          searchPlaceholder="학생 이름으로 검색"
-          className="max-w-none"
-          containerClassName="mt-0 mb-0"
-        />
+        {profileVisibilityField ?? profileStudentField}
       </div>
 
-      <Input
-        label="친구 코드"
-        type="text"
-        name="friendCode"
-        defaultValue={initialData?.friendCode ?? undefined}
-        description="8자리 영문자"
-        placeholder="[소셜] > [친구] > [ID 카드] 에서 확인"
-        error={error?.friendCode}
-        className="max-w-none md:max-w-md"
-      />
+      {profileVisibilityField ? (
+        <div className="grid gap-6 md:grid-cols-2">
+          {profileStudentField}
+          {friendCodeField}
+        </div>
+      ) : (
+        friendCodeField
+      )}
 
       <Textarea
         label="자기소개"

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -10,6 +10,7 @@ import { createRequestDiagnostics } from "./lib/request-diagnostics";
 import { canonicalUrl } from "./lib/seo";
 import {
   isGoogleSearchCrawler,
+  isSenseiProfilePath,
   materializeReactSuspenseBoundaries,
   requiresSelfCanonical,
   stripExecutableScripts,
@@ -81,6 +82,9 @@ export default async function handleRequest(
 
   responseHeaders.set("Content-Type", "text/html");
   responseHeaders.set("Cache-Control", "no-store, no-transform");
+  if (isSenseiProfilePath(path)) {
+    responseHeaders.set("X-Robots-Tag", "noindex");
+  }
   appendVary(responseHeaders, "User-Agent");
   responseHeaders.set(SEO_DEBUG_HEADERS.renderId, requestDiagnostics.renderId);
   responseHeaders.set(SEO_DEBUG_HEADERS.requestPath, requestDiagnostics.requestPath);

--- a/app/lib/seo-crawler.ts
+++ b/app/lib/seo-crawler.ts
@@ -33,6 +33,14 @@ export function isGoogleSearchCrawler(userAgent: string | null): boolean {
   return GOOGLE_SEARCH_CRAWLER_PATTERN.test(userAgent ?? "");
 }
 
+export function isSenseiProfilePath(pathname: string): boolean {
+  try {
+    return /^\/@[^/]+(?:\/|$)/.test(decodeURIComponent(pathname));
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Google Search only needs the fully rendered server HTML. Removing executable
  * scripts prevents WRS from hydrating into a different route while preserving

--- a/app/lib/seo-crawler.ts
+++ b/app/lib/seo-crawler.ts
@@ -34,10 +34,15 @@ export function isGoogleSearchCrawler(userAgent: string | null): boolean {
 }
 
 export function isSenseiProfilePath(pathname: string): boolean {
-  try {
-    return /^\/@[^/]+(?:\/|$)/.test(decodeURIComponent(pathname));
-  } catch {
+  const usernameSegment = pathname.split("/", 2)[1];
+  if (!usernameSegment) {
     return false;
+  }
+
+  try {
+    return /^@.+$/.test(decodeURIComponent(usernameSegment));
+  } catch {
+    return /^@.+$/.test(usernameSegment) || /^%40.+$/i.test(usernameSegment);
   }
 }
 

--- a/app/models/community.ts
+++ b/app/models/community.ts
@@ -13,7 +13,7 @@ import { cacheKey, cacheQuery, fetchCached } from "~/lib/cache";
 import { withD1Session } from "~/lib/d1-session";
 import { normalizeUtcTimestamp, nowUtcIso, type UtcIsoString } from "~/lib/date-time";
 import { watchIo } from "~/lib/io-watchdog";
-import { senseisTable } from "./sensei";
+import { senseiProfileVisibilityFilter, senseisTable } from "./sensei";
 
 export type CommunityPostType =
   | "student_review"
@@ -289,6 +289,19 @@ function communityCommentVisibilityFilter(currentUserId?: number | null): SQLWra
   return or(publicCondition, eq(communityCommentsTable.userId, currentUserId)) ?? publicCondition;
 }
 
+function communityPostAuthorProfileVisibilityFilter(currentUserId?: number | null): SQLWrapper {
+  return (
+    or(
+      eq(communityPostsTable.origin, "curated"),
+      senseiProfileVisibilityFilter(currentUserId, communityPostsTable.userId),
+    ) ?? senseiProfileVisibilityFilter(currentUserId, communityPostsTable.userId)
+  );
+}
+
+function communityCommentAuthorProfileVisibilityFilter(currentUserId?: number | null): SQLWrapper {
+  return senseiProfileVisibilityFilter(currentUserId, communityCommentsTable.userId);
+}
+
 function toNestedCommunityComment(
   comment: CommunityCommentRow,
   currentUserId?: number | null,
@@ -368,7 +381,13 @@ export async function getNestedCommunityCommentsByPostUids(
     })
     .from(communityCommentsTable)
     .innerJoin(senseisTable, eq(communityCommentsTable.userId, senseisTable.id))
-    .where(and(inArray(communityCommentsTable.postUid, postUids), communityCommentVisibilityFilter(currentUserId)))
+    .where(
+      and(
+        inArray(communityCommentsTable.postUid, postUids),
+        communityCommentVisibilityFilter(currentUserId),
+        communityCommentAuthorProfileVisibilityFilter(currentUserId),
+      ),
+    )
     .orderBy(sql`unixepoch(${communityCommentsTable.createdAt})`, communityCommentsTable.id);
 
   const result = postUids.reduce<Record<string, NestedCommunityComment[]>>((acc, postUid) => {
@@ -507,6 +526,7 @@ async function loadCommunityFeedPage(
   const db = drizzle(env.DB);
   const filters: SQLWrapper[] = [
     communityPostVisibilityFilter(currentUserId),
+    communityPostAuthorProfileVisibilityFilter(currentUserId),
     sql`(
       ${communityPostsTable.postType} <> 'walkthrough_timeline'
       or ${communityPostsTable.visibility} = 'public'
@@ -546,7 +566,13 @@ async function loadCommunityFeedPage(
 
   const [{ count }] = await watchIo(
     "community.feed.count",
-    Promise.resolve(db.select({ count: sql<number>`count(*)` }).from(communityPostsTable).where(where)),
+    Promise.resolve(
+      db
+        .select({ count: sql<number>`count(*)` })
+        .from(communityPostsTable)
+        .leftJoin(senseisTable, eq(communityPostsTable.userId, senseisTable.id))
+        .where(where),
+    ),
     traceContext,
     COMMUNITY_FEED_SLOW_WARN_MS,
   );
@@ -685,7 +711,13 @@ export async function getCommunityPostByUid(
     })
     .from(communityPostsTable)
     .leftJoin(senseisTable, eq(communityPostsTable.userId, senseisTable.id))
-    .where(and(eq(communityPostsTable.uid, postUid), communityPostVisibilityFilter(currentUserId)))
+    .where(
+      and(
+        eq(communityPostsTable.uid, postUid),
+        communityPostVisibilityFilter(currentUserId),
+        communityPostAuthorProfileVisibilityFilter(currentUserId),
+      ),
+    )
     .get();
 
   if (!row) {
@@ -742,7 +774,14 @@ export async function createCommunityComment(
   const post = await db
     .select({ uid: communityPostsTable.uid })
     .from(communityPostsTable)
-    .where(and(eq(communityPostsTable.uid, postUid), communityPostVisibilityFilter(userId)))
+    .leftJoin(senseisTable, eq(communityPostsTable.userId, senseisTable.id))
+    .where(
+      and(
+        eq(communityPostsTable.uid, postUid),
+        communityPostVisibilityFilter(userId),
+        communityPostAuthorProfileVisibilityFilter(userId),
+      ),
+    )
     .get();
 
   if (!post) {
@@ -757,7 +796,14 @@ export async function createCommunityComment(
         parentUid: communityCommentsTable.parentUid,
       })
       .from(communityCommentsTable)
-      .where(and(eq(communityCommentsTable.uid, targetParentUid), communityCommentVisibilityFilter(userId)))
+      .innerJoin(senseisTable, eq(communityCommentsTable.userId, senseisTable.id))
+      .where(
+        and(
+          eq(communityCommentsTable.uid, targetParentUid),
+          communityCommentVisibilityFilter(userId),
+          communityCommentAuthorProfileVisibilityFilter(userId),
+        ),
+      )
       .get();
 
     if (!parentComment || parentComment.postUid !== postUid) {
@@ -834,7 +880,14 @@ export async function setCommunityPostLike(env: Env, userId: number, postUid: st
       visibility: communityPostsTable.visibility,
     })
     .from(communityPostsTable)
-    .where(and(eq(communityPostsTable.uid, postUid), communityPostVisibilityFilter(userId)))
+    .leftJoin(senseisTable, eq(communityPostsTable.userId, senseisTable.id))
+    .where(
+      and(
+        eq(communityPostsTable.uid, postUid),
+        communityPostVisibilityFilter(userId),
+        communityPostAuthorProfileVisibilityFilter(userId),
+      ),
+    )
     .get();
 
   if (!post || post.postType === "walkthrough_timeline") {

--- a/app/models/content-comment.ts
+++ b/app/models/content-comment.ts
@@ -106,24 +106,6 @@ function commentAuthorProfileVisibilityFilter(userId?: number): SQLWrapper {
   return senseiProfileVisibilityFilter(userId, communityCommentsTable.userId);
 }
 
-export async function getUserComments(env: Env, userId: number): Promise<ContentComment[]> {
-  const db = drizzle(env.DB);
-  const rows = await db
-    .select({
-      id: communityPostsTable.id,
-      uid: communityPostsTable.uid,
-      subjectContentUid: communityPostsTable.subjectContentUid,
-      blocks: communityPostsTable.blocks,
-      visibility: communityPostsTable.visibility,
-      pinned: communityPostsTable.pinned,
-      createdAt: communityPostsTable.createdAt,
-    })
-    .from(communityPostsTable)
-    .where(and(eq(communityPostsTable.userId, userId), eq(communityPostsTable.postType, "event_opinion")));
-
-  return rows.map((row) => toContentCommentFromPost(row));
-}
-
 export async function getContentComments(
   env: Env,
   contentId: string,
@@ -608,49 +590,6 @@ export async function unpinComment(env: Env, userId: number, contentId: string):
         eq(communityPostsTable.pinned, 1),
       ),
     );
-}
-
-export async function getPinnedComment(
-  env: Env,
-  contentId: string,
-  userId: number,
-): Promise<ContentCommentWithSensei | null> {
-  const db = drizzle(env.DB);
-  const result = await db
-    .select({
-      id: communityPostsTable.id,
-      uid: communityPostsTable.uid,
-      subjectContentUid: communityPostsTable.subjectContentUid,
-      blocks: communityPostsTable.blocks,
-      visibility: communityPostsTable.visibility,
-      pinned: communityPostsTable.pinned,
-      createdAt: communityPostsTable.createdAt,
-      username: senseisTable.username,
-      profileStudentId: senseisTable.profileStudentId,
-    })
-    .from(communityPostsTable)
-    .innerJoin(senseisTable, eq(communityPostsTable.userId, senseisTable.id))
-    .where(
-      and(
-        eq(communityPostsTable.subjectContentUid, contentId),
-        eq(communityPostsTable.userId, userId),
-        eq(communityPostsTable.postType, "event_opinion"),
-        eq(communityPostsTable.pinned, 1),
-      ),
-    )
-    .get();
-
-  if (!result) {
-    return null;
-  }
-
-  return {
-    ...toContentCommentFromPost(result),
-    sensei: {
-      username: result.username,
-      profileStudentId: result.profileStudentId,
-    },
-  };
 }
 
 export type NestedComment = {

--- a/app/models/content-comment.ts
+++ b/app/models/content-comment.ts
@@ -14,7 +14,7 @@ import {
   parseCommunityPostBlocks,
   serializeCommunityPostBlocks,
 } from "./community";
-import { senseisTable } from "./sensei";
+import { senseiProfileVisibilityFilter, senseisTable } from "./sensei";
 
 type ContentCommentVisibility = "private" | "public";
 const IN_QUERY_BATCH_SIZE = 90;
@@ -98,6 +98,14 @@ function commentVisibilityFilter(userId?: number): SQLWrapper {
   );
 }
 
+function postAuthorProfileVisibilityFilter(userId?: number): SQLWrapper {
+  return senseiProfileVisibilityFilter(userId, communityPostsTable.userId);
+}
+
+function commentAuthorProfileVisibilityFilter(userId?: number): SQLWrapper {
+  return senseiProfileVisibilityFilter(userId, communityCommentsTable.userId);
+}
+
 export async function getUserComments(env: Env, userId: number): Promise<ContentComment[]> {
   const db = drizzle(env.DB);
   const rows = await db
@@ -157,6 +165,7 @@ export async function getContentsComments(
             eq(communityPostsTable.postType, "event_opinion"),
             inArray(communityPostsTable.subjectContentUid, batch),
             visibilityFilter(userId),
+            postAuthorProfileVisibilityFilter(userId),
           ),
         ),
     ),
@@ -212,7 +221,13 @@ export async function getContentsComments(
                 })
                 .from(communityCommentsTable)
                 .innerJoin(senseisTable, eq(communityCommentsTable.userId, senseisTable.id))
-                .where(and(inArray(communityCommentsTable.postUid, batch), commentVisibilityFilter(userId))),
+                .where(
+                  and(
+                    inArray(communityCommentsTable.postUid, batch),
+                    commentVisibilityFilter(userId),
+                    commentAuthorProfileVisibilityFilter(userId),
+                  ),
+                ),
             ),
           )
         ).flat();

--- a/app/models/content.ts
+++ b/app/models/content.ts
@@ -1,19 +1,17 @@
-export { CONTENT_ORDER, SHOW_LINK_CONTENT_TYPES, SHOW_LINK_RAID_TYPES } from "./content-rules";
+export type { ContentCommentSummary, NestedComment } from "./content-comment";
 export {
   contentComments,
-  getUserComments,
-  getContentComments,
-  getContentsComments,
-  getContentsCommentSummaries,
   createComment,
   createSubcomment,
-  updateComment,
   deleteComment,
   getCommentIdByUid,
-  pinComment,
-  unpinComment,
-  getPinnedComment,
+  getContentComments,
+  getContentsCommentSummaries,
+  getContentsComments,
   getNestedContentComments,
   nestComments,
+  pinComment,
+  unpinComment,
+  updateComment,
 } from "./content-comment";
-export type { ContentCommentSummary, NestedComment } from "./content-comment";
+export { CONTENT_ORDER, SHOW_LINK_CONTENT_TYPES, SHOW_LINK_RAID_TYPES } from "./content-rules";

--- a/app/models/followership.ts
+++ b/app/models/followership.ts
@@ -2,7 +2,7 @@ import { and, count, eq, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { int, sqliteTable, text } from "drizzle-orm/sqlite-core";
 import type { Sensei } from "./sensei";
-import { getSenseisById } from "./sensei";
+import { getVisibleSenseisById } from "./sensei";
 
 const followershipsTable = sqliteTable("followerships", {
   id: int().primaryKey({ autoIncrement: true }),
@@ -97,8 +97,8 @@ export async function getFollowerIds(env: Env, followeeId: number): Promise<numb
   return result.map((each) => each.followerId);
 }
 
-export async function getFollowers(env: Env, followeeId: number): Promise<Sensei[]> {
-  return getSenseisById(env, await getFollowerIds(env, followeeId));
+export async function getFollowers(env: Env, followeeId: number, viewerId?: number): Promise<Sensei[]> {
+  return getVisibleSenseisById(env, await getFollowerIds(env, followeeId), viewerId);
 }
 
 export async function getFollowingIds(env: Env, followerId: number): Promise<number[]> {
@@ -110,6 +110,6 @@ export async function getFollowingIds(env: Env, followerId: number): Promise<num
   return result.map((each) => each.followeeId);
 }
 
-export async function getFollowings(env: Env, followerId: number): Promise<Sensei[]> {
-  return getSenseisById(env, await getFollowingIds(env, followerId));
+export async function getFollowings(env: Env, followerId: number, viewerId?: number): Promise<Sensei[]> {
+  return getVisibleSenseisById(env, await getFollowingIds(env, followerId), viewerId);
 }

--- a/app/models/party.ts
+++ b/app/models/party.ts
@@ -6,7 +6,7 @@ import {
   type PartyInfoCommunityPostBlock,
   parseCommunityPostBlocks,
 } from "./community";
-import { getSenseisById, type Sensei, senseisTable } from "./sensei";
+import { getSenseisById, type Sensei, senseiProfileVisibilityFilter, senseisTable } from "./sensei";
 
 export type DBParty = {
   uid: string;
@@ -109,10 +109,12 @@ export async function getPartiesByRaidReference(
       blocks: communityPostsTable.blocks,
     })
     .from(communityPostsTable)
+    .innerJoin(senseisTable, eq(communityPostsTable.userId, senseisTable.id))
     .where(
       and(
         eq(communityPostsTable.postType, "guide"),
         eq(communityPostsTable.visibility, "public"),
+        senseiProfileVisibilityFilter(),
         eq(communityPostsTable.subjectRaidType, raidType),
         eq(communityPostsTable.subjectSeasonIndex, seasonIndex),
       ),

--- a/app/models/sensei.ts
+++ b/app/models/sensei.ts
@@ -1,10 +1,11 @@
-import { eq, inArray } from "drizzle-orm";
+import { type AnyColumn, and, eq, inArray, or, type SQLWrapper } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { int, sqliteTable, text } from "drizzle-orm/sqlite-core";
 import { nanoid } from "nanoid/non-secure";
 import { isUniqueConstraintError } from "~/lib/db";
 
 type SenseiRole = "guest" | "admin";
+export type ProfileVisibility = "public" | "private";
 
 export const senseisTable = sqliteTable("senseis", {
   id: int().primaryKey({ autoIncrement: true }),
@@ -17,6 +18,7 @@ export const senseisTable = sqliteTable("senseis", {
   githubId: text(),
   role: text().notNull().$type<SenseiRole>(),
   active: int().notNull().default(0),
+  profileVisibility: text().notNull().default("public").$type<ProfileVisibility>(),
 });
 
 export type Sensei = {
@@ -28,6 +30,7 @@ export type Sensei = {
   bio: string | null;
   active: boolean;
   role: SenseiRole;
+  profileVisibility: ProfileVisibility;
   config?: {
     darkMode?: boolean;
   };
@@ -57,10 +60,44 @@ export async function getSenseiByUsername(env: Env, username: string): Promise<S
 
 export async function getSenseisById(env: Env, ids: number[]): Promise<Sensei[]> {
   const uniqueIds = [...new Set(ids)];
+  if (uniqueIds.length === 0) {
+    return [];
+  }
   const db = drizzle(env.DB);
   const senseis = await db.select().from(senseisTable).where(inArray(senseisTable.id, uniqueIds));
 
   return senseis.map((row) => toSenseiModel(row));
+}
+
+export async function getVisibleSenseisById(env: Env, ids: number[], viewerUserId?: number): Promise<Sensei[]> {
+  const uniqueIds = [...new Set(ids)];
+  if (uniqueIds.length === 0) {
+    return [];
+  }
+
+  const db = drizzle(env.DB);
+  const senseis = await db
+    .select()
+    .from(senseisTable)
+    .where(and(inArray(senseisTable.id, uniqueIds), senseiProfileVisibilityFilter(viewerUserId)));
+
+  return senseis.map((row) => toSenseiModel(row));
+}
+
+export function isSenseiProfileVisibleTo(sensei: Sensei, viewerUserId?: number): boolean {
+  return sensei.profileVisibility === "public" || sensei.id === viewerUserId;
+}
+
+export function senseiProfileVisibilityFilter(
+  viewerUserId?: number | null,
+  ownerUserIdColumn: AnyColumn = senseisTable.id,
+): SQLWrapper {
+  const publicCondition = eq(senseisTable.profileVisibility, "public");
+  if (!viewerUserId) {
+    return publicCondition;
+  }
+
+  return or(publicCondition, eq(ownerUserIdColumn, viewerUserId)) ?? publicCondition;
 }
 
 export async function createSensei(
@@ -101,7 +138,9 @@ export async function createSensei(
 }
 
 // Update a sensei
-type SenseiUpdateFields = Partial<Pick<Sensei, "username" | "friendCode" | "profileStudentId" | "active" | "bio">>;
+type SenseiUpdateFields = Partial<
+  Pick<Sensei, "username" | "friendCode" | "profileStudentId" | "active" | "bio" | "profileVisibility">
+>;
 
 function nullableFieldToUpdate<T>(value: T | null | undefined, existingValue: T | null): T | null {
   if (value === undefined) {
@@ -130,6 +169,7 @@ export async function updateSensei(
         profileStudentId: nullableFieldToUpdate(fields.profileStudentId, existingSensei.profileStudentId),
         bio: nullableFieldToUpdate(fields.bio, existingSensei.bio),
         active: (fields.active ?? existingSensei.active) ? 1 : 0,
+        profileVisibility: fields.profileVisibility ?? existingSensei.profileVisibility,
       })
       .where(eq(senseisTable.id, id));
   } catch (e) {
@@ -156,5 +196,6 @@ export function toSenseiModel(row: typeof senseisTable.$inferSelect): Sensei {
     bio: row.bio,
     active: row.active === 1,
     role: row.role,
+    profileVisibility: row.profileVisibility ?? "public",
   };
 }

--- a/app/models/student-grading.ts
+++ b/app/models/student-grading.ts
@@ -1,7 +1,7 @@
-import { and, desc, eq, sql } from "drizzle-orm";
+import { and, desc, eq, type SQLWrapper, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { nanoid } from "nanoid/non-secure";
-import { type UtcIsoString, nowUtcIso } from "~/lib/date-time";
+import { nowUtcIso, type UtcIsoString } from "~/lib/date-time";
 import {
   communityPostsTable,
   createPlaintextCommunityPostBlocks,
@@ -11,7 +11,7 @@ import {
   parseCommunityPostBlocks,
   serializeCommunityPostBlocks,
 } from "./community";
-import { senseisTable } from "./sensei";
+import { senseiProfileVisibilityFilter, senseisTable } from "./sensei";
 import type { StudentGradingTagValue } from "./student-grading-tag";
 import {
   getGradingTags,
@@ -61,6 +61,10 @@ function studentReviewWhere(studentUid?: string) {
     eq(communityPostsTable.postType, "student_review"),
     studentUid ? eq(communityPostsTable.subjectStudentUid, studentUid) : undefined,
   );
+}
+
+function authorProfileVisibilityFilter(viewerUserId?: number): SQLWrapper {
+  return senseiProfileVisibilityFilter(viewerUserId, communityPostsTable.userId);
 }
 
 export async function getStudentGrading(
@@ -156,6 +160,7 @@ export async function getStudentGradingsByStudentWithUsers(
   env: Env,
   studentUid: string,
   includeTags = false,
+  viewerUserId?: number,
 ): Promise<StudentGradingWithUser[]> {
   const db = drizzle(env.DB);
   const gradings = await db
@@ -170,7 +175,7 @@ export async function getStudentGradingsByStudentWithUsers(
     })
     .from(communityPostsTable)
     .innerJoin(senseisTable, eq(communityPostsTable.userId, senseisTable.id))
-    .where(studentReviewWhere(studentUid));
+    .where(and(studentReviewWhere(studentUid), authorProfileVisibilityFilter(viewerUserId)));
 
   const result: StudentGradingWithUser[] = gradings.map((grading) => ({
     uid: grading.uid,
@@ -229,6 +234,7 @@ export async function getRecentStudentGradingsWithUsers(
   env: Env,
   limit = 3,
   includeTags = false,
+  viewerUserId?: number,
 ): Promise<StudentGradingWithUser[]> {
   const db = drizzle(env.DB);
   const gradings = await db
@@ -243,7 +249,7 @@ export async function getRecentStudentGradingsWithUsers(
     })
     .from(communityPostsTable)
     .innerJoin(senseisTable, eq(communityPostsTable.userId, senseisTable.id))
-    .where(eq(communityPostsTable.postType, "student_review"))
+    .where(and(eq(communityPostsTable.postType, "student_review"), authorProfileVisibilityFilter(viewerUserId)))
     .orderBy(
       desc(sql`unixepoch(${communityPostsTable.updatedAt})`),
       desc(sql`unixepoch(${communityPostsTable.createdAt})`),
@@ -279,6 +285,7 @@ export async function getRecentStudentGradingsPageWithUsers(
   page = 1,
   pageSize = 20,
   includeTags = false,
+  viewerUserId?: number,
 ): Promise<StudentGradingPageWithUser> {
   const db = drizzle(env.DB);
   const safePage = Math.max(1, page);
@@ -286,7 +293,8 @@ export async function getRecentStudentGradingsPageWithUsers(
   const [{ count }] = await db
     .select({ count: sql<number>`count(*)` })
     .from(communityPostsTable)
-    .where(eq(communityPostsTable.postType, "student_review"));
+    .innerJoin(senseisTable, eq(communityPostsTable.userId, senseisTable.id))
+    .where(and(eq(communityPostsTable.postType, "student_review"), authorProfileVisibilityFilter(viewerUserId)));
 
   const totalCount = Number(count);
   const totalPages = Math.max(1, Math.ceil(totalCount / safePageSize));
@@ -305,7 +313,7 @@ export async function getRecentStudentGradingsPageWithUsers(
     })
     .from(communityPostsTable)
     .innerJoin(senseisTable, eq(communityPostsTable.userId, senseisTable.id))
-    .where(eq(communityPostsTable.postType, "student_review"))
+    .where(and(eq(communityPostsTable.postType, "student_review"), authorProfileVisibilityFilter(viewerUserId)))
     .orderBy(
       desc(sql`unixepoch(${communityPostsTable.updatedAt})`),
       desc(sql`unixepoch(${communityPostsTable.createdAt})`),

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -25,7 +25,7 @@ import { initializeGoogleAnalytics, trackCurrentGoogleAnalyticsPageView } from "
 import { captureClientError } from "./lib/observability.client";
 import { createRequestDiagnostics } from "./lib/request-diagnostics";
 import { isServerRouteError, normalizeRouteError } from "./lib/route-error";
-import { isGoogleSearchCrawler } from "./lib/seo-crawler";
+import { isGoogleSearchCrawler, isSenseiProfilePath } from "./lib/seo-crawler";
 import styles from "./tailwind.css?url";
 import { getNavigationBarContents } from "./views/navigation";
 
@@ -132,6 +132,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <meta name="mollulog:request-path" content={loaderData?.requestDiagnostics?.requestPath ?? ""} />
         <meta name="mollulog:render-path" content={location.pathname} />
         <meta name="mollulog:build-id" content={loaderData?.requestDiagnostics?.buildId ?? ""} />
+        {isSenseiProfilePath(location.pathname) ? <meta name="robots" content="noindex" /> : null}
         <meta
           name="mollulog:front-better-stack-sentry-dsn"
           content={loaderData?.publicEnv?.FRONT_BETTER_STACK_SENTRY_DSN ?? ""}

--- a/app/routes/$username._index.tsx
+++ b/app/routes/$username._index.tsx
@@ -27,7 +27,8 @@ function parsePage(request: Request) {
 export const loader = async ({ context, request, params }: LoaderFunctionArgs) => {
   const { env, ctx } = context.cloudflare;
   const publicReadEnv = withD1Session(env, "first-unconstrained");
-  const [sensei, currentUser] = await Promise.all([getRouteSensei(env, params), getActiveSensei(env, request)]);
+  const currentUser = await getActiveSensei(env, request);
+  const sensei = await getRouteSensei(env, params, currentUser?.id);
   const page = parsePage(request);
 
   const [followership, recruitedStudents, allReleasedStudents, feedPage] = await Promise.all([

--- a/app/routes/$username.friends.tsx
+++ b/app/routes/$username.friends.tsx
@@ -2,6 +2,7 @@ import { SparklesIcon, UsersIcon } from "@heroicons/react/24/outline";
 import { useEffect, useState } from "react";
 import type { LoaderFunctionArgs } from "react-router";
 import { useLoaderData, useSearchParams } from "react-router";
+import { getActiveSensei } from "~/auth/authenticator.server";
 import { ErrorPage } from "~/components/features/layout";
 import { FilterButtons, SubTitle } from "~/components/primitives";
 import { getFollowers, getFollowings } from "~/models/followership";
@@ -9,12 +10,13 @@ import type { Sensei } from "~/models/sensei";
 import { getRouteSensei } from "./$username";
 import SenseiList from "./$username.friends._components/SenseiList";
 
-export const loader = async ({ params, context }: LoaderFunctionArgs) => {
+export const loader = async ({ params, context, request }: LoaderFunctionArgs) => {
   const env = context.cloudflare.env;
-  const sensei = await getRouteSensei(env, params);
+  const currentUser = await getActiveSensei(env, request);
+  const sensei = await getRouteSensei(env, params, currentUser?.id);
   return {
-    following: await getFollowings(env, sensei.id),
-    followers: await getFollowers(env, sensei.id),
+    following: await getFollowings(env, sensei.id, currentUser?.id),
+    followers: await getFollowers(env, sensei.id, currentUser?.id),
   };
 };
 

--- a/app/routes/$username.futures.tsx
+++ b/app/routes/$username.futures.tsx
@@ -25,8 +25,8 @@ export const meta: MetaFunction = ({ params }) => {
 export const loader = async ({ context, params, request }: LoaderFunctionArgs) => {
   const { env, ctx } = context.cloudflare;
   const publicReadEnv = withD1Session(env, "first-unconstrained");
-  const sensei = await getRouteSensei(env, params);
   const currentUser = await getActiveSensei(env, request);
+  const sensei = await getRouteSensei(env, params, currentUser?.id);
 
   const [favoritedStudents, futureContents, studentsMap] = await Promise.all([
     getUserFavoritedStudents(env, sensei.id, undefined, { ctx }),

--- a/app/routes/$username.parties._index.tsx
+++ b/app/routes/$username.parties._index.tsx
@@ -21,8 +21,8 @@ export const meta: MetaFunction = ({ params }) => {
 
 export const loader = async ({ context, request, params }: LoaderFunctionArgs) => {
   const env = context.cloudflare.env;
-  const sensei = await getRouteSensei(env, params);
   const currentUser = await getActiveSensei(env, request);
+  const sensei = await getRouteSensei(env, params, currentUser?.id);
   const me = sensei.username === currentUser?.username;
 
   const allStudents = await getAllStudents(env, true);

--- a/app/routes/$username.pickups._index.tsx
+++ b/app/routes/$username.pickups._index.tsx
@@ -4,8 +4,8 @@ import { getActiveSensei } from "~/auth/authenticator.server";
 import { AddContentButton } from "~/components/features/editor";
 import { SubTitle } from "~/components/primitives";
 import { getRecruitmentResultCountStats, resolveRecruitmentResultStudents } from "~/domain/recruitment-result";
-import { compareInstantAsc, compareInstantDesc } from "~/lib/date-time";
 import { withD1Session } from "~/lib/d1-session";
+import { compareInstantAsc, compareInstantDesc } from "~/lib/date-time";
 import { routeError } from "~/lib/http-errors";
 import { getRecruitmentGroupsByUids, getRecruitmentPoolStudents } from "~/models/recruitment";
 import {
@@ -37,7 +37,7 @@ export const action = async ({ context, request, params }: ActionFunctionArgs) =
     return redirect("/unauthorized");
   }
 
-  const routeSensei = await getRouteSensei(env, params);
+  const routeSensei = await getRouteSensei(env, params, sensei.id);
   if (routeSensei.username !== sensei.username) {
     return data({ error: "Forbidden" }, { status: 403 });
   }
@@ -55,7 +55,8 @@ export const action = async ({ context, request, params }: ActionFunctionArgs) =
 export const loader = async ({ context, request, params }: LoaderFunctionArgs) => {
   const { env, ctx } = context.cloudflare;
   const publicReadEnv = withD1Session(env, "first-unconstrained");
-  const sensei = await getRouteSensei(env, params);
+  const currentUser = await getActiveSensei(env, request);
+  const sensei = await getRouteSensei(env, params, currentUser?.id);
 
   const [recruitmentResults, allStudentsMap] = await Promise.all([
     getRecruitmentResults(env, sensei.id),
@@ -161,7 +162,6 @@ export const loader = async ({ context, request, params }: LoaderFunctionArgs) =
     })
     .sort((a, b) => compareInstantDesc(a.event.since, b.event.since));
 
-  const currentUser = await getActiveSensei(env, request);
   return {
     me: sensei.username === currentUser?.username,
     recruitmentHistories: aggregatedHistories,

--- a/app/routes/$username.students.tsx
+++ b/app/routes/$username.students.tsx
@@ -1,20 +1,25 @@
-import type { LoaderFunctionArgs, MetaFunction, ActionFunctionArgs } from "react-router";
-import { useLoaderData, data, useFetcher, useOutletContext } from "react-router";
-import { StudentCards, TierSelector } from "~/components/features/students";
+import { FunnelIcon, IdentificationIcon, MinusCircleIcon, PlusCircleIcon } from "@heroicons/react/24/outline";
+import { useEffect, useMemo, useState } from "react";
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from "react-router";
+import { data, useFetcher, useLoaderData, useOutletContext } from "react-router";
 import { getActiveSensei } from "~/auth/authenticator.server";
+import {
+  createStudentFilterState,
+  getFilteredStudentUids,
+  StudentCards,
+  StudentFilter,
+  TierSelector,
+} from "~/components/features/students";
 import { Button, SubTitle, Toggle } from "~/components/primitives";
-import { getRouteSensei } from "./$username";
+import { getRecruitedStudents, removeRecruitedStudent, upsertRecruitedStudent } from "~/models/recruited-student";
 import { getAllStudents } from "~/models/student";
-import { getRecruitedStudents, upsertRecruitedStudent, removeRecruitedStudent } from "~/models/recruited-student";
-import { MinusCircleIcon, IdentificationIcon, PlusCircleIcon, FunnelIcon } from "@heroicons/react/24/outline";
-import { useEffect, useState, useMemo } from "react";
-import { createStudentFilterState, getFilteredStudentUids, StudentFilter } from "~/components/features/students";
+import { getRouteSensei } from "./$username";
 
 export const loader = async ({ context, request, params }: LoaderFunctionArgs) => {
   const env = context.cloudflare.env;
   const currentUser = await getActiveSensei(env, request);
 
-  const sensei = await getRouteSensei(env, params);
+  const sensei = await getRouteSensei(env, params, currentUser?.id);
   const recruitedStudents = await getRecruitedStudents(env, sensei.id);
   const recruitedStudentTiers = recruitedStudents.reduce(
     (acc, { studentUid, tier }) => {
@@ -59,7 +64,7 @@ export const action = async ({ context, request, params }: ActionFunctionArgs) =
     return data({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const sensei = await getRouteSensei(env, params);
+  const sensei = await getRouteSensei(env, params, currentUser.id);
   if (currentUser.username !== sensei.username) {
     return data({ error: "Forbidden" }, { status: 403 });
   }

--- a/app/routes/$username.timelines.tsx
+++ b/app/routes/$username.timelines.tsx
@@ -12,7 +12,8 @@ export const meta: MetaFunction = ({ params }) => [
 
 export const loader = async ({ context, request, params }: LoaderFunctionArgs) => {
   const { env, ctx } = context.cloudflare;
-  const [sensei, currentUser] = await Promise.all([getRouteSensei(env, params), getActiveSensei(env, request)]);
+  const currentUser = await getActiveSensei(env, request);
+  const sensei = await getRouteSensei(env, params, currentUser?.id);
   const me = sensei.id === currentUser?.id;
   const timelines = await listPostgresWalkthroughTimelinesByUser(env, sensei.id, me, { ctx });
   const timelineUids = timelines.map((timeline) => timeline.uid);

--- a/app/routes/$username.tsx
+++ b/app/routes/$username.tsx
@@ -8,8 +8,7 @@ import {
   UserIcon,
 } from "@heroicons/react/24/outline";
 import { useEffect, useState } from "react";
-import { type LoaderFunctionArgs, Outlet, type Params, useLocation, useParams, useRouteError } from "react-router";
-import { getActiveSensei } from "~/auth/authenticator.server";
+import { Outlet, type Params, useLocation, useParams, useRouteError } from "react-router";
 import { ErrorPage, Page, ServerErrorPage } from "~/components/features/layout";
 import { Title } from "~/components/primitives";
 import { routeError } from "~/lib/http-errors";
@@ -33,13 +32,6 @@ export async function getRouteSensei(env: Env, params: Params<string>, viewerUse
 
   return sensei;
 }
-
-export const loader = async ({ context, request, params }: LoaderFunctionArgs) => {
-  const env = context.cloudflare.env;
-  const currentUser = await getActiveSensei(env, request);
-  await getRouteSensei(env, params, currentUser?.id);
-  return null;
-};
 
 export const ErrorBoundary = () => {
   const error = useRouteError();

--- a/app/routes/$username.tsx
+++ b/app/routes/$username.tsx
@@ -3,20 +3,22 @@ import {
   DocumentTextIcon,
   HeartIcon,
   IdentificationIcon,
+  LockClosedIcon,
   QueueListIcon,
   UserIcon,
 } from "@heroicons/react/24/outline";
 import { useEffect, useState } from "react";
-import { Outlet, type Params, useLocation, useParams, useRouteError } from "react-router";
+import { type LoaderFunctionArgs, Outlet, type Params, useLocation, useParams, useRouteError } from "react-router";
+import { getActiveSensei } from "~/auth/authenticator.server";
 import { ErrorPage, Page, ServerErrorPage } from "~/components/features/layout";
 import { Title } from "~/components/primitives";
 import { routeError } from "~/lib/http-errors";
 import { isServerRouteError, normalizeRouteError } from "~/lib/route-error";
-import { getSenseiByUsername, type Sensei } from "~/models/sensei";
+import { getSenseiByUsername, isSenseiProfileVisibleTo, type Sensei } from "~/models/sensei";
 
-export async function getRouteSensei(env: Env, params: Params<string>): Promise<Sensei> {
+export async function getRouteSensei(env: Env, params: Params<string>, viewerUserId?: number): Promise<Sensei> {
   const usernameParam = params.username;
-  if (!usernameParam || !usernameParam.startsWith("@")) {
+  if (!usernameParam?.startsWith("@")) {
     throw routeError(404, "sensei.not_found", "선생님을 찾을 수 없어요");
   }
 
@@ -25,9 +27,19 @@ export async function getRouteSensei(env: Env, params: Params<string>): Promise<
   if (!sensei) {
     throw routeError(404, "sensei.not_found", "선생님을 찾을 수 없어요", { username });
   }
+  if (!isSenseiProfileVisibleTo(sensei, viewerUserId)) {
+    throw routeError(403, "sensei.profile_private", "이 프로필은 비공개예요", { username });
+  }
 
   return sensei;
 }
+
+export const loader = async ({ context, request, params }: LoaderFunctionArgs) => {
+  const env = context.cloudflare.env;
+  const currentUser = await getActiveSensei(env, request);
+  await getRouteSensei(env, params, currentUser?.id);
+  return null;
+};
 
 export const ErrorBoundary = () => {
   const error = useRouteError();
@@ -41,6 +53,23 @@ export const ErrorBoundary = () => {
     typeof details === "object" && details !== null && "username" in details && typeof details.username === "string"
       ? details.username
       : undefined;
+
+  if (normalized.code === "sensei.profile_private") {
+    return (
+      <div className="space-y-6">
+        {username && <Title text={`@${username}`} />}
+        <div className="flex min-h-64 flex-col items-center justify-center gap-3 rounded-lg border border-border bg-card px-6 text-center">
+          <LockClosedIcon className="size-10 text-muted-foreground" />
+          <div>
+            <p className="text-lg font-semibold">비공개 프로필이에요</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              이 프로필의 정보와 작성한 콘텐츠는 본인만 볼 수 있어요.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <>

--- a/app/routes/api.followerships.tsx
+++ b/app/routes/api.followerships.tsx
@@ -3,7 +3,7 @@ import { redirect } from "react-router";
 import { getActiveSensei } from "~/auth/authenticator.server";
 import { getLogger } from "~/lib/observability.server";
 import { follow, unfollow } from "~/models/followership";
-import { getSenseiByUsername } from "~/models/sensei";
+import { getSenseiByUsername, isSenseiProfileVisibleTo } from "~/models/sensei";
 
 export const action: ActionFunction = async ({ request, context }) => {
   const { env, ctx } = context.cloudflare;
@@ -29,6 +29,9 @@ export const action: ActionFunction = async ({ request, context }) => {
 
   try {
     if (request.method === "POST") {
+      if (!isSenseiProfileVisibleTo(followee, follower.id)) {
+        return errorResponse(403, "비공개 프로필은 팔로우할 수 없어요.");
+      }
       await follow(env, follower.id, followee.id);
     } else if (request.method === "DELETE") {
       await unfollow(env, follower.id, followee.id);

--- a/app/routes/api.timelines.$uid.likes.tsx
+++ b/app/routes/api.timelines.$uid.likes.tsx
@@ -4,7 +4,22 @@ import {
   getPostgresWalkthroughTimelineLikeSummaries,
   setPostgresWalkthroughTimelineLike,
 } from "~/db/postgres/walkthrough-timeline-likes";
+import { getPostgresWalkthroughTimeline } from "~/db/postgres/walkthrough-timelines";
 import type { LikeChangedActionResult } from "~/domain/like";
+import { getSenseiById, isSenseiProfileVisibleTo } from "~/models/sensei";
+
+async function requireVisibleTimeline(env: Env, ctx: ExecutionContext, walkthroughUid: string, viewerUserId?: number) {
+  const timeline = await getPostgresWalkthroughTimeline(env, walkthroughUid, { ctx });
+  const author = timeline ? await getSenseiById(env, timeline.userId) : null;
+  if (
+    !timeline ||
+    !author ||
+    (timeline.visibility === "private" && timeline.userId !== viewerUserId) ||
+    !isSenseiProfileVisibleTo(author, viewerUserId)
+  ) {
+    throw new Response("Walkthrough not found", { status: 404 });
+  }
+}
 
 export const loader = async ({ request, params, context }: LoaderFunctionArgs) => {
   const walkthroughUid = params.uid;
@@ -12,6 +27,7 @@ export const loader = async ({ request, params, context }: LoaderFunctionArgs) =
 
   const { env, ctx } = context.cloudflare;
   const currentUser = await getActiveSensei(env, request);
+  await requireVisibleTimeline(env, ctx, walkthroughUid, currentUser?.id);
   const summaries = await getPostgresWalkthroughTimelineLikeSummaries(env, [walkthroughUid], currentUser?.id, { ctx });
   return summaries[walkthroughUid] ?? { liked: false, likeCount: 0 };
 };
@@ -27,6 +43,7 @@ export const action = async ({ request, params, context }: ActionFunctionArgs) =
   const { env, ctx } = context.cloudflare;
   const currentUser = await getActiveSensei(env, request);
   if (!currentUser) return redirect("/unauthorized");
+  await requireVisibleTimeline(env, ctx, walkthroughUid, currentUser.id);
 
   const actionData = await request.json<ActionData>();
   const updated = await setPostgresWalkthroughTimelineLike(env, walkthroughUid, currentUser.id, actionData.liked, {

--- a/app/routes/edit._index.tsx
+++ b/app/routes/edit._index.tsx
@@ -3,10 +3,10 @@ import { ArrowPathIcon, CheckCircleIcon } from "@heroicons/react/20/solid";
 import { ArrowRightStartOnRectangleIcon, KeyIcon, LinkIcon } from "@heroicons/react/24/outline";
 import { type ElementType, useEffect, useState } from "react";
 import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from "react-router";
-import { Form, Link, data, redirect, useActionData, useLoaderData, useNavigation } from "react-router";
+import { data, Form, Link, redirect, useActionData, useLoaderData, useNavigation } from "react-router";
 import { getActiveSensei, getAuthenticator, sessionStorage } from "~/auth/authenticator.server";
 import { ProfileEditor } from "~/components/features/profile";
-import { Button, Input, SectionCard, Title } from "~/components/primitives";
+import { Button, Input, SectionCard, Title, Toggle } from "~/components/primitives";
 import { nowUtcIso } from "~/lib/date-time";
 import { cn } from "~/lib/utils";
 import { type AuthProvider, getAuthIdentityStatuses } from "~/models/auth-identity";
@@ -36,6 +36,7 @@ export const loader = async ({ context, request }: LoaderFunctionArgs) => {
       bio: senseiData.bio,
       profileStudentId: senseiData.profileStudentId,
       friendCode: senseiData.friendCode,
+      profileVisibility: senseiData.profileVisibility,
       memberCode: senseiPrivacy?.memberCode ?? null,
     },
     allStudents: (await getAllStudents(env, true))
@@ -111,6 +112,11 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
     const profileStudentId = toNullable(getOptionalString("profileStudentId"));
     const friendCodeInput = toNullable(getOptionalString("friendCode"));
     const friendCode = typeof friendCodeInput === "string" ? friendCodeInput.toUpperCase() : friendCodeInput;
+    const profileVisibility = formData.has("profilePrivate")
+      ? formData.get("profilePrivate") === "true"
+        ? "private"
+        : "public"
+      : undefined;
 
     if (!username) {
       return data<ActionData>({ intent, error: { username: "닉네임을 입력해주세요." } }, { status: 400 });
@@ -128,7 +134,13 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
       return data<ActionData>({ intent, error: { friendCode: "친구 코드는 알파벳 8글자에요." } }, { status: 400 });
     }
 
-    const result = await updateSensei(env, sensei.id, { username, bio, profileStudentId, friendCode });
+    const result = await updateSensei(env, sensei.id, {
+      username,
+      bio,
+      profileStudentId,
+      friendCode,
+      profileVisibility,
+    });
     if (result.error) {
       return data<ActionData>({ intent, error: result.error }, { status: 400 });
     }
@@ -139,6 +151,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
     if (bio !== undefined) sensei.bio = bio;
     if (profileStudentId !== undefined) sensei.profileStudentId = profileStudentId;
     if (friendCode !== undefined) sensei.friendCode = friendCode;
+    if (profileVisibility !== undefined) sensei.profileVisibility = profileVisibility;
     session.set(authenticator.sessionKey, sensei);
 
     return data<ActionData>(
@@ -176,6 +189,26 @@ function SaveSubmitButton({
       {isSaved && !isSubmitting ? <CheckCircleIcon className="size-4" /> : null}
       {isSubmitting ? "저장 중..." : isSaved ? "저장됨" : idleLabel}
     </Button>
+  );
+}
+
+function ProfileVisibilityField({ initialPrivate }: { initialPrivate: boolean }) {
+  const [privateProfile, setPrivateProfile] = useState(initialPrivate);
+
+  return (
+    <div className="space-y-2">
+      <p className="text-sm font-semibold">프로필 공개 범위</p>
+      <p className="text-sm text-muted-foreground">프로필과 작성한 컨텐츠를 숨겨요.</p>
+      <div className="flex min-h-10 items-center">
+        <Toggle
+          name="profilePrivate"
+          label={privateProfile ? "비공개" : "공개"}
+          initialState={initialPrivate}
+          className="my-0"
+          onChange={setPrivateProfile}
+        />
+      </div>
+    </div>
   );
 }
 
@@ -275,7 +308,7 @@ export default function EditProfile() {
     <div className="space-y-8">
       <Title text="프로필 관리" />
 
-      <SectionCard title="프로필 정보" description="프로필 정보는 다른 사람에게 표시돼요">
+      <SectionCard title="프로필 정보" description="프로필 정보와 공개 범위를 관리할 수 있어요">
         <Form
           method="put"
           className="space-y-6"
@@ -285,7 +318,12 @@ export default function EditProfile() {
           }}
         >
           <input type="hidden" name="intent" value="profile" />
-          <ProfileEditor students={allStudents} initialData={sensei} error={profileActionData?.error} />
+          <ProfileEditor
+            students={allStudents}
+            initialData={sensei}
+            profileVisibilityField={<ProfileVisibilityField initialPrivate={sensei.profileVisibility === "private"} />}
+            error={profileActionData?.error}
+          />
           <div className="flex justify-end">
             <SaveSubmitButton
               idleLabel="프로필 저장"

--- a/app/routes/students.$id.tsx
+++ b/app/routes/students.$id.tsx
@@ -88,16 +88,16 @@ export const loader = async ({ params, context, request }: LoaderFunctionArgs) =
 
   // Per-uid reads only start once the uid is confirmed to be a real student, so
   // bot-scanned/invalid uids don't trigger extra D1 lookups.
+  const currentUser = await currentUserPromise;
   const tagCountsPromise = getTagCountsByStudent(env, uid);
-  const allGradingsPromise = getStudentGradingsByStudentWithUsers(env, uid, true);
+  const allGradingsPromise = getStudentGradingsByStudentWithUsers(env, uid, true, currentUser?.id);
 
   const recruitmentGroupUids = student.recruitments.map(
     (recruitment: { recruitmentGroup: { uid: string } }) => recruitment.recruitmentGroup.uid,
   );
 
-  const [timelineContents, currentUser, rawAllStudents, tagCounts, allGradings, allRaids] = await Promise.all([
+  const [timelineContents, rawAllStudents, tagCounts, allGradings, allRaids] = await Promise.all([
     getTimelineContentsByRecruitmentGroupUids(publicReadEnv, recruitmentGroupUids, { ctx }),
-    currentUserPromise,
     rawAllStudentsPromise,
     tagCountsPromise,
     allGradingsPromise,

--- a/app/routes/timelines.$uid.tsx
+++ b/app/routes/timelines.$uid.tsx
@@ -41,7 +41,7 @@ import { defenseTypeColor, defenseTypeLocale, difficultyLocale, terrainLocale } 
 import { bossImageUrl } from "~/models/assets";
 import { deleteCommunityPostByUid } from "~/models/community";
 import { getAllRaidSchedules } from "~/models/raid";
-import { getSenseiById } from "~/models/sensei";
+import { getSenseiById, isSenseiProfileVisibleTo } from "~/models/sensei";
 import { getAllStudentsMap } from "~/models/student";
 
 export const meta: MetaFunction<typeof loader> = ({ data }) => [
@@ -63,8 +63,11 @@ export const loader = async ({ context, request, params }: LoaderFunctionArgs) =
   if (timeline.visibility === "private" && !owner) {
     throw routeError(404, "timeline.not_found", "공략 타임라인을 찾을 수 없어요.");
   }
-  const [author, students, raids, engagementByUid] = await Promise.all([
-    storedTimeline ? getSenseiById(env, storedTimeline.userId) : Promise.resolve(null),
+  const author = storedTimeline ? await getSenseiById(env, storedTimeline.userId) : null;
+  if (storedTimeline && (!author || !isSenseiProfileVisibleTo(author, currentUser?.id))) {
+    throw routeError(404, "timeline.not_found", "공략 타임라인을 찾을 수 없어요.");
+  }
+  const [students, raids, engagementByUid] = await Promise.all([
     getAllStudentsMap(env, true),
     getAllRaidSchedules(env),
     storedTimeline
@@ -116,6 +119,16 @@ export const action = async ({ context, request, params }: ActionFunctionArgs) =
   const formData = await request.formData();
   const intent = String(formData.get("intent") ?? "");
   if (intent === "clone") {
+    const source = await getPostgresWalkthroughTimeline(env, params.uid, { ctx });
+    const sourceAuthor = source ? await getSenseiById(env, source.userId) : null;
+    if (
+      !source ||
+      !sourceAuthor ||
+      (source.visibility === "private" && source.userId !== currentUser.id) ||
+      !isSenseiProfileVisibleTo(sourceAuthor, currentUser.id)
+    ) {
+      throw routeError(404, "timeline.not_found", "복제할 타임라인을 찾을 수 없어요.");
+    }
     const cloned = await clonePostgresWalkthroughTimeline(env, params.uid, currentUser.id, { ctx });
     if (!cloned) throw routeError(404, "timeline.not_found", "복제할 타임라인을 찾을 수 없어요.");
     return redirect(`/timelines/${cloned.uid}/edit`);

--- a/app/routes/timelines.$uid_.viewer.tsx
+++ b/app/routes/timelines.$uid_.viewer.tsx
@@ -10,6 +10,7 @@ import {
 import { getPostgresWalkthroughTimeline } from "~/db/postgres/walkthrough-timelines";
 import { DEMO_WALKTHROUGH_TIMELINE, isDemoWalkthroughTimelineUid } from "~/domain/walkthrough-timeline-demo";
 import { routeError } from "~/lib/http-errors";
+import { getSenseiById, isSenseiProfileVisibleTo } from "~/models/sensei";
 import { getAllStudentsMap } from "~/models/student";
 
 export const meta: MetaFunction<typeof loader> = ({ data }) => [
@@ -26,6 +27,10 @@ export const loader = async ({ context, request, params }: LoaderFunctionArgs) =
   ]);
   const timeline = demo ? DEMO_WALKTHROUGH_TIMELINE : storedTimeline;
   if (!timeline || (storedTimeline?.visibility === "private" && storedTimeline.userId !== currentUser?.id)) {
+    throw routeError(404, "timeline.not_found", "공략 타임라인을 찾을 수 없어요.");
+  }
+  const author = storedTimeline ? await getSenseiById(env, storedTimeline.userId) : null;
+  if (storedTimeline && (!author || !isSenseiProfileVisibleTo(author, currentUser?.id))) {
     throw routeError(404, "timeline.not_found", "공략 타임라인을 찾을 수 없어요.");
   }
   const students = await getAllStudentsMap(env, true);

--- a/app/routes/timelines._index.tsx
+++ b/app/routes/timelines._index.tsx
@@ -31,7 +31,7 @@ import {
 import { bossImageUrl } from "~/models/assets";
 import { getAllRaidSchedules } from "~/models/raid";
 import { getRecruitedStudentTiers } from "~/models/recruited-student";
-import { getSenseisById } from "~/models/sensei";
+import { getVisibleSenseisById } from "~/models/sensei";
 import { getAllStudentsMap } from "~/models/student";
 
 export const meta: MetaFunction = ({ location }) => [
@@ -81,18 +81,21 @@ export const loader = async ({ context, request }: LoaderFunctionArgs) => {
     },
     { ctx },
   );
-  const timelineUids = timelines.map((timeline) => timeline.uid);
-  const [authors, recruitedStudentTiers, engagementByUid] = await Promise.all([
-    getSenseisById(
-      env,
-      timelines.map((timeline) => timeline.userId),
-    ),
+  const authors = await getVisibleSenseisById(
+    env,
+    timelines.map((timeline) => timeline.userId),
+    sensei?.id,
+  );
+  const visibleAuthorIds = new Set(authors.map((author) => author.id));
+  const visibleTimelines = timelines.filter((timeline) => visibleAuthorIds.has(timeline.userId));
+  const timelineUids = visibleTimelines.map((timeline) => timeline.uid);
+  const [recruitedStudentTiers, engagementByUid] = await Promise.all([
     sensei ? getRecruitedStudentTiers(env, sensei.id) : Promise.resolve({}),
     getPostgresWalkthroughTimelineLikeSummaries(env, timelineUids, sensei?.id, { ctx }),
   ]);
 
   return {
-    timelines,
+    timelines: visibleTimelines,
     filters,
     engagementByUid,
     bosses,

--- a/db/migrations/20260725000100_add_profile_visibility_to_senseis.sql
+++ b/db/migrations/20260725000100_add_profile_visibility_to_senseis.sql
@@ -1,0 +1,1 @@
+alter table senseis add column profileVisibility text not null default 'public';

--- a/test/app/lib/seo-crawler.test.ts
+++ b/test/app/lib/seo-crawler.test.ts
@@ -23,6 +23,9 @@ describe("Google search crawler SEO containment", () => {
     expect(isSenseiProfilePath("/@someone/")).toBe(true);
     expect(isSenseiProfilePath("/@someone/timelines/example")).toBe(true);
     expect(isSenseiProfilePath("/%40someone/students")).toBe(true);
+    expect(isSenseiProfilePath("/@someone/%E0%A4%A")).toBe(true);
+    expect(isSenseiProfilePath("/%40someone/%E0%A4%A")).toBe(true);
+    expect(isSenseiProfilePath("/%40some%ZZ/students")).toBe(true);
     expect(isSenseiProfilePath("/students/@someone")).toBe(false);
     expect(isSenseiProfilePath("/api/followerships")).toBe(false);
     expect(isSenseiProfilePath("/%E0%A4%A")).toBe(false);

--- a/test/app/lib/seo-crawler.test.ts
+++ b/test/app/lib/seo-crawler.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "@jest/globals";
 import {
   isGoogleSearchCrawler,
+  isSenseiProfilePath,
   materializeReactSuspenseBoundaries,
   requiresSelfCanonical,
   stripExecutableScripts,
@@ -15,6 +16,16 @@ describe("Google search crawler SEO containment", () => {
     expect(isGoogleSearchCrawler("Mozilla/5.0 (compatible; Google-InspectionTool/1.0;)")).toBe(true);
     expect(isGoogleSearchCrawler("Mozilla/5.0 Chrome/140.0.0.0 Safari/537.36")).toBe(false);
     expect(isGoogleSearchCrawler(null)).toBe(false);
+  });
+
+  it("recognizes every sensei profile path for noindex", () => {
+    expect(isSenseiProfilePath("/@someone")).toBe(true);
+    expect(isSenseiProfilePath("/@someone/")).toBe(true);
+    expect(isSenseiProfilePath("/@someone/timelines/example")).toBe(true);
+    expect(isSenseiProfilePath("/%40someone/students")).toBe(true);
+    expect(isSenseiProfilePath("/students/@someone")).toBe(false);
+    expect(isSenseiProfilePath("/api/followerships")).toBe(false);
+    expect(isSenseiProfilePath("/%E0%A4%A")).toBe(false);
   });
 
   it("removes executable scripts while preserving JSON-LD", () => {

--- a/test/app/models/community.test.ts
+++ b/test/app/models/community.test.ts
@@ -17,6 +17,7 @@ type FakeSenseiRow = {
   id: number;
   username: string;
   profileStudentId: string | null;
+  profileVisibility: "public" | "private";
 };
 
 type FakeCommunityPostRow = {
@@ -95,6 +96,19 @@ class FakeCommunityD1Database {
 
     if (normalizedSql.includes("count(*)") && normalizedSql.includes("from community_posts")) {
       return [[this.filterPosts(normalizedSql, params).length]];
+    }
+
+    if (
+      normalizedSql.includes("from community_posts") &&
+      normalizedSql.includes("left join senseis") &&
+      !normalizedSql.startsWith("select community_posts.id,")
+    ) {
+      const post = this.findPostForSelect(normalizedSql, params);
+      if (!post || !this.isAuthorProfileVisible(post, normalizedSql, params)) return [];
+      if (normalizedSql.includes("posttype") && normalizedSql.includes("visibility")) {
+        return [[post.uid, post.postType, post.visibility]];
+      }
+      return [[post.uid]];
     }
 
     if (normalizedSql.includes("from community_posts") && normalizedSql.includes("left join senseis")) {
@@ -196,6 +210,12 @@ class FakeCommunityD1Database {
 
   private filterPosts(sql: string, params: unknown[]): FakeCommunityPostRow[] {
     let rows = this.posts.filter((post) => post.visibility === "public");
+    if (sql.includes("senseis.profilevisibility")) {
+      const hasOwnerException = sql.includes("community_posts.userid = ?");
+      rows = rows.filter((post) => {
+        return this.isAuthorProfileVisible(post, sql, params, hasOwnerException);
+      });
+    }
     const stringParams = params.filter((param): param is string => typeof param === "string");
     const postTypes = stringParams.filter((param) =>
       [
@@ -225,6 +245,20 @@ class FakeCommunityD1Database {
       });
     }
     return rows;
+  }
+
+  private isAuthorProfileVisible(
+    post: FakeCommunityPostRow,
+    sql: string,
+    params: unknown[],
+    hasOwnerException = sql.includes("community_posts.userid = ?"),
+  ): boolean {
+    if (post.origin === "curated") return true;
+    const sensei = this.senseis.find((candidate) => candidate.id === post.userId);
+    return (
+      sensei?.profileVisibility === "public" ||
+      (hasOwnerException && params.some((param) => Number(param) === post.userId))
+    );
   }
 
   private findPostForSelect(sql: string, params: unknown[]): FakeCommunityPostRow | undefined {
@@ -412,7 +446,7 @@ function createEnv(db: FakeCommunityD1Database): Env {
 describe("community model feed queries", () => {
   it("keeps existing user-authored posts visible with author data and created-at fallback displayAt", async () => {
     const db = new FakeCommunityD1Database();
-    db.senseis.push({ id: 1, username: "sensei", profileStudentId: "student-profile" });
+    db.senseis.push({ id: 1, username: "sensei", profileStudentId: "student-profile", profileVisibility: "public" });
     db.posts.push(createUserPost());
 
     const page = await getCommunityFeedPage(createEnv(db), {
@@ -439,7 +473,7 @@ describe("community model feed queries", () => {
 
   it("orders curated YouTube posts by displayAt while existing user posts fall back to createdAt", async () => {
     const db = new FakeCommunityD1Database();
-    db.senseis.push({ id: 1, username: "sensei", profileStudentId: null });
+    db.senseis.push({ id: 1, username: "sensei", profileStudentId: null, profileVisibility: "public" });
     db.posts.push(
       createUserPost({ updatedAt: "2026-05-09T00:00:00.000Z" }),
       createYoutubePost({
@@ -471,7 +505,7 @@ describe("community model feed queries", () => {
 
   it("does not move old user-authored posts to the top when they are updated", async () => {
     const db = new FakeCommunityD1Database();
-    db.senseis.push({ id: 1, username: "sensei", profileStudentId: null });
+    db.senseis.push({ id: 1, username: "sensei", profileStudentId: null, profileVisibility: "public" });
     db.posts.push(
       createUserPost({
         id: 1,
@@ -500,7 +534,7 @@ describe("community model feed queries", () => {
 
   it("can limit YouTube feed items by channel without hiding user-authored posts", async () => {
     const db = new FakeCommunityD1Database();
-    db.senseis.push({ id: 1, username: "sensei", profileStudentId: null });
+    db.senseis.push({ id: 1, username: "sensei", profileStudentId: null, profileVisibility: "public" });
     db.posts.push(
       createUserPost({ uid: "post-user-review", updatedAt: "2026-05-09T00:00:00.000Z" }),
       createYoutubePost({ uid: "youtube-kr", sourceUid: "video-kr", displayAt: "2026-05-10T00:00:00.000Z" }),
@@ -527,11 +561,33 @@ describe("community model feed queries", () => {
 
     expect(page.items.map((item) => item.uid)).toEqual(["youtube-kr", "post-user-review"]);
   });
+
+  it("hides a private profile's posts from others while keeping them visible to the owner", async () => {
+    const db = new FakeCommunityD1Database();
+    db.senseis.push({ id: 1, username: "private-sensei", profileStudentId: null, profileVisibility: "private" });
+    db.posts.push(createUserPost());
+
+    const publicPage = await getCommunityFeedPage(createEnv(db), {
+      postTypes: ["student_review"],
+      pageSize: 20,
+      includeEngagement: false,
+    });
+    const ownerPage = await getCommunityFeedPage(createEnv(db), {
+      currentUserId: 1,
+      postTypes: ["student_review"],
+      pageSize: 20,
+      includeEngagement: false,
+    });
+
+    expect(publicPage.items).toEqual([]);
+    expect(ownerPage.items.map((item) => item.uid)).toEqual(["post-user-review"]);
+  });
 });
 
 describe("community model likes", () => {
   it("keeps existing post likes idempotent", async () => {
     const db = new FakeCommunityD1Database();
+    db.senseis.push({ id: 1, username: "sensei", profileStudentId: null, profileVisibility: "public" });
     db.posts.push(createUserPost());
 
     await setCommunityPostLike(createEnv(db), 10, "post-user-review", true);
@@ -557,6 +613,7 @@ describe("community model likes", () => {
 
   it("does not store walkthrough timeline likes in the community model", async () => {
     const db = new FakeCommunityD1Database();
+    db.senseis.push({ id: 1, username: "sensei", profileStudentId: null, profileVisibility: "public" });
     db.posts.push(
       createUserPost({ uid: "timeline-public", postType: "walkthrough_timeline", sourceType: "raid_walkthrough" }),
       createUserPost({

--- a/test/app/models/content-comment.test.ts
+++ b/test/app/models/content-comment.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it, jest } from "@jest/globals";
 import { serializeCommunityPostBlocks } from "~/models/community";
-import { getContentsCommentSummaries } from "~/models/content-comment";
+import { getContentsCommentSummaries, getContentsComments } from "~/models/content-comment";
+
+type SenseiRow = {
+  id: number;
+  username: string;
+  profileStudentId: string | null;
+  profileVisibility: "public" | "private";
+};
 
 type CommunityPostRow = {
   id: number;
@@ -15,8 +22,12 @@ type CommunityPostRow = {
 };
 
 type CommunityCommentRow = {
+  id?: number;
+  uid?: string;
   postUid: string;
   userId: number;
+  parentUid?: string | null;
+  body?: string;
   visibility: "public" | "private";
   createdAt: string;
 };
@@ -46,6 +57,7 @@ class FakeD1Statement {
 class FakeContentCommentD1Database {
   readonly posts: CommunityPostRow[] = [];
   readonly comments: CommunityCommentRow[] = [];
+  readonly senseis: SenseiRow[] = [];
   activeQueries = 0;
   maxConcurrentQueries = 0;
   queryDelayMs = 0;
@@ -70,12 +82,60 @@ class FakeContentCommentD1Database {
   selectRows(sql: string, params: unknown[]): unknown[][] {
     const normalizedSql = normalizeSql(sql);
 
+    if (normalizedSql.includes("from community_posts") && normalizedSql.includes("inner join senseis")) {
+      return this.filterPosts(params)
+        .filter((post) => this.isAuthorProfileVisible(post.userId, normalizedSql, params, "community_posts"))
+        .flatMap((post) => {
+          const sensei = this.senseis.find((candidate) => candidate.id === post.userId);
+          if (!sensei) {
+            return [];
+          }
+          return [
+            [
+              post.id,
+              post.uid,
+              post.subjectContentUid,
+              post.blocks,
+              post.visibility,
+              post.pinned,
+              post.createdAt,
+              sensei.username,
+              sensei.profileStudentId,
+            ],
+          ];
+        });
+    }
+
     if (normalizedSql.includes("from community_posts")) {
       const posts = this.filterPosts(params);
       if (normalizedSql.includes("blocks")) {
         return posts.filter((post) => post.pinned === 1).map((post) => [post.subjectContentUid, post.blocks]);
       }
       return posts.map((post) => [post.id, post.uid, post.userId, post.subjectContentUid, post.pinned, post.createdAt]);
+    }
+
+    if (normalizedSql.includes("from community_comments") && normalizedSql.includes("inner join senseis")) {
+      return this.filterComments(params)
+        .filter((comment) => this.isAuthorProfileVisible(comment.userId, normalizedSql, params, "community_comments"))
+        .flatMap((comment) => {
+          const sensei = this.senseis.find((candidate) => candidate.id === comment.userId);
+          if (!sensei) {
+            return [];
+          }
+          return [
+            [
+              comment.id ?? 0,
+              comment.uid ?? "",
+              comment.postUid,
+              comment.parentUid ?? null,
+              comment.body ?? "",
+              comment.visibility,
+              comment.createdAt,
+              sensei.username,
+              sensei.profileStudentId,
+            ],
+          ];
+        });
     }
 
     if (normalizedSql.includes("from community_comments")) {
@@ -120,6 +180,23 @@ class FakeContentCommentD1Database {
       return comment.visibility === "public" || (comment.visibility === "private" && comment.userId === userId);
     });
   }
+
+  private isAuthorProfileVisible(
+    authorUserId: number,
+    sql: string,
+    params: unknown[],
+    authorTable: "community_posts" | "community_comments",
+  ): boolean {
+    if (!sql.includes("senseis.profilevisibility")) {
+      return true;
+    }
+
+    const sensei = this.senseis.find((candidate) => candidate.id === authorUserId);
+    const hasOwnerException = sql.includes(`${authorTable}.userid = ?`);
+    return (
+      sensei?.profileVisibility === "public" || (hasOwnerException && params.some((param) => param === authorUserId))
+    );
+  }
 }
 
 function createEnv(db = new FakeContentCommentD1Database()): { db: FakeContentCommentD1Database; env: Env } {
@@ -145,6 +222,51 @@ function post(overrides: Partial<CommunityPostRow> & Pick<CommunityPostRow, "uid
 function normalizeSql(sql: string): string {
   return sql.replaceAll('"', "").replace(/\s+/g, " ").trim().toLowerCase();
 }
+
+describe("getContentsComments profile visibility", () => {
+  it("hides a private profile's posts and subcomments from others while keeping them visible to the owner", async () => {
+    const { db, env } = createEnv();
+    db.senseis.push(
+      {
+        id: 10,
+        username: "private-sensei",
+        profileStudentId: null,
+        profileVisibility: "private",
+      },
+      {
+        id: 20,
+        username: "public-sensei",
+        profileStudentId: "student-20",
+        profileVisibility: "public",
+      },
+    );
+    db.posts.push(
+      post({ uid: "post-1", userId: 10, subjectContentUid: "content-a" }),
+      post({ uid: "post-2", userId: 20, subjectContentUid: "content-a" }),
+    );
+    db.comments.push({
+      id: 101,
+      uid: "comment-1",
+      postUid: "post-2",
+      userId: 10,
+      body: "private profile subcomment",
+      visibility: "public",
+      createdAt: "2026-06-02T00:00:00.000Z",
+    });
+
+    const anonymousComments = await getContentsComments(env, ["content-a"]);
+    const otherUserComments = await getContentsComments(env, ["content-a"], 20);
+    const ownerComments = await getContentsComments(env, ["content-a"], 10);
+
+    expect(anonymousComments["content-a"].map((comment) => comment.sensei.username)).toEqual(["public-sensei"]);
+    expect(otherUserComments["content-a"].map((comment) => comment.sensei.username)).toEqual(["public-sensei"]);
+    expect(ownerComments["content-a"].map((comment) => comment.sensei.username)).toEqual([
+      "private-sensei",
+      "public-sensei",
+      "private-sensei",
+    ]);
+  });
+});
 
 describe("getContentsCommentSummaries", () => {
   it("counts visible comments and subcomments, detects recent activity, and returns pinned preview", async () => {

--- a/test/app/models/sensei-visibility.test.ts
+++ b/test/app/models/sensei-visibility.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "@jest/globals";
+import { isSenseiProfileVisibleTo, type Sensei } from "~/models/sensei";
+
+function sensei(profileVisibility: Sensei["profileVisibility"]): Sensei {
+  return {
+    id: 7,
+    uid: "sensei-uid",
+    username: "sensei",
+    friendCode: null,
+    profileStudentId: null,
+    bio: null,
+    active: true,
+    role: "guest",
+    profileVisibility,
+  };
+}
+
+describe("sensei profile visibility", () => {
+  it("shows public profiles to everyone", () => {
+    expect(isSenseiProfileVisibleTo(sensei("public"))).toBe(true);
+    expect(isSenseiProfileVisibleTo(sensei("public"), 9)).toBe(true);
+  });
+
+  it("shows private profiles only to their owner", () => {
+    expect(isSenseiProfileVisibleTo(sensei("private"))).toBe(false);
+    expect(isSenseiProfileVisibleTo(sensei("private"), 9)).toBe(false);
+    expect(isSenseiProfileVisibleTo(sensei("private"), 7)).toBe(true);
+  });
+});

--- a/test/app/routes/__manage.test.ts
+++ b/test/app/routes/__manage.test.ts
@@ -14,6 +14,7 @@ function makeSensei(overrides: Partial<Sensei>): Sensei {
     bio: null,
     active: true,
     role: "guest",
+    profileVisibility: "public",
     ...overrides,
   };
 }

--- a/test/app/routes/pickup-history-index.test.ts
+++ b/test/app/routes/pickup-history-index.test.ts
@@ -29,6 +29,7 @@ jest.mock("~/models/recruitment-result", () => ({
 
 jest.mock("~/models/sensei", () => ({
   getSenseiByUsername: jest.fn(),
+  isSenseiProfileVisibleTo: jest.fn(() => true),
 }));
 
 jest.mock("~/models/student", () => ({

--- a/test/app/routes/profile-privacy-architecture.test.ts
+++ b/test/app/routes/profile-privacy-architecture.test.ts
@@ -6,7 +6,7 @@ const ROUTES_DIRECTORY = join(process.cwd(), "app", "routes");
 const MODELS_DIRECTORY = join(process.cwd(), "app", "models");
 
 describe("profile route privacy guard", () => {
-  it("keeps every public @username data route behind getRouteSensei", () => {
+  it("keeps every public @username data route behind getRouteSensei as a coarse architecture backstop", () => {
     const unguardedRoutes = readdirSync(ROUTES_DIRECTORY)
       .filter((file) => file.startsWith("$username") && file.endsWith(".tsx"))
       .filter((file) => !file.includes(".edit."))
@@ -19,7 +19,7 @@ describe("profile route privacy guard", () => {
     expect(unguardedRoutes).toEqual([]);
   });
 
-  it("uses the shared profile policy in models that expose sensei identity", () => {
+  it("uses the shared profile policy in model files that expose sensei identity as a coarse architecture backstop", () => {
     const unguardedModels = readdirSync(MODELS_DIRECTORY)
       .filter((file) => file.endsWith(".ts"))
       .filter((file) => {

--- a/test/app/routes/profile-privacy-architecture.test.ts
+++ b/test/app/routes/profile-privacy-architecture.test.ts
@@ -1,0 +1,48 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "@jest/globals";
+
+const ROUTES_DIRECTORY = join(process.cwd(), "app", "routes");
+const MODELS_DIRECTORY = join(process.cwd(), "app", "models");
+
+describe("profile route privacy guard", () => {
+  it("keeps every public @username data route behind getRouteSensei", () => {
+    const unguardedRoutes = readdirSync(ROUTES_DIRECTORY)
+      .filter((file) => file.startsWith("$username") && file.endsWith(".tsx"))
+      .filter((file) => !file.includes(".edit."))
+      .filter((file) => {
+        const source = readFileSync(join(ROUTES_DIRECTORY, file), "utf8");
+        const hasDataHandler = /export const (?:loader|action)\s*=/.test(source);
+        return hasDataHandler && !source.includes("getRouteSensei");
+      });
+
+    expect(unguardedRoutes).toEqual([]);
+  });
+
+  it("uses the shared profile policy in models that expose sensei identity", () => {
+    const unguardedModels = readdirSync(MODELS_DIRECTORY)
+      .filter((file) => file.endsWith(".ts"))
+      .filter((file) => {
+        const source = readFileSync(join(MODELS_DIRECTORY, file), "utf8");
+        return source.includes("username: senseisTable.username") && !source.includes("senseiProfileVisibilityFilter");
+      });
+
+    expect(unguardedModels).toEqual([]);
+  });
+
+  it("guards public Postgres timeline routes with D1 profile visibility", () => {
+    const unguardedRoutes = readdirSync(ROUTES_DIRECTORY)
+      .filter((file) => file.endsWith(".tsx") && !file.includes(".edit."))
+      .filter((file) => {
+        const source = readFileSync(join(ROUTES_DIRECTORY, file), "utf8");
+        const readsTimeline = /(?:get|list)Postgres\w*WalkthroughTimeline/.test(source);
+        const checksProfile =
+          source.includes("getRouteSensei") ||
+          source.includes("isSenseiProfileVisibleTo") ||
+          source.includes("getVisibleSenseisById");
+        return readsTimeline && !checksProfile;
+      });
+
+    expect(unguardedRoutes).toEqual([]);
+  });
+});

--- a/test/app/routes/profile-route-privacy.test.ts
+++ b/test/app/routes/profile-route-privacy.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { getSenseiByUsername, type Sensei } from "~/models/sensei";
+
+jest.mock("~/auth/authenticator.server", () => ({ getActiveSensei: jest.fn() }));
+jest.mock("~/components/features/layout", () => ({
+  ErrorPage: jest.fn(() => null),
+  Page: jest.fn(({ children }: { children?: unknown }) => children ?? null),
+  ServerErrorPage: jest.fn(() => null),
+}));
+jest.mock("~/models/sensei", () => ({
+  ...jest.requireActual<typeof import("~/models/sensei")>("~/models/sensei"),
+  getSenseiByUsername: jest.fn(),
+}));
+
+import { getRouteSensei } from "../../../app/routes/$username";
+
+const mockedGetSenseiByUsername = getSenseiByUsername as jest.MockedFunction<typeof getSenseiByUsername>;
+
+function sensei(profileVisibility: Sensei["profileVisibility"]): Sensei {
+  return {
+    id: 7,
+    uid: "sensei-uid",
+    username: "private-sensei",
+    friendCode: null,
+    profileStudentId: null,
+    bio: null,
+    active: true,
+    role: "guest",
+    profileVisibility,
+  };
+}
+
+describe("@username profile privacy", () => {
+  it("returns a friendly 403 route response for another user's private profile", async () => {
+    mockedGetSenseiByUsername.mockResolvedValue(sensei("private"));
+
+    await expect(getRouteSensei({} as Env, { username: "@private-sensei" }, 9)).rejects.toMatchObject({
+      type: "DataWithResponseInit",
+      init: { status: 403 },
+      data: {
+        error: {
+          code: "sensei.profile_private",
+          details: { username: "private-sensei" },
+        },
+      },
+    });
+  });
+
+  it("allows the owner to access their private profile", async () => {
+    const privateSensei = sensei("private");
+    mockedGetSenseiByUsername.mockResolvedValue(privateSensei);
+
+    await expect(getRouteSensei({} as Env, { username: "@private-sensei" }, 7)).resolves.toBe(privateSensei);
+  });
+});


### PR DESCRIPTION
## Summary

- Allow users to make their profile private from the profile editor.
- Show private profiles and identity-bearing authored content only to the owner while keeping anonymous aggregates intact.
- Prevent every `/@username/**` route from being indexed by search engines.

## Changes

- Added `senseis.profile_visibility` and the profile visibility control.
- Reorganized the profile form into nickname / profile visibility and profile student / friend code rows.
- Added shared visibility policy helpers and a friendly private-profile response.
- Applied visibility filtering to community posts, comments, student reviews, follow lists, parties, and timelines.
- Added `noindex` metadata and `X-Robots-Tag` headers for profile routes.
- Removed the redundant parent profile loader and unused unguarded comment query exports.
- Kept malformed profile-shaped paths fail-safe for `noindex`.
- Added architecture, route, model, and crawler regression tests.

> [!IMPORTANT]
> Apply `db/migrations/20260725000100_add_profile_visibility_to_senseis.sql` before deploying the application.

## Verification

- [x] I verified the related behavior myself.
- [ ] I ran all repository-wide lint and formatting checks without diagnostics.
- [ ] A person reviewed AI-generated code.

- `mise exec -- pnpm exec jest --runInBand` — passed (132 suites, 773 tests)
- `mise exec -- pnpm run typecheck` — passed
- `mise exec -- pnpm run prod:build` — passed
- Biome checks for the changed TypeScript files — passed
- `git diff --check` — passed
- Repository-wide Biome still reports pre-existing diagnostics outside this change.

## Related issues

None.
