### PR TITLE
feat: update pyroxene planner recruitment rules

### DIFF
--- a/app/components/features/futures/PyroxeneSchedule.tsx
+++ b/app/components/features/futures/PyroxeneSchedule.tsx
@@ -247,6 +247,7 @@ export default function PyroxeneSchedule({
   }, [scheduleItems, collectedSourceKeySet]);
 
   let displayedYear: number | null = null;
+  let displayedRecruitmentReworkDivider = false;
 
   return (
     <div className="space-y-10">
@@ -314,9 +315,13 @@ export default function PyroxeneSchedule({
             if (source.event) {
               const { event } = source;
               const eventData = eventDataMap.get(event.uid);
+              const showRecruitmentReworkDivider =
+                !displayedRecruitmentReworkDivider && event.recruitmentRuleSet === "call_charge_v1";
+              displayedRecruitmentReworkDivider ||= showRecruitmentReworkDivider;
               return (
                 <div key={`event-${event.uid}`}>
                   {showYearDivider ? <TimelineYearDivider year={year} /> : null}
+                  {showRecruitmentReworkDivider ? <TimelineRecruitmentReworkDivider /> : null}
                   <PyroxeneTimelineEvent
                     event={event}
                     completed={eventData?.completed ?? false}
@@ -378,6 +383,15 @@ function TimelineYearDivider({ year }: { year: number }) {
     <div className="flex items-center gap-3 pb-2 pt-3">
       <span className="text-sm font-semibold tabular-nums text-muted-foreground">{year}</span>
       <span className="h-px flex-1 bg-border" />
+    </div>
+  );
+}
+
+function TimelineRecruitmentReworkDivider() {
+  return (
+    <div className="flex items-center gap-3 pb-2 pt-3">
+      <span className="text-sm font-semibold text-primary">모집 시스템 개편 기준 적용</span>
+      <span className="h-px flex-1 bg-primary/50" />
     </div>
   );
 }

--- a/app/components/features/futures/PyroxeneTimelineEvent.tsx
+++ b/app/components/features/futures/PyroxeneTimelineEvent.tsx
@@ -53,7 +53,7 @@ export default function PyroxeneTimelineEvent({
         const contentUid = sourceContentUid ?? event.uid;
         return [
           {
-            uid: student.uid,
+            uid: student.imageUid === null ? "unlisted" : (student.imageUid ?? student.uid),
             selectionKey: `${contentUid}\u0000${student.uid}`,
             contentUid,
             name: student.name,

--- a/app/domain/pyroxene-schedule.ts
+++ b/app/domain/pyroxene-schedule.ts
@@ -1,4 +1,5 @@
 import type { TimelineSourceType } from "~/domain/pyroxene-planner";
+import type { RecruitmentRuleSet } from "~/domain/recruitment-cost";
 import type { RecruitmentTypeEnum } from "~/graphql/graphql";
 import type { UtcIsoString } from "~/lib/date-time";
 import dayjs from "~/lib/dayjs";
@@ -16,12 +17,13 @@ export type PyroxeneScheduleContent =
       rewardAt?: UtcIsoString;
       earnablePyroxene: number | null;
       tags: string[];
+      recruitmentRuleSet?: RecruitmentRuleSet;
       recruitments: {
         recruitmentType: RecruitmentTypeEnum;
         pickup: boolean;
         rerun: boolean;
         until: UtcIsoString | null;
-        student: { uid: string; name: string; initialTier: number } | null;
+        student: { uid: string; imageUid?: string | null; name: string; initialTier: number } | null;
         // Set when this content merges recruitments from multiple events sharing one
         // recruitment group; identifies which event this particular recruitment belongs to,
         // since favorites are stored per-event rather than per-group.
@@ -55,12 +57,13 @@ export type PyroxeneScheduleItem = {
     rewardAt?: UtcIsoString | Date;
     earnablePyroxene: number | null;
     tags: string[];
+    recruitmentRuleSet?: RecruitmentRuleSet;
     recruitments: {
       recruitmentType: RecruitmentTypeEnum;
       pickup: boolean;
       rerun: boolean;
       until: UtcIsoString | null;
-      student: { uid: string; name: string; initialTier: number } | null;
+      student: { uid: string; imageUid?: string | null; name: string; initialTier: number } | null;
       favorited: boolean;
       sourceContentUid?: string;
     }[];
@@ -167,6 +170,7 @@ export function buildPyroxeneScheduleItems(
           rewardAt: content.rewardAt,
           earnablePyroxene: content.earnablePyroxene ?? null,
           tags: content.tags,
+          recruitmentRuleSet: content.recruitmentRuleSet,
           recruitmentPool: content.recruitmentPool,
           recruitments: content.recruitments.map((recruitment) => ({
             ...recruitment,

--- a/app/domain/pyroxene-timeline.ts
+++ b/app/domain/pyroxene-timeline.ts
@@ -2,6 +2,13 @@ import type { Dayjs } from "dayjs";
 import type { PyroxeneCalculationOptions, TimelineSourceType } from "~/domain/pyroxene-planner";
 import type { PyroxeneScheduleItem } from "~/domain/pyroxene-schedule";
 import { calculateDailyApChargePyroxene, collectedSourceKeyForEventReward } from "~/domain/pyroxene-sources";
+import {
+  convolvePullCostDistributions,
+  type PullCostDistribution,
+  type RecruitmentCostPeriod,
+  simulateRecruitmentCost,
+  splitRecruitmentCostPeriodByChargeScope,
+} from "~/domain/recruitment-cost";
 import { DEFAULT_PICKUP_STUDENT_RATE_BY_TIER } from "~/domain/recruitment-simulator";
 import dayjs from "~/lib/dayjs";
 
@@ -70,7 +77,7 @@ const MIN_PROBABILITY = 1e-6;
 const RESOURCE_STATE_MIN_PROBABILITY = 1e-12;
 const MAX_PICKUP_TRIAL_COST_DISTRIBUTION_CACHE_SIZE = 200;
 
-type TrialDistribution = number[];
+type TrialDistribution = PullCostDistribution;
 
 export { calculateDailyApChargePyroxene } from "~/domain/pyroxene-sources";
 
@@ -533,6 +540,7 @@ function getPickupTrialCostDistributionCacheKey(
   return [
     mode,
     event.uid,
+    event.recruitmentRuleSet ?? "legacy_points",
     isFreeRecruitment100Event(event) ? "free100" : "paid",
     event.recruitmentPool?.tier2Count ?? "",
     event.recruitmentPool?.tier3Count ?? "",
@@ -554,6 +562,32 @@ function getPickupTrialCostDistribution(
   const cached = pickupTrialCostDistributionCache.get(cacheKey);
   if (cached) {
     return cached;
+  }
+
+  if (mode === "with_pity" && event.recruitmentRuleSet === "call_charge_v1") {
+    const tier2TargetCount = pickupRecruitments.filter(
+      (recruitment) => getRecruitmentStudentTier(recruitment) === 2,
+    ).length;
+    const tier3TargetCount = pickupRecruitments.length - tier2TargetCount;
+    const recruitmentPeriod: RecruitmentCostPeriod = {
+      uid: event.uid,
+      recruitmentType: pickupRecruitments[0]?.recruitmentType ?? "usual",
+      targets: pickupRecruitments.map((recruitment) => ({
+        key: recruitment.student?.uid ?? "unlisted",
+        initialTier: getRecruitmentStudentTier(recruitment),
+        recruitmentType: recruitment.recruitmentType,
+      })),
+      tier2PoolCount: Math.max(event.recruitmentPool?.tier2Count ?? 1, tier2TargetCount),
+      tier3PoolCount: Math.max(event.recruitmentPool?.tier3Count ?? 1, tier3TargetCount),
+      freePulls: isFreeRecruitment100Event(event) ? PYROXENE.FREE_RECRUITMENT_TRIAL : 0,
+    };
+    const distribution = splitRecruitmentCostPeriodByChargeScope(recruitmentPeriod).reduce(
+      (combined, scopedPeriod) =>
+        convolvePullCostDistributions(combined, simulateRecruitmentCost(scopedPeriod, "call_charge_v1")),
+      [1] as PullCostDistribution,
+    );
+    cachePickupTrialCostDistribution(cacheKey, distribution);
+    return distribution;
   }
 
   const distribution: TrialDistribution = [];

--- a/app/domain/recruitment-cost.ts
+++ b/app/domain/recruitment-cost.ts
@@ -1,0 +1,373 @@
+import type { RecruitmentTypeEnum } from "~/graphql/graphql";
+
+export type RecruitmentRuleSet = "legacy_points" | "call_charge_v1";
+
+export const CALL_CHARGE_ANCHOR_TIMELINE_UID = "pandemonium-cruise";
+
+export type RecruitmentCostTarget = {
+  key: string;
+  initialTier: number;
+  recruitmentType: RecruitmentTypeEnum;
+};
+
+export type RecruitmentCostPeriod = {
+  uid: string;
+  recruitmentType: RecruitmentTypeEnum;
+  targets: RecruitmentCostTarget[];
+  tier2PoolCount: number;
+  tier3PoolCount: number;
+  freePulls?: number;
+};
+
+export type PullCostDistribution = number[];
+
+export type RecruitmentChargeScope = "limited_fes" | Exclude<RecruitmentTypeEnum, "limited" | "fes" | "given">;
+
+const PULLS_PER_BATCH = 10;
+const LEGACY_EXCHANGE_INTERVAL = 200;
+const CALL_CHARGE_MIDPOINT = 100;
+const CALL_CHARGE_CEILING = 200;
+const MIN_PROBABILITY = 1e-14;
+const MAX_TARGETS_PER_PERIOD = 20;
+
+export function getRecruitmentChargeScope(recruitmentType: RecruitmentTypeEnum): RecruitmentChargeScope | null {
+  if (recruitmentType === "given") return null;
+  if (recruitmentType === "limited" || recruitmentType === "fes") return "limited_fes";
+  return recruitmentType;
+}
+
+export function splitRecruitmentCostPeriodByChargeScope(period: RecruitmentCostPeriod): RecruitmentCostPeriod[] {
+  const targetsByScope = new Map<RecruitmentChargeScope, RecruitmentCostTarget[]>();
+  for (const target of period.targets) {
+    const scope = getRecruitmentChargeScope(target.recruitmentType);
+    if (!scope) continue;
+    const targets = targetsByScope.get(scope) ?? [];
+    targets.push(target);
+    targetsByScope.set(scope, targets);
+  }
+
+  return [...targetsByScope.entries()].map(([scope, targets], index) => ({
+    ...period,
+    uid: `${period.uid}:${scope}`,
+    recruitmentType: targets[0]?.recruitmentType ?? period.recruitmentType,
+    targets,
+    freePulls: index === 0 ? period.freePulls : 0,
+  }));
+}
+
+type BatchState = {
+  acquiredMask: number;
+  charge: number;
+};
+
+type SlotOutcome = {
+  acquiredBit: number;
+  activePickup: boolean;
+  probability: number;
+};
+
+function allTargetsMask(targetCount: number): number {
+  return targetCount === 0 ? 0 : 2 ** targetCount - 1;
+}
+
+function firstUnacquiredTargetIndex(acquiredMask: number, targetCount: number): number {
+  for (let index = 0; index < targetCount; index += 1) {
+    if ((acquiredMask & (1 << index)) === 0) return index;
+  }
+  return targetCount;
+}
+
+function targetTier(target: RecruitmentCostTarget): 2 | 3 {
+  return target.initialTier === 2 ? 2 : 3;
+}
+
+function directPickupRate(target: RecruitmentCostTarget): number {
+  return targetTier(target) === 2 ? 0.03 : 0.007;
+}
+
+function tier3SlotRate(period: RecruitmentCostPeriod): number {
+  return period.recruitmentType === "fes" || period.targets.some((target) => target.recruitmentType === "fes")
+    ? 0.06
+    : 0.03;
+}
+
+function tierSlotRate(period: RecruitmentCostPeriod, tier: 2 | 3, slotIndex: number): number {
+  if (tier === 3) return tier3SlotRate(period);
+  return slotIndex === PULLS_PER_BATCH - 1 ? 1 - tier3SlotRate(period) : 0.185;
+}
+
+function poolCount(period: RecruitmentCostPeriod, tier: 2 | 3): number {
+  return tier === 2 ? period.tier2PoolCount : period.tier3PoolCount;
+}
+
+function mergeSlotOutcome(outcomes: Map<string, SlotOutcome>, outcome: SlotOutcome) {
+  if (outcome.probability <= MIN_PROBABILITY) return;
+  const key = `${outcome.acquiredBit}:${outcome.activePickup ? 1 : 0}`;
+  const existing = outcomes.get(key);
+  if (existing) existing.probability += outcome.probability;
+  else outcomes.set(key, outcome);
+}
+
+function normalSlotOutcomes(
+  period: RecruitmentCostPeriod,
+  activeTargetIndex: number,
+  slotIndex: number,
+): SlotOutcome[] {
+  const activeTarget = period.targets[activeTargetIndex];
+  if (!activeTarget) return [{ acquiredBit: 0, activePickup: false, probability: 1 }];
+
+  const outcomes = new Map<string, SlotOutcome>();
+  const activeTier = targetTier(activeTarget);
+  const activeProbability = directPickupRate(activeTarget);
+  mergeSlotOutcome(outcomes, {
+    acquiredBit: 1 << activeTargetIndex,
+    activePickup: true,
+    probability: activeProbability,
+  });
+
+  for (let index = 0; index < period.targets.length; index += 1) {
+    if (index === activeTargetIndex) continue;
+    const otherTarget = period.targets[index];
+    if (!otherTarget) continue;
+    const otherTier = targetTier(otherTarget);
+    const availablePoolCount = Math.max(1, poolCount(period, otherTier) - (otherTier === activeTier ? 1 : 0));
+    const offRate = Math.max(
+      0,
+      tierSlotRate(period, otherTier, slotIndex) - (otherTier === activeTier ? activeProbability : 0),
+    );
+    mergeSlotOutcome(outcomes, {
+      acquiredBit: 1 << index,
+      activePickup: false,
+      probability: offRate / availablePoolCount,
+    });
+  }
+
+  const hitProbability = [...outcomes.values()].reduce((sum, outcome) => sum + outcome.probability, 0);
+  mergeSlotOutcome(outcomes, {
+    acquiredBit: 0,
+    activePickup: false,
+    probability: Math.max(0, 1 - hitProbability),
+  });
+  return [...outcomes.values()];
+}
+
+function midpointSlotOutcomes(period: RecruitmentCostPeriod, activeTargetIndex: number): SlotOutcome[] {
+  const activeTarget = period.targets[activeTargetIndex];
+  if (!activeTarget) return [{ acquiredBit: 0, activePickup: false, probability: 1 }];
+
+  const outcomes = new Map<string, SlotOutcome>();
+  mergeSlotOutcome(outcomes, {
+    acquiredBit: 1 << activeTargetIndex,
+    activePickup: true,
+    probability: 0.5,
+  });
+
+  const activeTier = targetTier(activeTarget);
+  const availableTier3Count = Math.max(1, period.tier3PoolCount - (activeTier === 3 ? 1 : 0));
+  for (let index = 0; index < period.targets.length; index += 1) {
+    if (index === activeTargetIndex) continue;
+    const target = period.targets[index];
+    if (!target || targetTier(target) !== 3) continue;
+    mergeSlotOutcome(outcomes, {
+      acquiredBit: 1 << index,
+      activePickup: false,
+      probability: 0.5 / availableTier3Count,
+    });
+  }
+
+  const hitProbability = [...outcomes.values()].reduce((sum, outcome) => sum + outcome.probability, 0);
+  mergeSlotOutcome(outcomes, {
+    acquiredBit: 0,
+    activePickup: false,
+    probability: Math.max(0, 1 - hitProbability),
+  });
+  return [...outcomes.values()];
+}
+
+function ceilingSlotOutcomes(activeTargetIndex: number): SlotOutcome[] {
+  return [{ acquiredBit: 1 << activeTargetIndex, activePickup: true, probability: 1 }];
+}
+
+function stateKey(state: BatchState): string {
+  return `${state.acquiredMask}:${state.charge}`;
+}
+
+function mergeState(
+  states: Map<string, { state: BatchState; probability: number }>,
+  state: BatchState,
+  probability: number,
+) {
+  if (probability <= MIN_PROBABILITY) return;
+  const key = stateKey(state);
+  const existing = states.get(key);
+  if (existing) existing.probability += probability;
+  else states.set(key, { state, probability });
+}
+
+function runLegacyBatch(
+  period: RecruitmentCostPeriod,
+  acquiredMask: number,
+  activeTargetIndex: number,
+): Map<number, number> {
+  let states = new Map<number, number>([[acquiredMask, 1]]);
+  for (let slotIndex = 0; slotIndex < PULLS_PER_BATCH; slotIndex += 1) {
+    const nextStates = new Map<number, number>();
+    for (const [mask, probability] of states) {
+      for (const outcome of normalSlotOutcomes(period, activeTargetIndex, slotIndex)) {
+        const nextMask = mask | outcome.acquiredBit;
+        nextStates.set(nextMask, (nextStates.get(nextMask) ?? 0) + probability * outcome.probability);
+      }
+    }
+    states = nextStates;
+  }
+  return states;
+}
+
+function runCallChargeBatch(
+  period: RecruitmentCostPeriod,
+  initialState: BatchState,
+  activeTargetIndex: number,
+): Map<string, { state: BatchState; probability: number }> {
+  let states = new Map<string, { state: BatchState; probability: number }>();
+  mergeState(states, initialState, 1);
+
+  for (let slotIndex = 0; slotIndex < PULLS_PER_BATCH; slotIndex += 1) {
+    const nextStates = new Map<string, { state: BatchState; probability: number }>();
+    for (const { state, probability } of states.values()) {
+      const nextCharge = state.charge + 1;
+      const outcomes =
+        nextCharge === CALL_CHARGE_CEILING
+          ? ceilingSlotOutcomes(activeTargetIndex)
+          : nextCharge === CALL_CHARGE_MIDPOINT
+            ? midpointSlotOutcomes(period, activeTargetIndex)
+            : normalSlotOutcomes(period, activeTargetIndex, slotIndex);
+      for (const outcome of outcomes) {
+        mergeState(
+          nextStates,
+          {
+            acquiredMask: state.acquiredMask | outcome.acquiredBit,
+            charge: outcome.activePickup ? 0 : nextCharge,
+          },
+          probability * outcome.probability,
+        );
+      }
+    }
+    states = nextStates;
+  }
+  return states;
+}
+
+function addDistributionProbability(distribution: PullCostDistribution, pulls: number, probability: number) {
+  while (distribution.length <= pulls) distribution.push(0);
+  distribution[pulls] = (distribution[pulls] ?? 0) + probability;
+}
+
+function applyFreePulls(distribution: PullCostDistribution, freePulls: number): PullCostDistribution {
+  if (freePulls <= 0) return distribution;
+  const paidDistribution: PullCostDistribution = [];
+  for (let pulls = 0; pulls < distribution.length; pulls += 1) {
+    const probability = distribution[pulls] ?? 0;
+    if (probability <= MIN_PROBABILITY) continue;
+    addDistributionProbability(paidDistribution, Math.max(0, pulls - freePulls), probability);
+  }
+  return paidDistribution;
+}
+
+function validatePeriod(period: RecruitmentCostPeriod) {
+  if (period.targets.length > MAX_TARGETS_PER_PERIOD) {
+    throw new Error(`too many recruitment targets in one period: ${period.targets.length}`);
+  }
+  const keys = new Set(period.targets.map((target) => target.key));
+  if (keys.size !== period.targets.length) {
+    throw new Error(`duplicate recruitment target in period: ${period.uid}`);
+  }
+}
+
+function simulateLegacyPeriod(period: RecruitmentCostPeriod): PullCostDistribution {
+  const targetCount = period.targets.length;
+  if (targetCount === 0) return [1];
+  const finalMask = allTargetsMask(targetCount);
+  const distribution: PullCostDistribution = [];
+  let activeStates = new Map<number, number>([[0, 1]]);
+
+  for (let pulls = PULLS_PER_BATCH; activeStates.size > 0; pulls += PULLS_PER_BATCH) {
+    const nextStates = new Map<number, number>();
+    for (const [acquiredMask, stateProbability] of activeStates) {
+      const activeTargetIndex = firstUnacquiredTargetIndex(acquiredMask, targetCount);
+      for (const [batchMask, batchProbability] of runLegacyBatch(period, acquiredMask, activeTargetIndex)) {
+        let nextMask = batchMask;
+        if (pulls % LEGACY_EXCHANGE_INTERVAL === 0 && nextMask !== finalMask) {
+          const exchangeTargetIndex = firstUnacquiredTargetIndex(nextMask, targetCount);
+          nextMask |= 1 << exchangeTargetIndex;
+        }
+        const probability = stateProbability * batchProbability;
+        if (nextMask === finalMask) addDistributionProbability(distribution, pulls, probability);
+        else nextStates.set(nextMask, (nextStates.get(nextMask) ?? 0) + probability);
+      }
+    }
+    activeStates = nextStates;
+  }
+
+  return distribution;
+}
+
+function simulateCallChargePeriod(period: RecruitmentCostPeriod): PullCostDistribution {
+  const targetCount = period.targets.length;
+  if (targetCount === 0) return [1];
+  const finalMask = allTargetsMask(targetCount);
+  const distribution: PullCostDistribution = [];
+  let activeStates = new Map<string, { state: BatchState; probability: number }>();
+  mergeState(activeStates, { acquiredMask: 0, charge: 0 }, 1);
+
+  for (let pulls = PULLS_PER_BATCH; activeStates.size > 0; pulls += PULLS_PER_BATCH) {
+    const nextStates = new Map<string, { state: BatchState; probability: number }>();
+    for (const { state, probability: stateProbability } of activeStates.values()) {
+      const activeTargetIndex = firstUnacquiredTargetIndex(state.acquiredMask, targetCount);
+      for (const { state: batchState, probability: batchProbability } of runCallChargeBatch(
+        period,
+        state,
+        activeTargetIndex,
+      ).values()) {
+        const probability = stateProbability * batchProbability;
+        if (batchState.acquiredMask === finalMask) addDistributionProbability(distribution, pulls, probability);
+        else mergeState(nextStates, batchState, probability);
+      }
+    }
+    activeStates = nextStates;
+  }
+
+  return distribution;
+}
+
+export function simulateRecruitmentCost(
+  period: RecruitmentCostPeriod,
+  ruleSet: RecruitmentRuleSet,
+): PullCostDistribution {
+  validatePeriod(period);
+  const distribution = ruleSet === "call_charge_v1" ? simulateCallChargePeriod(period) : simulateLegacyPeriod(period);
+  return applyFreePulls(distribution, period.freePulls ?? 0);
+}
+
+export function convolvePullCostDistributions(
+  left: PullCostDistribution,
+  right: PullCostDistribution,
+): PullCostDistribution {
+  const distribution: PullCostDistribution = [];
+  for (let leftPulls = 0; leftPulls < left.length; leftPulls += 1) {
+    const leftProbability = left[leftPulls] ?? 0;
+    if (leftProbability <= MIN_PROBABILITY) continue;
+    for (let rightPulls = 0; rightPulls < right.length; rightPulls += 1) {
+      const rightProbability = right[rightPulls] ?? 0;
+      if (rightProbability <= MIN_PROBABILITY) continue;
+      addDistributionProbability(distribution, leftPulls + rightPulls, leftProbability * rightProbability);
+    }
+  }
+  return distribution;
+}
+
+export function getRecruitmentRuleSet(
+  startAt: string | Date,
+  callChargeAnchorStartAt: string | Date,
+): RecruitmentRuleSet {
+  return new Date(startAt).getTime() < new Date(callChargeAnchorStartAt).getTime() ? "legacy_points" : "call_charge_v1";
+}

--- a/app/views/pyroxene.ts
+++ b/app/views/pyroxene.ts
@@ -1,4 +1,9 @@
-import { filterRecruitmentsByStudentUids } from "~/domain/recruitment-identity";
+import {
+  CALL_CHARGE_ANCHOR_TIMELINE_UID,
+  getRecruitmentRuleSet,
+  type RecruitmentRuleSet,
+} from "~/domain/recruitment-cost";
+import { filterRecruitmentsByStudentUids, getRecruitmentFavoriteKey } from "~/domain/recruitment-identity";
 import { buildRecruitmentPoolSnapshot } from "~/domain/recruitment-simulator";
 import type { RecruitmentTypeEnum } from "~/graphql/graphql";
 import { compareInstantAsc, compareInstantDesc, toUtcIso, type UtcIsoString } from "~/lib/date-time";
@@ -16,6 +21,7 @@ import type { TimelineContent, TimelineContentType } from "~/models/timeline-con
 import {
   findEventsForRecruitmentStudent,
   getFutureRaidContents,
+  getTimelineContent,
   getTimelineContents,
   groupTimelineContentsByRecruitmentGroupUid,
 } from "~/models/timeline-content.server";
@@ -36,12 +42,13 @@ export type PyroxenePlannerContent =
       rewardAt?: UtcIsoString;
       earnablePyroxene: number | null;
       tags: string[];
+      recruitmentRuleSet: RecruitmentRuleSet;
       recruitments: {
         recruitmentType: RecruitmentTypeEnum;
         pickup: boolean;
         rerun: boolean;
         until: UtcIsoString | null;
-        student: { uid: string; name: string; initialTier: number } | null;
+        student: { uid: string; imageUid: string | null; name: string; initialTier: number } | null;
         // Which event this recruitment "belongs to" when its group is shared by multiple
         // events. Only set on the merged recruitment entry (see buildGroupRecruitmentContent);
         // absent elsewhere, where recruitment.uid === content.uid already disambiguates.
@@ -85,6 +92,7 @@ export function buildMainStoryRewardContents(volumes: MainStoryVolume[]): Pyroxe
           rewardAt,
           earnablePyroxene: episodeCount * MAIN_STORY_PYROXENE_PER_EPISODE,
           tags: ["main_story_reward"],
+          recruitmentRuleSet: "legacy_points",
           recruitments: [],
         });
       }
@@ -136,11 +144,14 @@ function toRecruitmentDetail(
     pickup: recruitment.pickup,
     rerun: recruitment.rerun,
     until: recruitment.until ? toUtcIso(recruitment.until) : null,
-    student: recruitment.student
+    student: recruitment.pickup
       ? {
-          uid: recruitment.student.uid,
-          name: recruitment.student.name,
-          initialTier: studentsMap[recruitment.student.uid]?.initialTier ?? 0,
+          uid: getRecruitmentFavoriteKey(recruitment),
+          imageUid: recruitment.student?.uid ?? null,
+          name: recruitment.student?.name ?? recruitment.studentName,
+          initialTier: recruitment.student
+            ? (studentsMap[recruitment.student.uid]?.initialTier ?? recruitment.student.initialTier ?? 3)
+            : 3,
         }
       : null,
     ...(sourceContentUid ? { sourceContentUid } : {}),
@@ -152,9 +163,12 @@ function buildRecruitmentPoolInfo(
   recruitmentPoolStudents: Awaited<ReturnType<typeof getRecruitmentPoolStudents>>,
 ): PyroxeneEventVariant["recruitmentPool"] {
   const snapshot = buildRecruitmentPoolSnapshot({ recruitmentGroup: group, students: recruitmentPoolStudents });
+  const provisionalTier3PickupCount = group.recruitments.filter(
+    (recruitment) => recruitment.pickup && recruitment.recruitmentType !== "given" && recruitment.student === null,
+  ).length;
   return {
     tier2Count: snapshot.nonPickupStudentsByTier.tier2.length,
-    tier3Count: snapshot.nonPickupStudentsByTier.tier3.length,
+    tier3Count: snapshot.nonPickupStudentsByTier.tier3.length + provisionalTier3PickupCount,
   };
 }
 
@@ -164,11 +178,15 @@ export async function getPyroxenePlannerContents(
   ctx?: ExecutionContext,
 ): Promise<PyroxenePlannerContent[]> {
   // Events require syncedAt (confirmed by BAQL); raids are fetched regardless of syncedAt
-  const [eventContents, raidContents, mainStories] = await Promise.all([
+  const [eventContents, raidContents, mainStories, callChargeAnchor] = await Promise.all([
     getTimelineContents(env, undefined, { ctx }),
     getFutureRaidContents(env, ["raid"], { ctx }),
     getMainStories(env, forceRefresh),
+    getTimelineContent(env, CALL_CHARGE_ANCHOR_TIMELINE_UID, { ctx }),
   ]);
+  if (!callChargeAnchor) {
+    throw new Error(`call-charge anchor timeline is missing: ${CALL_CHARGE_ANCHOR_TIMELINE_UID}`);
+  }
   const raidUids = new Set(raidContents.map((c) => c.uid));
   const mainStoryRewardContents = buildMainStoryRewardContents(mainStories);
   const allContents: (TimelineContent | PyroxenePlannerContent)[] = [
@@ -231,6 +249,9 @@ export async function getPyroxenePlannerContents(
               until,
               earnablePyroxene,
               tags: content.tags,
+              recruitmentRuleSet: group
+                ? getRecruitmentRuleSet(group.startAt, callChargeAnchor.startAt)
+                : "legacy_points",
               recruitments,
               recruitmentPool: group ? buildRecruitmentPoolInfo(group, recruitmentPoolStudents) : undefined,
             },
@@ -246,6 +267,7 @@ export async function getPyroxenePlannerContents(
           until,
           earnablePyroxene,
           tags: content.tags,
+          recruitmentRuleSet: "legacy_points",
           recruitments: [],
         };
 
@@ -275,6 +297,9 @@ export async function getPyroxenePlannerContents(
             until: group?.endAt ? toUtcIso(group.endAt) : until,
             earnablePyroxene: null,
             tags: [...new Set(sortedSiblings.flatMap((sibling) => sibling.tags))],
+            recruitmentRuleSet: group
+              ? getRecruitmentRuleSet(group.startAt, callChargeAnchor.startAt)
+              : "legacy_points",
             recruitments: mergedRecruitments,
             recruitmentPool: group ? buildRecruitmentPoolInfo(group, recruitmentPoolStudents) : undefined,
           },

--- a/test/app/domain/pyroxene-timeline.test.ts
+++ b/test/app/domain/pyroxene-timeline.test.ts
@@ -7,6 +7,7 @@ import {
   type PickupResources,
   type PyroxeneTimelineBandMode,
 } from "~/domain/pyroxene-timeline";
+import type { RecruitmentRuleSet } from "~/domain/recruitment-cost";
 import { RecruitmentTypeEnum } from "~/graphql/graphql";
 
 jest.mock("~/models/recruitment", () => ({
@@ -62,6 +63,7 @@ function eventItem({
   earnablePyroxene = null,
   recruitments = [pickupRecruitment()],
   recruitmentPool = { tier2Count: 150, tier3Count: 202 },
+  recruitmentRuleSet,
   tags = [],
 }: {
   uid: string;
@@ -70,6 +72,7 @@ function eventItem({
   earnablePyroxene?: number | null;
   recruitments?: NonNullable<PyroxeneScheduleItem["event"]>["recruitments"];
   recruitmentPool?: NonNullable<PyroxeneScheduleItem["event"]>["recruitmentPool"];
+  recruitmentRuleSet?: RecruitmentRuleSet;
   tags?: string[];
 }): PyroxeneScheduleItem {
   return {
@@ -80,6 +83,7 @@ function eventItem({
       until,
       earnablePyroxene,
       tags,
+      recruitmentRuleSet,
       recruitments,
       recruitmentPool,
     },
@@ -392,6 +396,25 @@ describe("buildTimeline pyroxene balance band", () => {
     expect(eventEntry?.accumulatedResources.pyroxene).toBe(87_040);
     expect(eventEntry?.accumulatedResourcesBand?.optimistic.pyroxene).toBeGreaterThan(87_040);
     expect(eventEntry?.accumulatedResourcesBand?.pessimistic.pyroxene).toBe(76_000);
+  });
+
+  it("switches the planner probability distribution to call charge for post-anchor events", () => {
+    const options = { ...defaultOptions, event: { pickupChance: "average_pity" as const } };
+    const legacy = buildTestTimeline({
+      scheduleItems: [eventItem({ uid: "legacy", recruitmentRuleSet: "legacy_points" })],
+      options,
+    });
+    const callCharge = buildTestTimeline({
+      scheduleItems: [eventItem({ uid: "call-charge", recruitmentRuleSet: "call_charge_v1" })],
+      options,
+    });
+    const legacyCost =
+      100_000 - (legacy.find((entry) => entry.source.event?.uid === "legacy")?.accumulatedResources.pyroxene ?? 0);
+    const callChargeCost =
+      100_000 -
+      (callCharge.find((entry) => entry.source.event?.uid === "call-charge")?.accumulatedResources.pyroxene ?? 0);
+
+    expect(callChargeCost).toBeLessThan(legacyCost);
   });
 
   it("uses the average-mode linear central path while keeping ticket spending order unchanged", () => {

--- a/test/app/domain/recruitment-cost.test.ts
+++ b/test/app/domain/recruitment-cost.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  convolvePullCostDistributions,
+  getRecruitmentChargeScope,
+  getRecruitmentRuleSet,
+  type PullCostDistribution,
+  type RecruitmentCostPeriod,
+  simulateRecruitmentCost,
+  splitRecruitmentCostPeriodByChargeScope,
+} from "~/domain/recruitment-cost";
+import { RecruitmentTypeEnum } from "~/graphql/graphql";
+
+function period(targetCount = 1, overrides: Partial<RecruitmentCostPeriod> = {}): RecruitmentCostPeriod {
+  return {
+    uid: "period",
+    recruitmentType: RecruitmentTypeEnum.Usual,
+    tier2PoolCount: 20,
+    tier3PoolCount: 100,
+    targets: Array.from({ length: targetCount }, (_, index) => ({
+      key: `target-${index}`,
+      initialTier: 3,
+      recruitmentType: RecruitmentTypeEnum.Usual,
+    })),
+    ...overrides,
+  };
+}
+
+function expectedPulls(distribution: PullCostDistribution): number {
+  const totalProbability = distribution.reduce((sum, probability) => sum + (probability ?? 0), 0);
+  return distribution.reduce(
+    (sum, probability, pulls) => sum + (totalProbability > 0 ? ((probability ?? 0) / totalProbability) * pulls : 0),
+    0,
+  );
+}
+
+describe("simulateRecruitmentCost", () => {
+  it("bills only complete ten-pull batches", () => {
+    const distribution = simulateRecruitmentCost(period(), "legacy_points");
+    expect(distribution.findIndex((probability) => probability > 0)).toBe(10);
+    expect(distribution.some((probability, pulls) => probability > 0 && pulls % 10 !== 0)).toBe(false);
+  });
+
+  it("caps the legacy system at the 200-pull exchange", () => {
+    const distribution = simulateRecruitmentCost(period(), "legacy_points");
+    expect(distribution.length - 1).toBe(200);
+    expect(distribution[200]).toBeGreaterThan(0);
+  });
+
+  it("applies the call-charge midpoint and ceiling", () => {
+    const distribution = simulateRecruitmentCost(period(), "call_charge_v1");
+    expect(distribution.length - 1).toBe(200);
+    expect(expectedPulls(distribution)).toBeLessThan(expectedPulls(simulateRecruitmentCost(period(), "legacy_points")));
+  });
+
+  it("keeps the active banner fixed for the remaining slots in a ten-pull", () => {
+    const distribution = simulateRecruitmentCost(period(2), "call_charge_v1");
+    expect(distribution[10]).toBeGreaterThan(0);
+    expect(distribution[20]).toBeGreaterThan(0);
+    expect(distribution.some((probability, pulls) => probability > 0 && pulls % 10 !== 0)).toBe(false);
+  });
+
+  it("counts free pulls toward progress while removing them from paid cost", () => {
+    const distribution = simulateRecruitmentCost(period(1, { freePulls: 100 }), "call_charge_v1");
+    expect(distribution[0]).toBeGreaterThan(0.5);
+    expect(distribution.length - 1).toBe(100);
+  });
+
+  it("uses the actual pickup tier for provisional tier-two targets", () => {
+    const tier2Period = period(1, {
+      targets: [
+        {
+          key: "tier-2",
+          initialTier: 2,
+          recruitmentType: RecruitmentTypeEnum.Usual,
+        },
+      ],
+    });
+    expect(expectedPulls(simulateRecruitmentCost(tier2Period, "legacy_points"))).toBeLessThan(40);
+  });
+});
+
+describe("distribution helpers", () => {
+  it("convolves independent recruitment periods", () => {
+    expect(convolvePullCostDistributions([1], [0, 0.5, 0.5])).toEqual([0, 0.5, 0.5]);
+  });
+
+  it("shares charge only between limited and fes recruitment types", () => {
+    expect(getRecruitmentChargeScope(RecruitmentTypeEnum.Limited)).toBe("limited_fes");
+    expect(getRecruitmentChargeScope(RecruitmentTypeEnum.Fes)).toBe("limited_fes");
+    expect(getRecruitmentChargeScope(RecruitmentTypeEnum.Usual)).toBe("usual");
+    expect(getRecruitmentChargeScope(RecruitmentTypeEnum.Given)).toBeNull();
+  });
+
+  it("splits independent charge scopes while applying free pulls only once", () => {
+    const scopedPeriods = splitRecruitmentCostPeriodByChargeScope({
+      ...period(3, { freePulls: 100 }),
+      targets: [
+        { key: "limited", initialTier: 3, recruitmentType: RecruitmentTypeEnum.Limited },
+        { key: "fes", initialTier: 3, recruitmentType: RecruitmentTypeEnum.Fes },
+        { key: "usual", initialTier: 3, recruitmentType: RecruitmentTypeEnum.Usual },
+      ],
+    });
+
+    expect(scopedPeriods.map((scopedPeriod) => scopedPeriod.targets.map((target) => target.key))).toEqual([
+      ["limited", "fes"],
+      ["usual"],
+    ]);
+    expect(scopedPeriods.map((scopedPeriod) => scopedPeriod.freePulls)).toEqual([100, 0]);
+  });
+});
+
+describe("getRecruitmentRuleSet", () => {
+  it("switches at the dynamic anchor instant", () => {
+    const anchor = "2026-11-24T02:00:00.000Z";
+    expect(getRecruitmentRuleSet("2026-11-23T02:00:00.000Z", anchor)).toBe("legacy_points");
+    expect(getRecruitmentRuleSet(anchor, anchor)).toBe("call_charge_v1");
+    expect(getRecruitmentRuleSet("2026-11-25T02:00:00.000Z", anchor)).toBe("call_charge_v1");
+  });
+});

--- a/test/app/views/pyroxene.test.ts
+++ b/test/app/views/pyroxene.test.ts
@@ -16,6 +16,7 @@ jest.mock("~/models/main-story", () => ({
 jest.mock("~/models/timeline-content.server", () => ({
   ...jest.requireActual<typeof import("~/models/timeline-content.server")>("~/models/timeline-content.server"),
   getFutureRaidContents: jest.fn(),
+  getTimelineContent: jest.fn(),
   getTimelineContents: jest.fn(),
 }));
 
@@ -148,8 +149,9 @@ describe("getPyroxenePlannerContents with a recruitment group shared by two even
       jest.requireMock<typeof import("~/models/recruitment")>("~/models/recruitment");
     const { getAllStudentsMap } = jest.requireMock<typeof import("~/models/student")>("~/models/student");
     const { getMainStories } = jest.requireMock<typeof import("~/models/main-story")>("~/models/main-story");
-    const { getFutureRaidContents, getTimelineContents } =
-      jest.requireMock<typeof import("~/models/timeline-content.server")>("~/models/timeline-content.server");
+    const { getFutureRaidContents, getTimelineContent, getTimelineContents } = jest.requireMock<
+      typeof import("~/models/timeline-content.server")
+    >("~/models/timeline-content.server");
 
     const eventA = timelineContent({
       uid: "event-a",
@@ -174,6 +176,13 @@ describe("getPyroxenePlannerContents with a recruitment group shared by two even
 
     (getTimelineContents as jest.MockedFunction<typeof getTimelineContents>).mockResolvedValue([eventA, eventB]);
     (getFutureRaidContents as jest.MockedFunction<typeof getFutureRaidContents>).mockResolvedValue([]);
+    (getTimelineContent as jest.MockedFunction<typeof getTimelineContent>).mockResolvedValue(
+      timelineContent({
+        uid: "pandemonium-cruise",
+        startAt: "2026-11-24T02:00:00.000Z",
+        endAt: "2026-12-08T02:00:00.000Z",
+      }),
+    );
     (getMainStories as jest.MockedFunction<typeof getMainStories>).mockResolvedValue([]);
     (getAllStudentsMap as jest.MockedFunction<typeof getAllStudentsMap>).mockResolvedValue({});
     (getRecruitmentPoolStudents as jest.MockedFunction<typeof getRecruitmentPoolStudents>).mockResolvedValue([]);
@@ -222,5 +231,75 @@ describe("getPyroxenePlannerContents with a recruitment group shared by two even
       ["c", "event-b"],
       ["d", "event-b"],
     ]);
+  });
+});
+
+describe("getPyroxenePlannerContents with an unregistered pickup student", () => {
+  it("keeps the target as a provisional three-star and switches rules at the anchor event", async () => {
+    const { getRecruitmentGroupsByUids, getRecruitmentPoolStudents } =
+      jest.requireMock<typeof import("~/models/recruitment")>("~/models/recruitment");
+    const { getAllStudentsMap } = jest.requireMock<typeof import("~/models/student")>("~/models/student");
+    const { getMainStories } = jest.requireMock<typeof import("~/models/main-story")>("~/models/main-story");
+    const { getFutureRaidContents, getTimelineContent, getTimelineContents } = jest.requireMock<
+      typeof import("~/models/timeline-content.server")
+    >("~/models/timeline-content.server");
+    const event = timelineContent({
+      uid: "pandemonium-cruise-schedule",
+      name: "판데모니엄 크루즈",
+      startAt: "2026-11-24T02:00:00.000Z",
+      endAt: "2026-12-08T02:00:00.000Z",
+      recruitmentGroupUid: "anchor-group",
+    });
+
+    (getTimelineContents as jest.MockedFunction<typeof getTimelineContents>).mockResolvedValue([event]);
+    (getFutureRaidContents as jest.MockedFunction<typeof getFutureRaidContents>).mockResolvedValue([]);
+    (getTimelineContent as jest.MockedFunction<typeof getTimelineContent>).mockResolvedValue(
+      timelineContent({
+        uid: "pandemonium-cruise",
+        startAt: "2026-11-24T02:00:00.000Z",
+        endAt: "2026-12-08T02:00:00.000Z",
+      }),
+    );
+    (getMainStories as jest.MockedFunction<typeof getMainStories>).mockResolvedValue([]);
+    (getAllStudentsMap as jest.MockedFunction<typeof getAllStudentsMap>).mockResolvedValue({});
+    (getRecruitmentPoolStudents as jest.MockedFunction<typeof getRecruitmentPoolStudents>).mockResolvedValue([]);
+    (getRecruitmentGroupsByUids as jest.MockedFunction<typeof getRecruitmentGroupsByUids>).mockResolvedValue([
+      {
+        uid: "anchor-group",
+        startAt: "2026-11-24T02:00:00.000Z",
+        endAt: "2026-12-08T02:00:00.000Z",
+        recruitmentType: "usual",
+        recruitments: [
+          {
+            recruitmentType: "usual",
+            pickup: true,
+            rerun: false,
+            since: "2026-11-24T02:00:00.000Z",
+            until: null,
+            studentName: "미등록 학생",
+            student: null,
+          },
+        ],
+      },
+    ] as unknown as Awaited<ReturnType<typeof getRecruitmentGroupsByUids>>);
+
+    const content = (await getPyroxenePlannerContents({} as Env)).find(
+      (candidate) => candidate.kind === "event" && candidate.uid === event.uid,
+    );
+
+    expect(content).toMatchObject({
+      recruitmentRuleSet: "call_charge_v1",
+      recruitmentPool: { tier3Count: 1 },
+      recruitments: [
+        {
+          student: {
+            uid: expect.stringMatching(/^provisional:/),
+            imageUid: null,
+            name: "미등록 학생",
+            initialTier: 3,
+          },
+        },
+      ],
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Include favorited pickup students without a registered UID in the pyroxene planner as provisional three-star targets.
- Switch the planner's pity-aware recruitment calculation to the new call-charge rules for recruitment groups starting with `pandemonium-cruise`.
- Keep the recruitment rework simulator route, menu, and comparison UI out of this PR so the planner changes can ship independently.

## Changes

- Preserve unregistered pickup students with deterministic provisional keys, a three-star default, and the unlisted image placeholder.
- Resolve the call-charge rollout boundary from the `pandemonium-cruise` timeline UID instead of a hard-coded date.
- Add the call-charge distribution model with the 100-pull midpoint, 200-pull guarantee, active-pickup reset, ten-pull slot ordering, free recruitments, and charge scopes.
- Propagate the recruitment rule set through the pyroxene schedule and use it for the `average_pity` planner calculation.
- Keep pre-anchor recruitment groups on the existing recruitment-point calculation.
- Add regression coverage for provisional students, rollout boundary selection, charge sharing, free pulls, and planner cost differences.

## Verification

- [x] I verified the related behavior myself.
- [ ] I ran all repository-wide lint and formatting checks without diagnostics.
- [ ] A person reviewed AI-generated code.

- `mise exec -- pnpm run typecheck` — passed
- `mise exec -- pnpm exec jest --runInBand --silent` — passed (144 suites, 858 tests)
- `mise exec -- pnpm run prod:build` — passed
- Biome checks for all 8 changed TypeScript files — passed
- `git diff --check` — passed
- Repository-wide Biome still reports pre-existing diagnostics outside this change.

## Related issues

None.