### PR TITLE
feat: add configurable site banners and post detail pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ This project has been deployed to Cloudflare Workers.
 
 ## Development Guides
 - Please follow the conventions of the project. Search for the existing code and follow the same style.
+- Before creating or changing database models, schemas, or migrations, read `docs/data/database.md` and follow its modeling and validation rules.
 - For UI layout, use modern and simple design.
 - Before creating or changing UI components, read `docs/frontend/design.md` and follow its component structure, naming, reuse, layout, and performance rules.
 - Before adding, moving, or refactoring components, read `docs/frontend/components.md` and follow its final structure rules for `primitives`, `features`, and route-local components.

--- a/app/components/features/layout/NavigationBar.tsx
+++ b/app/components/features/layout/NavigationBar.tsx
@@ -33,6 +33,7 @@ import {
   normalizeNavigationFavoriteIds,
   toggleNavigationFavoriteId,
 } from "~/domain/navigation-favorites";
+import type { SiteBanner as SiteBannerData } from "~/domain/site-banner";
 import { parseUtcTimestamp, type UtcIsoString } from "~/lib/date-time";
 import { cn } from "~/lib/utils";
 import { timelineContentTypeLocale } from "~/locales/ko";
@@ -46,6 +47,7 @@ import {
   type NavigationItem,
   type NavigationSectionStates,
 } from "./navigation-menu";
+import { SiteBanner, shouldRenderGlobalSiteBanner } from "./SiteBanner";
 
 type NavigationBarProps = {
   currentUsername: string | null;
@@ -58,6 +60,7 @@ type NavigationBarProps = {
   hasOngoingRaid: boolean;
   hasUnconsumedCoupons: boolean;
   hasUnreadFeedbackReplies: boolean;
+  siteBanner: SiteBannerData | null;
 };
 
 type NavigationSearchVariant = "desktop" | "mobile";
@@ -306,6 +309,7 @@ export default function NavigationBar({
   hasOngoingRaid,
   hasUnconsumedCoupons,
   hasUnreadFeedbackReplies,
+  siteBanner,
 }: NavigationBarProps) {
   const matches = useMatches();
   const location = useLocation();
@@ -341,6 +345,12 @@ export default function NavigationBar({
           <NavigationSearch key={`desktop:${searchResetKey}`} variant="desktop" />
         </div>
 
+        {siteBanner && shouldRenderGlobalSiteBanner(siteBanner, "desktop_navigation", pathname) ? (
+          <div className="px-3 pb-2">
+            <SiteBanner banner={siteBanner} slot="desktop_navigation" />
+          </div>
+        ) : null}
+
         <div className="no-scrollbar flex-1 overflow-y-auto px-3 py-2">
           <DesktopMenuContent
             currentUsername={currentUsername}
@@ -371,6 +381,8 @@ export default function NavigationBar({
         hasRecentNews={hasRecentNews}
         hasUnreadFeedbackReplies={hasUnreadFeedbackReplies}
         searchResetKey={searchResetKey}
+        pathname={pathname}
+        siteBanner={siteBanner}
       />
 
       <MobileBottomNavigation
@@ -389,16 +401,44 @@ function MobileBrandHeader({
   hasRecentNews,
   hasUnreadFeedbackReplies,
   searchResetKey,
+  pathname,
+  siteBanner,
 }: {
   darkMode: boolean;
   setDarkMode: NavigationBarProps["setDarkMode"];
   hasRecentNews: boolean;
   hasUnreadFeedbackReplies: boolean;
   searchResetKey: string;
+  pathname: string;
+  siteBanner: SiteBannerData | null;
 }) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const submit = useSubmit();
+  const bannerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const shouldRenderBanner = siteBanner ? shouldRenderGlobalSiteBanner(siteBanner, "mobile_header", pathname) : false;
+    const updateHeight = () => {
+      const height = shouldRenderBanner ? (bannerRef.current?.getBoundingClientRect().height ?? 0) : 0;
+      root.style.setProperty("--mobile-site-banner-height", `${Math.ceil(height)}px`);
+    };
+
+    updateHeight();
+    const banner = bannerRef.current;
+    const observer = typeof ResizeObserver === "undefined" || !banner ? null : new ResizeObserver(updateHeight);
+    if (observer && banner) {
+      observer.observe(banner);
+    }
+    window.addEventListener("resize", updateHeight);
+
+    return () => {
+      observer?.disconnect();
+      window.removeEventListener("resize", updateHeight);
+      root.style.setProperty("--mobile-site-banner-height", "0px");
+    };
+  }, [pathname, siteBanner]);
 
   useEffect(() => {
     void searchResetKey;
@@ -436,7 +476,7 @@ function MobileBrandHeader({
         border-border border-b bg-background
       "
     >
-      <div className="flex h-[var(--mobile-header-height)] w-full items-center justify-between px-4 pt-[env(safe-area-inset-top)]">
+      <div className="flex h-[var(--mobile-header-row-height)] w-full items-center justify-between px-4 pt-[env(safe-area-inset-top)]">
         <Link
           to="/"
           className="-ml-1 flex w-fit items-center rounded-md px-1 py-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
@@ -493,6 +533,12 @@ function MobileBrandHeader({
           <NavigationSearch key={`mobile:${searchResetKey}`} variant="mobile" />
         </div>
       )}
+
+      {siteBanner && shouldRenderGlobalSiteBanner(siteBanner, "mobile_header", pathname) ? (
+        <div ref={bannerRef}>
+          <SiteBanner banner={siteBanner} slot="mobile_header" />
+        </div>
+      ) : null}
 
       {isMenuOpen && (
         <>

--- a/app/components/features/layout/NavigationBar.tsx
+++ b/app/components/features/layout/NavigationBar.tsx
@@ -422,7 +422,11 @@ function MobileBrandHeader({
     const shouldRenderBanner = siteBanner ? shouldRenderGlobalSiteBanner(siteBanner, "mobile_header", pathname) : false;
     const updateHeight = () => {
       const height = shouldRenderBanner ? (bannerRef.current?.getBoundingClientRect().height ?? 0) : 0;
-      root.style.setProperty("--mobile-site-banner-height", `${Math.ceil(height)}px`);
+      if (height > 0) {
+        root.style.setProperty("--mobile-site-banner-measured-height", `${Math.ceil(height)}px`);
+      } else {
+        root.style.removeProperty("--mobile-site-banner-measured-height");
+      }
     };
 
     updateHeight();
@@ -436,7 +440,7 @@ function MobileBrandHeader({
     return () => {
       observer?.disconnect();
       window.removeEventListener("resize", updateHeight);
-      root.style.setProperty("--mobile-site-banner-height", "0px");
+      root.style.removeProperty("--mobile-site-banner-measured-height");
     };
   }, [pathname, siteBanner]);
 

--- a/app/components/features/layout/SiteBanner.tsx
+++ b/app/components/features/layout/SiteBanner.tsx
@@ -1,0 +1,76 @@
+import { Link } from "react-router";
+import {
+  getSiteBannerPageScreen,
+  isValidSiteBannerLink,
+  type SiteBanner as SiteBannerData,
+  type SiteBannerPreset,
+  type SiteBannerScreen,
+  shouldRenderGlobalSiteBanner,
+} from "~/domain/site-banner";
+import { cn } from "~/lib/utils";
+
+export type SiteBannerSlot = SiteBannerScreen;
+
+type SiteBannerProps = {
+  banner: SiteBannerData;
+  slot: SiteBannerSlot;
+  className?: string;
+};
+
+const slotClassNames: Record<SiteBannerSlot, string> = {
+  desktop_navigation: "w-full rounded-md px-3 py-2",
+  mobile_header: "w-full px-4 py-2",
+  futures_top: "mb-4 w-full rounded-lg px-3 py-2.5 sm:px-4",
+  community_top: "mb-4 w-full rounded-lg px-3 py-2.5 sm:px-4",
+};
+
+const presetClassNames: Record<SiteBannerPreset, { container: string; text: string }> = {
+  red: {
+    container: "bg-gradient-to-r from-rose-50 to-red-50 dark:from-rose-900/20 dark:to-red-900/20",
+    text: "text-rose-700 dark:text-rose-300",
+  },
+  green: {
+    container: "bg-gradient-to-r from-green-50 to-emerald-50 dark:from-green-900/20 dark:to-emerald-900/20",
+    text: "text-green-700 dark:text-green-300",
+  },
+  blue: {
+    container: "bg-gradient-to-r from-sky-50 to-blue-50 dark:from-sky-900/20 dark:to-blue-900/20",
+    text: "text-sky-700 dark:text-sky-300",
+  },
+  black: {
+    container: "bg-neutral-100 dark:bg-neutral-700/70",
+    text: "text-neutral-700 dark:text-neutral-200",
+  },
+};
+
+export function SiteBanner({ banner, slot, className }: SiteBannerProps) {
+  if (!banner.screens.includes(slot) || !isValidSiteBannerLink(banner.link)) {
+    return null;
+  }
+
+  const preset = presetClassNames[banner.colorPreset];
+  const linkClassName = cn(
+    "block text-sm font-normal leading-5 transition-opacity hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring/30",
+    preset.container,
+    preset.text,
+    slotClassNames[slot],
+    className,
+  );
+
+  if (banner.link.startsWith("https://")) {
+    return (
+      <a href={banner.link} target="_blank" rel="noopener noreferrer" className={linkClassName}>
+        {banner.message}
+      </a>
+    );
+  }
+
+  return <Link to={banner.link} className={linkClassName}>{banner.message}</Link>;
+}
+
+export function getPageSiteBannerSlot(pathname: string, banner: Pick<SiteBannerData, "screens"> | null | undefined) {
+  const slot = getSiteBannerPageScreen(pathname);
+  return slot && banner?.screens.includes(slot) ? slot : null;
+}
+
+export { shouldRenderGlobalSiteBanner };

--- a/app/components/features/layout/index.ts
+++ b/app/components/features/layout/index.ts
@@ -1,8 +1,9 @@
+export { default as ErrorPage } from "./ErrorPage";
+export { default as Footer } from "./Footer";
+export { default as MobileMoreTabNoticeBanner } from "./MobileMoreTabNoticeBanner";
+export { default as NavigationBar } from "./NavigationBar";
 export { default as Page } from "./Page";
 export type { PagePanelProps } from "./PagePanel";
-export { default as NavigationBar } from "./NavigationBar";
-export { default as MobileMoreTabNoticeBanner } from "./MobileMoreTabNoticeBanner";
-export { default as Footer } from "./Footer";
-export { default as ErrorPage } from "./ErrorPage";
 export { createPageErrorBoundary, default as RouteErrorBoundary } from "./RouteErrorBoundary";
 export { default as ServerErrorPage } from "./ServerErrorPage";
+export { getPageSiteBannerSlot, SiteBanner, shouldRenderGlobalSiteBanner } from "./SiteBanner";

--- a/app/db/postgres/posts.ts
+++ b/app/db/postgres/posts.ts
@@ -89,6 +89,22 @@ export async function getPostgresPosts(
   );
 }
 
+export async function getPostgresPostByUid(
+  env: Pick<Env, "HYPERDRIVE">,
+  uid: string,
+  options: PostgresPostsOptions = {},
+): Promise<Post | null> {
+  return withPostsDatabase(
+    env,
+    "get_by_uid",
+    async (db) => {
+      const [row] = await db.select().from(pgPostsTable).where(eq(pgPostsTable.uid, uid)).limit(1);
+      return row ? toPost(row) : null;
+    },
+    options,
+  );
+}
+
 export async function getPostgresNewsPosts(
   env: Pick<Env, "HYPERDRIVE">,
   page = 1,

--- a/app/db/postgres/schema.ts
+++ b/app/db/postgres/schema.ts
@@ -14,6 +14,7 @@ import {
 import type { CouponReward } from "~/domain/coupon";
 import type { FeedbackAdditional } from "~/domain/feedback";
 import type { OcrJobKind, OcrTaskMessage } from "~/domain/ocr";
+import type { SiteBannerPreset, SiteBannerScreen } from "~/domain/site-banner";
 import type { TimelineContentVideo } from "~/domain/timeline-content";
 import type { TimelineContentNameI18n } from "~/domain/timeline-content-name-i18n";
 import type {
@@ -125,6 +126,25 @@ export const pgCouponsTable = pgTable(
     uniqueIndex("coupons_uid_uidx").on(table.uid),
     uniqueIndex("coupons_code_uidx").on(table.code),
     index("coupons_expires_at_idx").on(table.expiresAt),
+  ],
+);
+
+export const pgSiteBannersTable = pgTable(
+  "site_banners",
+  {
+    uid: text().primaryKey(),
+    message: text().notNull(),
+    colorPreset: text("color_preset").$type<SiteBannerPreset>().notNull(),
+    link: text().notNull(),
+    screens: jsonb().$type<SiteBannerScreen[]>().notNull().default([]),
+    startsAt: timestamptz("starts_at").notNull(),
+    endsAt: timestamptz("ends_at").notNull(),
+    createdAt: timestamptz("created_at").notNull().defaultNow(),
+    updatedAt: timestamptz("updated_at").notNull().defaultNow(),
+  },
+  (table) => [
+    index("site_banners_active_ends_at_uid_idx").on(table.endsAt, table.uid),
+    index("site_banners_starts_at_idx").on(table.startsAt),
   ],
 );
 

--- a/app/db/postgres/site-banners.ts
+++ b/app/db/postgres/site-banners.ts
@@ -1,0 +1,84 @@
+import { and, asc, gt, lte } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { pgSiteBannersTable } from "~/db/postgres/schema";
+import {
+  isSiteBannerPreset,
+  isSiteBannerScreen,
+  type SiteBanner,
+  type SiteBannerPreset,
+  type SiteBannerScreen,
+} from "~/domain/site-banner";
+import { normalizeInstant, type UtcIsoString } from "~/lib/date-time";
+import { createPostgresClient, type PostgresClientFactory, withPostgresClient } from "~/lib/postgres.server";
+
+type PostgresSiteBannerRow = typeof pgSiteBannersTable.$inferSelect;
+
+export type PostgresSiteBannerOptions = {
+  ctx?: ExecutionContext;
+  createClient?: PostgresClientFactory;
+};
+
+function normalizePostgresInstant(value: string | Date): UtcIsoString {
+  return normalizeInstant(value instanceof Date ? value.toISOString() : value);
+}
+
+function toSiteBanner(row: PostgresSiteBannerRow): SiteBanner {
+  const colorPreset = row.colorPreset;
+  const screens = row.screens;
+  if (!isSiteBannerPreset(colorPreset) || !screens.every(isSiteBannerScreen)) {
+    throw new Error(`Invalid site banner enum value for ${row.uid}`);
+  }
+
+  return {
+    uid: row.uid,
+    message: row.message,
+    colorPreset: colorPreset as SiteBannerPreset,
+    link: row.link,
+    screens: screens as SiteBannerScreen[],
+    startsAt: normalizePostgresInstant(row.startsAt),
+    endsAt: normalizePostgresInstant(row.endsAt),
+    createdAt: normalizePostgresInstant(row.createdAt),
+    updatedAt: normalizePostgresInstant(row.updatedAt),
+  };
+}
+
+async function selectActive(
+  env: Pick<Env, "HYPERDRIVE">,
+  now: Date,
+  options: PostgresSiteBannerOptions,
+): Promise<SiteBanner | null> {
+  const { ctx, createClient = createPostgresClient } = options;
+  return withPostgresClient(
+    env,
+    async (client) => {
+      const execute = async (span?: { setAttribute(name: string, value: string | number | boolean): void }) => {
+        span?.setAttribute("db.system.name", "postgresql");
+        span?.setAttribute("db.operation.name", "select");
+        span?.setAttribute("db.collection.name", "site_banners");
+        const rows = await drizzle(client)
+          .select()
+          .from(pgSiteBannersTable)
+          .where(and(lte(pgSiteBannersTable.startsAt, now), gt(pgSiteBannersTable.endsAt, now)))
+          .orderBy(asc(pgSiteBannersTable.endsAt), asc(pgSiteBannersTable.uid))
+          .limit(1);
+        span?.setAttribute("db.response.returned_rows", rows.length);
+        return rows[0] ? toSiteBanner(rows[0]) : null;
+      };
+      return ctx ? ctx.tracing.enterSpan("postgres.site_banners.get_active", execute) : execute();
+    },
+    createClient,
+    ctx,
+  );
+}
+
+export async function getPostgresActiveSiteBanner(
+  env: Pick<Env, "HYPERDRIVE">,
+  now: UtcIsoString | Date = new Date(),
+  options: PostgresSiteBannerOptions = {},
+): Promise<SiteBanner | null> {
+  const instant = now instanceof Date ? now : new Date(now);
+  if (Number.isNaN(instant.getTime())) {
+    throw new Error(`Invalid site banner time: ${String(now)}`);
+  }
+  return selectActive(env, instant, options);
+}

--- a/app/domain/site-banner.ts
+++ b/app/domain/site-banner.ts
@@ -1,0 +1,84 @@
+export const SITE_BANNER_PRESETS = ["red", "green", "blue", "black"] as const;
+export type SiteBannerPreset = (typeof SITE_BANNER_PRESETS)[number];
+
+export const SITE_BANNER_SCREENS = ["desktop_navigation", "mobile_header", "futures_top", "community_top"] as const;
+export type SiteBannerScreen = (typeof SITE_BANNER_SCREENS)[number];
+
+export type SiteBanner = {
+  uid: string;
+  message: string;
+  colorPreset: SiteBannerPreset;
+  link: string;
+  screens: SiteBannerScreen[];
+  startsAt: string;
+  endsAt: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export function isSiteBannerPreset(value: string): value is SiteBannerPreset {
+  return SITE_BANNER_PRESETS.includes(value as SiteBannerPreset);
+}
+
+export function isSiteBannerScreen(value: string): value is SiteBannerScreen {
+  return SITE_BANNER_SCREENS.includes(value as SiteBannerScreen);
+}
+
+export function isValidSiteBannerLink(value: string): boolean {
+  const link = value.trim();
+  if (link === "/" || (link.startsWith("/") && !link.startsWith("//"))) {
+    return true;
+  }
+
+  if (!link.startsWith("https://")) {
+    return false;
+  }
+
+  try {
+    const url = new URL(link);
+    return url.protocol === "https:" && url.hostname.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+export function getSiteBannerPageScreen(
+  pathname: string,
+): Extract<SiteBannerScreen, "futures_top" | "community_top"> | null {
+  if (pathname === "/futures") {
+    return "futures_top";
+  }
+
+  if (pathname === "/community") {
+    return "community_top";
+  }
+
+  return null;
+}
+
+export function shouldRenderGlobalSiteBanner(
+  banner: Pick<SiteBanner, "screens"> | null | undefined,
+  screen: Extract<SiteBannerScreen, "desktop_navigation" | "mobile_header">,
+  pathname: string,
+): boolean {
+  if (!banner?.screens.includes(screen)) {
+    return false;
+  }
+
+  const pageScreen = getSiteBannerPageScreen(pathname);
+  return pageScreen === null || !banner.screens.includes(pageScreen);
+}
+
+export function selectActiveSiteBanner(banners: SiteBanner[], now: string | Date): SiteBanner | null {
+  const nowMs = toTimestamp(now);
+  return (
+    [...banners]
+      .filter((banner) => toTimestamp(banner.startsAt) <= nowMs && nowMs < toTimestamp(banner.endsAt))
+      .sort((a, b) => toTimestamp(a.endsAt) - toTimestamp(b.endsAt) || a.uid.localeCompare(b.uid))[0] ?? null
+  );
+}
+
+function toTimestamp(value: string | Date): number {
+  const date = value instanceof Date ? value : new Date(value);
+  return date.getTime();
+}

--- a/app/domain/site-banner.ts
+++ b/app/domain/site-banner.ts
@@ -69,13 +69,9 @@ export function shouldRenderGlobalSiteBanner(
   return pageScreen === null || !banner.screens.includes(pageScreen);
 }
 
-export function selectActiveSiteBanner(banners: SiteBanner[], now: string | Date): SiteBanner | null {
+export function isSiteBannerActive(banner: Pick<SiteBanner, "startsAt" | "endsAt">, now: string | Date): boolean {
   const nowMs = toTimestamp(now);
-  return (
-    [...banners]
-      .filter((banner) => toTimestamp(banner.startsAt) <= nowMs && nowMs < toTimestamp(banner.endsAt))
-      .sort((a, b) => toTimestamp(a.endsAt) - toTimestamp(b.endsAt) || a.uid.localeCompare(b.uid))[0] ?? null
-  );
+  return toTimestamp(banner.startsAt) <= nowMs && nowMs < toTimestamp(banner.endsAt);
 }
 
 function toTimestamp(value: string | Date): number {

--- a/app/models/post.ts
+++ b/app/models/post.ts
@@ -2,6 +2,7 @@ import {
   getPostgresLatestPostTime,
   getPostgresNewsPosts,
   getPostgresPostByTimelineContentUid,
+  getPostgresPostByUid,
   getPostgresPosts,
   type PostgresPostsOptions,
 } from "~/db/postgres/posts";
@@ -14,6 +15,10 @@ export function getAllPosts(env: Env, board?: string, options: PostgresPostsOpti
 
 export function getNewsPosts(env: Env, page = 1, pageSize = 5, options: PostgresPostsOptions = {}) {
   return getPostgresNewsPosts(env, page, pageSize, options);
+}
+
+export function getPostByUid(env: Env, uid: string, options: PostgresPostsOptions = {}) {
+  return getPostgresPostByUid(env, uid, options);
 }
 
 export function getPostByTimelineContentUid(env: Env, timelineContentUid: string, options: PostgresPostsOptions = {}) {

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -15,10 +15,19 @@ import LoadingBar, { type LoadingBarRef } from "react-top-loading-bar";
 import type { Route } from "./+types/root";
 import { getActiveSensei } from "./auth/authenticator.server";
 import { getPreference } from "./auth/preference.server";
-import { ErrorPage, Footer, NavigationBar, ServerErrorPage } from "./components/features/layout";
+import {
+  ErrorPage,
+  Footer,
+  getPageSiteBannerSlot,
+  NavigationBar,
+  ServerErrorPage,
+  SiteBanner,
+  shouldRenderGlobalSiteBanner,
+} from "./components/features/layout";
 import { SignInProvider, useSignIn } from "./contexts/SignInProvider";
 import { StudentCardPopupProvider } from "./contexts/StudentCardPopupProvider";
 import { TimeZoneProvider } from "./contexts/TimeZoneProvider";
+import { getPostgresActiveSiteBanner } from "./db/postgres/site-banners";
 import { withD1Session } from "./lib/d1-session";
 import { DEFAULT_TIME_ZONE, getBrowserTimeZone, normalizeTimeZone } from "./lib/date-time";
 import { initializeGoogleAnalytics, trackCurrentGoogleAnalyticsPageView } from "./lib/google-analytics.client";
@@ -57,9 +66,10 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
     const sensei = await ctx.tracing.enterSpan("root_auth", () => getActiveSensei(env, request));
     const preference = await ctx.tracing.enterSpan("root_preference", () => getPreference(env, request));
     const publicReadEnv = withD1Session(env, "first-unconstrained");
-    const navigationBarContents = await ctx.tracing.enterSpan("root_nav", () =>
-      getNavigationBarContents(env, false, sensei?.id, ctx, publicReadEnv),
-    );
+    const [navigationBarContents, siteBanner] = await Promise.all([
+      ctx.tracing.enterSpan("root_nav", () => getNavigationBarContents(env, false, sensei?.id, ctx, publicReadEnv)),
+      ctx.tracing.enterSpan("root_site_banner", () => getPostgresActiveSiteBanner(publicReadEnv, new Date(), { ctx })),
+    ]);
 
     span.setAttribute("signedIn", sensei !== null);
     if (colo) {
@@ -73,6 +83,7 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
       displayTimeZone: normalizeTimeZone(preference.timeZone ?? DEFAULT_TIME_ZONE),
       favoriteNavigationIds: preference.favoriteNavigationIds ?? [],
       navigationBarContents,
+      siteBanner,
       publicEnv: {
         STAGE: env.STAGE ?? "local",
         FRONT_BETTER_STACK_SENTRY_DSN: env.FRONT_BETTER_STACK_SENTRY_DSN ?? "",
@@ -118,8 +129,15 @@ export function Layout({ children }: { children: React.ReactNode }) {
   const location = useLocation();
   const darkMode = loaderData?.darkMode ?? true;
   const theme = darkMode ? themeConfig.dark : themeConfig.light;
+  const reserveMobileSiteBanner = Boolean(
+    loaderData?.siteBanner && shouldRenderGlobalSiteBanner(loaderData.siteBanner, "mobile_header", location.pathname),
+  );
   return (
-    <html lang="ko" className={darkMode ? "dark" : undefined}>
+    <html
+      lang="ko"
+      className={darkMode ? "dark" : undefined}
+      style={{ "--mobile-site-banner-height": reserveMobileSiteBanner ? "4rem" : "0px" } as React.CSSProperties}
+    >
       <head>
         <meta charSet="utf-8" />
         <meta
@@ -156,7 +174,8 @@ export function Layout({ children }: { children: React.ReactNode }) {
 
 export default function App() {
   const loaderData = useLoaderData<typeof loader>();
-  const { currentUsername, currentProfileStudentId, favoriteNavigationIds, navigationBarContents } = loaderData;
+  const { currentUsername, currentProfileStudentId, favoriteNavigationIds, navigationBarContents, siteBanner } =
+    loaderData;
 
   const [darkMode, setDarkMode] = useState(loaderData.darkMode);
   const [displayTimeZone, setDisplayTimeZone] = useState(loaderData.displayTimeZone);
@@ -207,6 +226,7 @@ export default function App() {
 
   const location = useLocation();
   const pathname = location.pathname;
+  const pageBannerSlot = getPageSiteBannerSlot(pathname, siteBanner);
   const pagePath = `${location.pathname}${location.search}`;
   const analyticsEnabled = loaderData.publicEnv.STAGE === "prod";
   const routeKey = location.key;
@@ -249,11 +269,13 @@ export default function App() {
             hasOngoingRaid={navigationBarContents.hasOngoingRaid}
             hasUnconsumedCoupons={navigationBarContents.hasUnconsumedCoupons}
             hasUnreadFeedbackReplies={navigationBarContents.hasUnreadFeedbackReplies}
+            siteBanner={siteBanner}
           />
           <div className="mllg-content-area w-full overflow-y-scroll pt-[var(--mobile-header-height)] lg:pt-0">
             <div className="mx-auto w-full max-w-7xl px-4 pt-2 pb-6 transition-all duration-300 ease-out has-[[data-page-max-width=wide]]:max-w-screen-2xl has-[[data-page-max-width=full]]:max-w-none motion-reduce:transition-none md:px-8 lg:min-h-screen lg:py-6">
               <TimeZoneProvider timeZone={displayTimeZone}>
                 <StudentCardPopupProvider key={pathname}>
+                  {pageBannerSlot && siteBanner ? <SiteBanner banner={siteBanner} slot={pageBannerSlot} /> : null}
                   <Outlet context={{ darkMode, setDarkMode } satisfies RootOutletContext} />
                 </StudentCardPopupProvider>
               </TimeZoneProvider>

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -27,7 +27,6 @@ import {
 import { SignInProvider, useSignIn } from "./contexts/SignInProvider";
 import { StudentCardPopupProvider } from "./contexts/StudentCardPopupProvider";
 import { TimeZoneProvider } from "./contexts/TimeZoneProvider";
-import { getPostgresActiveSiteBanner } from "./db/postgres/site-banners";
 import { withD1Session } from "./lib/d1-session";
 import { DEFAULT_TIME_ZONE, getBrowserTimeZone, normalizeTimeZone } from "./lib/date-time";
 import { initializeGoogleAnalytics, trackCurrentGoogleAnalyticsPageView } from "./lib/google-analytics.client";
@@ -37,6 +36,7 @@ import { isServerRouteError, normalizeRouteError } from "./lib/route-error";
 import { isGoogleSearchCrawler, isSenseiProfilePath } from "./lib/seo-crawler";
 import styles from "./tailwind.css?url";
 import { getNavigationBarContents } from "./views/navigation";
+import { getSiteBanner } from "./views/site-banner";
 
 const SignInBottomSheet = lazy(() => import("./components/features/auth/SignInBottomSheet"));
 const themeConfig = {
@@ -68,7 +68,7 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
     const publicReadEnv = withD1Session(env, "first-unconstrained");
     const [navigationBarContents, siteBanner] = await Promise.all([
       ctx.tracing.enterSpan("root_nav", () => getNavigationBarContents(env, false, sensei?.id, ctx, publicReadEnv)),
-      ctx.tracing.enterSpan("root_site_banner", () => getPostgresActiveSiteBanner(publicReadEnv, new Date(), { ctx })),
+      ctx.tracing.enterSpan("root_site_banner", () => getSiteBanner(publicReadEnv, new Date(), ctx)),
     ]);
 
     span.setAttribute("signedIn", sensei !== null);
@@ -136,7 +136,11 @@ export function Layout({ children }: { children: React.ReactNode }) {
     <html
       lang="ko"
       className={darkMode ? "dark" : undefined}
-      style={{ "--mobile-site-banner-height": reserveMobileSiteBanner ? "4rem" : "0px" } as React.CSSProperties}
+      style={
+        {
+          "--mobile-site-banner-estimated-height": reserveMobileSiteBanner ? "4rem" : "0px",
+        } as React.CSSProperties
+      }
     >
       <head>
         <meta charSet="utf-8" />

--- a/app/routes/posts.$uid._components/PostArticle.tsx
+++ b/app/routes/posts.$uid._components/PostArticle.tsx
@@ -1,0 +1,23 @@
+import dayjs from "dayjs";
+import { MarkdownText } from "~/components/primitives";
+import type { Post } from "~/models/post";
+
+type PostArticleProps = {
+  post: Pick<Post, "title" | "content" | "createdAt">;
+};
+
+export default function PostArticle({ post }: PostArticleProps) {
+  return (
+    <article className="mx-auto min-h-[60dvh] max-w-3xl pt-3 md:pt-4">
+      <header className="pb-5">
+        <h1 className="break-words text-2xl font-black md:text-3xl">{post.title}</h1>
+        <time className="mt-2 block text-sm text-muted-foreground" dateTime={post.createdAt}>
+          {dayjs(post.createdAt).format("YYYY-MM-DD")}
+        </time>
+      </header>
+      <div className="mt-6 [&_img]:mx-auto [&_img]:max-h-[60svh] [&_img]:w-auto [&_img]:object-contain">
+        <MarkdownText text={post.content} />
+      </div>
+    </article>
+  );
+}

--- a/app/routes/posts.$uid.tsx
+++ b/app/routes/posts.$uid.tsx
@@ -1,0 +1,54 @@
+import type { LoaderFunctionArgs, MetaFunction } from "react-router";
+import { useLoaderData } from "react-router";
+import { RouteErrorBoundary } from "~/components/features/layout";
+import { routeError } from "~/lib/http-errors";
+import { canonicalLink } from "~/lib/seo";
+import { getPostByUid } from "~/models/post";
+import PostArticle from "./posts.$uid._components/PostArticle";
+
+function notFoundResponse() {
+  return routeError(404, "post.not_found", "게시물을 찾을 수 없어요.");
+}
+
+export const loader = async ({ context, params }: LoaderFunctionArgs) => {
+  const uid = params.uid;
+  if (!uid) {
+    throw notFoundResponse();
+  }
+
+  const { env, ctx } = context.cloudflare;
+  const post = await getPostByUid(env, uid, { ctx });
+  if (!post) {
+    throw notFoundResponse();
+  }
+
+  return {
+    post: {
+      uid: post.uid,
+      title: post.title,
+      content: post.content,
+      createdAt: post.createdAt,
+    },
+  };
+};
+
+export const meta: MetaFunction<typeof loader> = ({ data, location }) => {
+  if (!data?.post) {
+    return [
+      { title: "게시물 | 몰루로그" },
+      { name: "description", content: "몰루로그 게시물 내용을 확인해보세요." },
+      canonicalLink(location.pathname),
+    ];
+  }
+
+  const title = `${data.post.title} | 몰루로그`;
+  const description = `${data.post.title} 게시물 내용을 확인해보세요.`;
+  return [{ title }, { name: "description", content: description }, canonicalLink(location.pathname)];
+};
+
+export const ErrorBoundary = RouteErrorBoundary;
+
+export default function PostDetailPage() {
+  const { post } = useLoaderData<typeof loader>();
+  return <PostArticle post={post} />;
+}

--- a/app/tailwind.css
+++ b/app/tailwind.css
@@ -26,7 +26,9 @@
   --shadow-t-3xl: 0 -35px 60px -15px rgba(0, 0, 0, 0.3);
 
   --pb-safe-or-6: max(env(safe-area-inset-bottom), 1.5rem);
-  --mobile-header-height: calc(2.875rem + env(safe-area-inset-top));
+  --mobile-header-row-height: calc(2.875rem + env(safe-area-inset-top));
+  --mobile-site-banner-height: 0px;
+  --mobile-header-height: calc(var(--mobile-header-row-height) + var(--mobile-site-banner-height));
   --mobile-nav-height: calc(3.25rem + max(env(safe-area-inset-bottom), 0.375rem));
   --mobile-bottom-offset: calc(var(--mobile-nav-height) + 1rem);
   --mobile-page-bottom-padding: calc(var(--mobile-nav-height) + 2rem);

--- a/app/tailwind.css
+++ b/app/tailwind.css
@@ -27,7 +27,11 @@
 
   --pb-safe-or-6: max(env(safe-area-inset-bottom), 1.5rem);
   --mobile-header-row-height: calc(2.875rem + env(safe-area-inset-top));
-  --mobile-site-banner-height: 0px;
+  --mobile-site-banner-estimated-height: 0px;
+  --mobile-site-banner-height: var(
+    --mobile-site-banner-measured-height,
+    var(--mobile-site-banner-estimated-height)
+  );
   --mobile-header-height: calc(var(--mobile-header-row-height) + var(--mobile-site-banner-height));
   --mobile-nav-height: calc(3.25rem + max(env(safe-area-inset-bottom), 0.375rem));
   --mobile-bottom-offset: calc(var(--mobile-nav-height) + 1rem);

--- a/app/views/site-banner.ts
+++ b/app/views/site-banner.ts
@@ -1,0 +1,43 @@
+import { getPostgresActiveSiteBanner } from "~/db/postgres/site-banners";
+import { isSiteBannerActive, type SiteBanner } from "~/domain/site-banner";
+import { cacheKey, fetchRouteCached } from "~/lib/cache";
+import { captureServerError, getLogger } from "~/lib/observability.server";
+
+// Keep schedule changes responsive while retaining a short outage fallback.
+// Cached rows are checked against `now` again below, so expired banners never render from stale data.
+const SITE_BANNER_CACHE_FRESH_TTL = 30;
+const SITE_BANNER_CACHE_MAX_STALE_TTL = 5 * 60;
+const SITE_BANNER_CACHE_EXPIRATION_TTL = 10 * 60;
+
+export async function getSiteBanner(
+  env: Env,
+  now: Date = new Date(),
+  ctx?: ExecutionContext,
+): Promise<SiteBanner | null> {
+  try {
+    const banner = await fetchRouteCached(
+      env,
+      ctx,
+      cacheKey("route", "site-banner", 1, "active"),
+      () => getPostgresActiveSiteBanner(env, now, { ctx }),
+      false,
+      {
+        freshTtl: SITE_BANNER_CACHE_FRESH_TTL,
+        maxStaleTtl: SITE_BANNER_CACHE_MAX_STALE_TTL,
+        expirationTtl: SITE_BANNER_CACHE_EXPIRATION_TTL,
+      },
+    );
+
+    return banner && isSiteBannerActive(banner, now) ? banner : null;
+  } catch (error) {
+    const errorContext = {
+      view: "site_banner",
+      operation: "get_active",
+    };
+    getLogger(env, ctx, { view: "site_banner" }).error("Failed to load active site banner", error, {
+      operation: "get_active",
+    });
+    captureServerError(error, errorContext);
+    return null;
+  }
+}

--- a/db/postgres/migrations/20260801000100_create_site_banners.sql
+++ b/db/postgres/migrations/20260801000100_create_site_banners.sql
@@ -1,0 +1,14 @@
+CREATE TABLE site_banners (
+  uid text PRIMARY KEY,
+  message text NOT NULL,
+  color_preset text NOT NULL,
+  link text NOT NULL,
+  screens jsonb NOT NULL DEFAULT '[]'::jsonb,
+  starts_at timestamptz NOT NULL,
+  ends_at timestamptz NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX site_banners_active_ends_at_uid_idx ON site_banners (ends_at, uid);
+CREATE INDEX site_banners_starts_at_idx ON site_banners (starts_at);

--- a/docs/data/database.md
+++ b/docs/data/database.md
@@ -35,6 +35,12 @@ SQL that is not a schema change but a one-off correction, validation, or re-aggr
 - Models handle data access only (CRUD, BAQL reads, source cache, normalization). Pure logic such as scoring or simulation belongs in `app/domain`, and screen composition belongs in `app/views`.
 - Do not extend legacy tables in an area where a new canonical store is already defined.
 
+## Validation boundary
+
+- Do not add database `CHECK` constraints for domain or application validation in D1 or PostgreSQL migrations and Drizzle schemas.
+- Validate allowed values, required combinations, ranges, and other domain rules in the application layer and cover them with tests.
+- Structural declarations such as primary keys, `NOT NULL`, and indexes are not part of this restriction.
+
 ## Drizzle usage
 
 ```ts

--- a/test/app/db/postgres/posts.test.ts
+++ b/test/app/db/postgres/posts.test.ts
@@ -4,11 +4,17 @@ import {
   getPostgresLatestPostTime,
   getPostgresNewsPosts,
   getPostgresPostByTimelineContentUid,
+  getPostgresPostByUid,
   getPostgresPosts,
 } from "~/db/postgres/posts";
 
-function postRow(uid = "post-1", createdAt = "2026-07-14T00:00:00.000Z", timelineContentUid: string | null = null) {
-  return [1, uid, "제목", "본문", "news", timelineContentUid, new Date(createdAt), new Date(createdAt)];
+function postRow(
+  uid = "post-1",
+  createdAt = "2026-07-14T00:00:00.000Z",
+  timelineContentUid: string | null = null,
+  board = "news",
+) {
+  return [1, uid, "제목", "본문", board, timelineContentUid, new Date(createdAt), new Date(createdAt)];
 }
 
 describe("PostgreSQL posts read", () => {
@@ -67,6 +73,32 @@ describe("PostgreSQL posts read", () => {
     expect(text).toContain('where "posts"."timeline_content_uid" = $1');
     expect(text).toContain('order by "posts"."created_at" desc, "posts"."uid" desc');
     expect(values).toEqual(["live-stream-1", 1]);
+  });
+
+  it("loads a post directly by uid without filtering by board", async () => {
+    const client = {
+      connect: jest.fn(async () => undefined),
+      end: jest.fn(async () => undefined),
+      query: jest.fn(async () => ({
+        rows: [postRow("notice-1", "2026-07-26T00:00:00.000Z", null, "notice")],
+        rowCount: 1,
+      })),
+    } as unknown as Client;
+
+    await expect(
+      getPostgresPostByUid({ HYPERDRIVE: { connectionString: "postgres://unused" } as Hyperdrive }, "notice-1", {
+        createClient: () => client,
+      }),
+    ).resolves.toMatchObject({
+      uid: "notice-1",
+      board: "notice",
+    });
+
+    const [{ text }, values] = (client.query as jest.Mock).mock.calls[0] as [{ text: string }, unknown[]];
+    expect(text).toContain('where "posts"."uid" = $1');
+    expect(text).toContain("limit $2");
+    expect(values).toEqual(["notice-1", 1]);
+    expect(client.end).toHaveBeenCalledTimes(1);
   });
 
   it("preserves page clamping and uses one Hyperdrive connection for count and rows", async () => {

--- a/test/app/db/postgres/site-banners.test.ts
+++ b/test/app/db/postgres/site-banners.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import type { Client } from "pg";
+import { getPostgresActiveSiteBanner } from "~/db/postgres/site-banners";
+
+const env = { HYPERDRIVE: { connectionString: "postgres://unused" } as Hyperdrive };
+
+describe("PostgreSQL site banners", () => {
+  it("queries the half-open active range with deterministic overlap ordering", async () => {
+    type QueryConfig = { text?: string };
+    const query = jest.fn<(...args: [QueryConfig]) => Promise<{ rows: []; rowCount: number }>>(async () => ({
+      rows: [],
+      rowCount: 0,
+    }));
+    const client = {
+      connect: jest.fn(async () => undefined),
+      end: jest.fn(async () => undefined),
+      query,
+    } as unknown as Client;
+
+    const result = await getPostgresActiveSiteBanner(env, "2026-08-01T00:30:00.000Z", {
+      createClient: () => client,
+    });
+
+    expect(result).toBeNull();
+    const queryConfig = query.mock.calls.find(([value]) => typeof value === "object" && value !== null)?.[0];
+    expect(queryConfig).toBeDefined();
+    if (!queryConfig) throw new Error("Expected a PostgreSQL query call");
+    expect(queryConfig.text).toContain('"starts_at" <= $1');
+    expect(queryConfig.text).toContain('"ends_at" > $2');
+    expect(queryConfig.text).toContain('order by "site_banners"."ends_at" asc, "site_banners"."uid" asc');
+    expect(client.end).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/app/domain/site-banner.test.ts
+++ b/test/app/domain/site-banner.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  getSiteBannerPageScreen,
+  isValidSiteBannerLink,
+  type SiteBanner,
+  selectActiveSiteBanner,
+  shouldRenderGlobalSiteBanner,
+} from "~/domain/site-banner";
+
+function banner(uid: string, startsAt: string, endsAt: string, screens = ["desktop_navigation"]): SiteBanner {
+  return {
+    uid,
+    message: uid,
+    colorPreset: "blue",
+    link: "/news",
+    screens: screens as SiteBanner["screens"],
+    startsAt,
+    endsAt,
+    createdAt: startsAt,
+    updatedAt: startsAt,
+  };
+}
+
+describe("site banner domain", () => {
+  it("uses a half-open active period", () => {
+    const item = banner("banner", "2026-08-01T00:00:00.000Z", "2026-08-01T01:00:00.000Z");
+
+    expect(selectActiveSiteBanner([item], "2026-08-01T00:00:00.000Z")?.uid).toBe("banner");
+    expect(selectActiveSiteBanner([item], "2026-08-01T00:59:59.999Z")?.uid).toBe("banner");
+    expect(selectActiveSiteBanner([item], "2026-08-01T01:00:00.000Z")).toBeNull();
+  });
+
+  it("orders accidental overlaps by earliest end and then UID", () => {
+    const sameEndA = banner("a", "2026-08-01T00:00:00.000Z", "2026-08-01T02:00:00.000Z");
+    const sameEndB = banner("b", "2026-08-01T00:00:00.000Z", "2026-08-01T02:00:00.000Z");
+    const earlierEnd = banner("z", "2026-08-01T00:00:00.000Z", "2026-08-01T01:00:00.000Z");
+
+    expect(selectActiveSiteBanner([sameEndB, earlierEnd, sameEndA], "2026-08-01T00:30:00.000Z")?.uid).toBe("z");
+    expect(selectActiveSiteBanner([sameEndB, sameEndA], "2026-08-01T00:30:00.000Z")?.uid).toBe("a");
+  });
+
+  it("recognizes only allowed link forms", () => {
+    expect(isValidSiteBannerLink("/")).toBe(true);
+    expect(isValidSiteBannerLink("/community?type=guide")).toBe(true);
+    expect(isValidSiteBannerLink("https://example.com/news")).toBe(true);
+    expect(isValidSiteBannerLink("//example.com")).toBe(false);
+    expect(isValidSiteBannerLink("http://example.com")).toBe(false);
+    expect(isValidSiteBannerLink("javascript:alert(1)")).toBe(false);
+  });
+
+  it("lets a selected page slot replace a matching global slot", () => {
+    const pageBanner = banner("banner", "2026-08-01T00:00:00.000Z", "2026-08-01T01:00:00.000Z", [
+      "desktop_navigation",
+      "futures_top",
+    ]);
+
+    expect(getSiteBannerPageScreen("/futures")).toBe("futures_top");
+    expect(shouldRenderGlobalSiteBanner(pageBanner, "desktop_navigation", "/futures")).toBe(false);
+    expect(shouldRenderGlobalSiteBanner(pageBanner, "desktop_navigation", "/community")).toBe(true);
+  });
+});

--- a/test/app/domain/site-banner.test.ts
+++ b/test/app/domain/site-banner.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "@jest/globals";
 import {
   getSiteBannerPageScreen,
+  isSiteBannerActive,
   isValidSiteBannerLink,
   type SiteBanner,
-  selectActiveSiteBanner,
   shouldRenderGlobalSiteBanner,
 } from "~/domain/site-banner";
 
@@ -25,18 +25,9 @@ describe("site banner domain", () => {
   it("uses a half-open active period", () => {
     const item = banner("banner", "2026-08-01T00:00:00.000Z", "2026-08-01T01:00:00.000Z");
 
-    expect(selectActiveSiteBanner([item], "2026-08-01T00:00:00.000Z")?.uid).toBe("banner");
-    expect(selectActiveSiteBanner([item], "2026-08-01T00:59:59.999Z")?.uid).toBe("banner");
-    expect(selectActiveSiteBanner([item], "2026-08-01T01:00:00.000Z")).toBeNull();
-  });
-
-  it("orders accidental overlaps by earliest end and then UID", () => {
-    const sameEndA = banner("a", "2026-08-01T00:00:00.000Z", "2026-08-01T02:00:00.000Z");
-    const sameEndB = banner("b", "2026-08-01T00:00:00.000Z", "2026-08-01T02:00:00.000Z");
-    const earlierEnd = banner("z", "2026-08-01T00:00:00.000Z", "2026-08-01T01:00:00.000Z");
-
-    expect(selectActiveSiteBanner([sameEndB, earlierEnd, sameEndA], "2026-08-01T00:30:00.000Z")?.uid).toBe("z");
-    expect(selectActiveSiteBanner([sameEndB, sameEndA], "2026-08-01T00:30:00.000Z")?.uid).toBe("a");
+    expect(isSiteBannerActive(item, "2026-08-01T00:00:00.000Z")).toBe(true);
+    expect(isSiteBannerActive(item, "2026-08-01T00:59:59.999Z")).toBe(true);
+    expect(isSiteBannerActive(item, "2026-08-01T01:00:00.000Z")).toBe(false);
   });
 
   it("recognizes only allowed link forms", () => {

--- a/test/app/routes/posts-detail.test.ts
+++ b/test/app/routes/posts-detail.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import type { Post } from "~/models/post";
+import { getPostByUid } from "~/models/post";
+import { loader, meta } from "~/routes/posts.$uid";
+import PostArticle from "~/routes/posts.$uid._components/PostArticle";
+
+jest.mock("~/models/post", () => ({
+  getPostByUid: jest.fn(),
+}));
+
+const mockedGetPostByUid = getPostByUid as jest.MockedFunction<typeof getPostByUid>;
+const env = { HYPERDRIVE: { connectionString: "postgres://unused" } } as Env;
+const ctx = {} as ExecutionContext;
+
+function createLoaderArgs(params: Record<string, string | undefined> = {}) {
+  return {
+    request: new Request("https://mollulog.net/posts/post-1"),
+    context: { cloudflare: { env, ctx } },
+    params,
+  } as never;
+}
+
+function post(overrides: Partial<Post> = {}): Post {
+  return {
+    uid: "post-1",
+    title: "서비스 업데이트",
+    content: "본문입니다.",
+    board: "internal-notice",
+    timelineContentUid: null,
+    createdAt: "2026-07-26T00:00:00.000Z",
+    updatedAt: "2026-07-26T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("post detail route", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("loads a post by uid regardless of its board", async () => {
+    const loadedPost = post({ board: "announcement" });
+    mockedGetPostByUid.mockResolvedValue(loadedPost);
+
+    const result = await loader(createLoaderArgs({ uid: loadedPost.uid }));
+
+    expect(result).toEqual({
+      post: {
+        uid: loadedPost.uid,
+        title: loadedPost.title,
+        content: loadedPost.content,
+        createdAt: loadedPost.createdAt,
+      },
+    });
+    expect(result.post).not.toHaveProperty("board");
+    expect(result.post).not.toHaveProperty("timelineContentUid");
+    expect(mockedGetPostByUid).toHaveBeenCalledWith(env, loadedPost.uid, { ctx });
+  });
+
+  it.each([
+    ["missing uid", {}, undefined],
+    ["unknown uid", { uid: "missing" }, null],
+  ])("returns a friendly 404 for %s", async (_label, params, result) => {
+    mockedGetPostByUid.mockResolvedValue(result as Post | null);
+
+    await expect(loader(createLoaderArgs(params))).rejects.toMatchObject({
+      init: { status: 404 },
+      data: { error: { code: "post.not_found", message: "게시물을 찾을 수 없어요." } },
+    });
+  });
+
+  it("derives title, description, and canonical metadata from the post title and path", () => {
+    const loadedPost = post({ title: "새로운 공지" });
+    const descriptors = meta({
+      data: { post: loadedPost },
+      location: { pathname: `/posts/${loadedPost.uid}` },
+    } as never);
+
+    expect(descriptors).toEqual([
+      { title: "새로운 공지 | 몰루로그" },
+      { name: "description", content: "새로운 공지 게시물 내용을 확인해보세요." },
+      { tagName: "link", rel: "canonical", href: `https://mollulog.net/posts/${loadedPost.uid}` },
+    ]);
+  });
+
+  it("renders a responsive article surface with title and date", () => {
+    const loadedPost = post();
+    const article = PostArticle({ post: loadedPost });
+
+    expect(article.type).toBe("article");
+    expect(article.props.className).toContain("max-w-3xl");
+    expect(article.props.children[0].props.children[0].props.children).toBe(loadedPost.title);
+    expect(article.props.children[0].props.children[1].props.dateTime).toBe(loadedPost.createdAt);
+  });
+});

--- a/test/app/views/site-banner.test.ts
+++ b/test/app/views/site-banner.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { getPostgresActiveSiteBanner } from "~/db/postgres/site-banners";
+import type { SiteBanner } from "~/domain/site-banner";
+import { fetchRouteCached } from "~/lib/cache";
+import { captureServerError, getLogger } from "~/lib/observability.server";
+import { getSiteBanner } from "~/views/site-banner";
+
+jest.mock("~/db/postgres/site-banners", () => ({
+  getPostgresActiveSiteBanner: jest.fn(),
+}));
+
+jest.mock("~/lib/cache", () => ({
+  cacheKey: jest.fn(() => "route::site-banner::v1::active"),
+  fetchRouteCached: jest.fn(),
+}));
+
+jest.mock("~/lib/observability.server", () => ({
+  captureServerError: jest.fn(),
+  getLogger: jest.fn(),
+}));
+
+const mockedGetPostgresActiveSiteBanner = getPostgresActiveSiteBanner as jest.MockedFunction<
+  typeof getPostgresActiveSiteBanner
+>;
+const mockedFetchRouteCached = fetchRouteCached as jest.MockedFunction<typeof fetchRouteCached>;
+const mockedCaptureServerError = captureServerError as jest.MockedFunction<typeof captureServerError>;
+const mockedGetLogger = getLogger as jest.MockedFunction<typeof getLogger>;
+const logger = {
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+};
+const env = {} as Env;
+const ctx = {} as ExecutionContext;
+const now = new Date("2026-08-01T00:30:00.000Z");
+
+function banner(overrides: Partial<SiteBanner> = {}): SiteBanner {
+  return {
+    uid: "banner-1",
+    message: "점검 안내",
+    colorPreset: "red",
+    link: "/posts/notice",
+    screens: ["desktop_navigation"],
+    startsAt: "2026-08-01T00:00:00.000Z",
+    endsAt: "2026-08-01T01:00:00.000Z",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("site banner view", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedGetLogger.mockReturnValue(logger);
+    mockedFetchRouteCached.mockImplementation(async (_env, _ctx, _key, fn) => fn());
+  });
+
+  it("uses a bounded route cache for the active banner", async () => {
+    const activeBanner = banner();
+    mockedGetPostgresActiveSiteBanner.mockResolvedValue(activeBanner);
+
+    await expect(getSiteBanner(env, now, ctx)).resolves.toEqual(activeBanner);
+
+    expect(mockedFetchRouteCached).toHaveBeenCalledWith(
+      env,
+      ctx,
+      "route::site-banner::v1::active",
+      expect.any(Function),
+      false,
+      {
+        freshTtl: 30,
+        maxStaleTtl: 300,
+        expirationTtl: 600,
+      },
+    );
+    expect(mockedGetPostgresActiveSiteBanner).toHaveBeenCalledWith(env, now, { ctx });
+  });
+
+  it("does not render an expired banner returned from stale cache", async () => {
+    mockedFetchRouteCached.mockResolvedValue(banner({ endsAt: "2026-08-01T00:30:00.000Z" }));
+
+    await expect(getSiteBanner(env, now, ctx)).resolves.toBeNull();
+  });
+
+  it("fails open and reports the error when the banner cannot be loaded", async () => {
+    const error = new Error("postgres unavailable");
+    mockedFetchRouteCached.mockRejectedValue(error);
+
+    await expect(getSiteBanner(env, now, ctx)).resolves.toBeNull();
+    expect(logger.error).toHaveBeenCalledWith("Failed to load active site banner", error, {
+      operation: "get_active",
+    });
+    expect(mockedCaptureServerError).toHaveBeenCalledWith(error, {
+      view: "site_banner",
+      operation: "get_active",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add scheduled, screen-targeted site banners for maintenance notices and other announcements.

Also add standalone `/posts/:uid` pages so banners can link directly to a specific post without requiring a separate site entry point.

## Changes

- Add the PostgreSQL `site_banners` schema and active-banner query.
- Select the active banner by schedule, nearest end time, and UID.
- Support banner placement in the desktop navigation, mobile header, futures page, and community page.
- Prevent duplicate rendering when a page-specific banner placement is configured.
- Add predefined banner color presets and validate internal and HTTPS links.
- Adjust responsive layout offsets when a mobile header banner is displayed.
- Add a public SSR route for viewing any `posts` row by UID.
- Render post details as a responsive, sanitized Markdown article with title, publication date, SEO metadata, and a friendly 404 state.
- Exclude internal post fields such as `board` and `timelineContentUid` from serialized route data.
- Add database, domain, and route coverage for banner and post behavior.
- Update the database documentation for the new banner storage.

## Verification

- [x] I verified the related behavior myself.
- [ ] I ran `pnpm typecheck`, `pnpm exec biome check .`, and relevant tests when needed.
  - Full Jest suite passed.
  - Focused post detail tests passed: 2 suites, 10 tests.
  - Changed-file Biome checks passed.
  - React Router type generation passed.
  - Production build passed.
  - `tsc --noEmit` is currently blocked by the pre-existing `ExecutionContext` mock error in `test/app/routes/api-ocr-public-errors.test.ts:187`.
- [ ] (If AI tools were used) The generated content was reviewed by a person.

## Related issues

N/A